### PR TITLE
parser: Implement composite literal parsing

### DIFF
--- a/pkg/lexer/token.go
+++ b/pkg/lexer/token.go
@@ -179,6 +179,13 @@ func (t TokenType) GoString() string {
 	return t.String()
 }
 
+func (t TokenType) FormatDetails() string {
+	if t == EOF {
+		return "<end of input>"
+	}
+	return "'" + t.Format() + "'"
+}
+
 func (t *Token) SetType(tokenType TokenType) *Token {
 	t.Type = tokenType
 	return t

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -83,7 +83,8 @@ type ArrayLiteral struct {
 
 type MapLiteral struct {
 	Token *lexer.Token
-	Pairs map[string]*Term
+	Pairs map[string]Node
+	Order []string // Track insertion order of keys for deterministic output.
 	nType *Type
 }
 
@@ -196,7 +197,8 @@ func (a *ArrayLiteral) Type() *Type {
 
 func (m *MapLiteral) String() string {
 	pairs := make([]string, 0, len(m.Pairs))
-	for key, val := range m.Pairs {
+	for _, key := range m.Order {
+		val := m.Pairs[key]
 		pairs = append(pairs, key+":"+val.String())
 	}
 	return "{" + strings.Join(pairs, ", ") + "}"

--- a/pkg/parser/parser_literal.go
+++ b/pkg/parser/parser_literal.go
@@ -1,0 +1,39 @@
+package parser
+
+import (
+	"strconv"
+
+	"foxygo.at/evy/pkg/lexer"
+)
+
+func (p *Parser) isLiteral() bool {
+	tt := p.cur.TokenType()
+	if tt == lexer.NUM_LIT || tt == lexer.STRING_LIT || tt == lexer.TRUE || tt == lexer.FALSE {
+		return true
+	}
+	if !isBasicType(tt) {
+		return false
+	}
+	peek := p.peek.TokenType()
+	return peek == lexer.LBRACKET || peek == lexer.LCURLY
+}
+
+func (p *Parser) parseLiteral() Node {
+	tok := p.cur
+	tt := tok.TokenType()
+	p.advance()
+	switch tt {
+	case lexer.STRING_LIT:
+		return &StringLiteral{Token: tok, Value: tok.Literal}
+	case lexer.NUM_LIT:
+		val, err := strconv.ParseFloat(tok.Literal, 64)
+		if err != nil {
+			p.appendError(err.Error())
+			return nil
+		}
+		return &NumLiteral{Token: tok, Value: val}
+	case lexer.TRUE, lexer.FALSE:
+		return &Bool{Token: tok, Value: tt == lexer.TRUE}
+	}
+	return nil
+}

--- a/pkg/parser/parser_literal.go
+++ b/pkg/parser/parser_literal.go
@@ -21,11 +21,12 @@ func (p *Parser) isLiteral() bool {
 func (p *Parser) parseLiteral() Node {
 	tok := p.cur
 	tt := tok.TokenType()
-	p.advance()
 	switch tt {
 	case lexer.STRING_LIT:
+		p.advance()
 		return &StringLiteral{Token: tok, Value: tok.Literal}
 	case lexer.NUM_LIT:
+		p.advance()
 		val, err := strconv.ParseFloat(tok.Literal, 64)
 		if err != nil {
 			p.appendError(err.Error())
@@ -33,7 +34,79 @@ func (p *Parser) parseLiteral() Node {
 		}
 		return &NumLiteral{Token: tok, Value: val}
 	case lexer.TRUE, lexer.FALSE:
+		p.advance()
 		return &Bool{Token: tok, Value: tt == lexer.TRUE}
 	}
+	return p.parseCompositeLiteral()
+}
+
+func (p *Parser) parseCompositeLiteral() Node {
+	tok := p.cur
+	litType := p.parseLiteralType()
+	switch litType.Name {
+	case ARRAY:
+		elements := p.parseArrayElements(litType.Sub)
+		return &ArrayLiteral{Token: tok, Elements: elements, nType: litType}
+	case MAP:
+		pairs, order := p.parseMapPairs(litType.Sub)
+		return &MapLiteral{
+			Token: tok,
+			Pairs: pairs,
+			Order: order,
+			nType: litType,
+		}
+	}
+	p.appendError("unknown literal " + tok.String())
 	return nil
+}
+
+func (p *Parser) parseArrayElements(t *Type) []Node {
+	terms := p.parseTerms()
+	tt := p.cur.TokenType()
+	p.advance()
+	if tt != lexer.RBRACKET {
+		p.appendError("invalid array end: " + tt.FormatDetails())
+		return nil
+	}
+	for _, term := range terms {
+		if !t.Accepts(term.Type()) {
+			p.appendError("array literal '" + term.String() + "' should have type '" + t.Format() + "'")
+		}
+	}
+	return terms
+}
+
+func (p *Parser) parseMapPairs(t *Type) (map[string]Node, []string) {
+	pairs := map[string]Node{}
+	var order []string
+	for !p.isTermsEnd() {
+		tt := p.cur.TokenType()
+		key := p.cur.Literal
+		p.advance()
+		p.assertToken(lexer.COLON)
+		p.advance()
+		val := p.parseTerm()
+		if tt != lexer.IDENT {
+			p.appendError("invalid map key '" + tt.Format() + "'")
+			continue
+		}
+		if _, ok := pairs[key]; ok {
+			p.appendError("duplicated map key'" + key + "'")
+			continue
+		}
+		// type check
+		if !t.Accepts(val.Type()) {
+			p.appendError("map literal '" + val.String() + "' should have type '" + t.Format() + "'")
+		}
+
+		pairs[key] = val
+		order = append(order, key)
+	}
+	tt := p.cur.TokenType()
+	p.advance()
+	if tt != lexer.RCURLY {
+		p.appendError("invalid map end: " + tt.FormatDetails())
+		return nil, nil
+	}
+	return pairs, order
 }

--- a/pkg/parser/parser_type.go
+++ b/pkg/parser/parser_type.go
@@ -33,3 +33,37 @@ func (p *Parser) parseSubType(parent *Type) *Type {
 	node := &Type{Name: typeName, Sub: parent}
 	return p.parseSubType(node)
 }
+
+// parseLiteralType parses `num{}[` into `ARRAY MAP NUM` inverting the order.
+// Parsing stops after the final opening rune `{` or `[`.
+func (p *Parser) parseLiteralType() *Type {
+	result := p.parseBasicType()
+	if result == ILLEGAL_TYPE {
+		return result
+	}
+	return p.parseSubTypeNoClose(result)
+}
+
+func (p *Parser) parseSubTypeNoClose(parent *Type) *Type {
+	tt := p.cur.TokenType()
+	typeName := compositeTypeName(tt)
+	if typeName == ILLEGAL {
+		return ILLEGAL_TYPE
+	}
+	// non-empty declaration `num[1]`
+	if !matchParen(tt, p.peek.TokenType()) { // we have moved past the declaration
+		p.advance() // advance past opening token `[` or `{`
+		return &Type{Name: typeName, Sub: parent}
+	}
+	// empty declaration `num[]`
+	peek2 := p.lookAt(p.pos + 2).TokenType()
+	if compositeTypeName(peek2) == ILLEGAL {
+		p.advance() // advance past opening token `[` or `{`
+		return &Type{Name: typeName, Sub: parent}
+	}
+	// nested declaration `num[]{}`
+	p.advance() // advance past opening token `[` or `{`
+	p.advance() // advance past closing token `]` or `}`
+	node := &Type{Name: typeName, Sub: parent}
+	return p.parseSubTypeNoClose(node)
+}

--- a/pkg/parser/parser_type.go
+++ b/pkg/parser/parser_type.go
@@ -1,0 +1,35 @@
+package parser
+
+// parseType parses `num[]{}` into `MAP ARRAY NUM` inverting the order.
+func (p *Parser) parseType() *Type {
+	result := p.parseBasicType()
+	if result == ILLEGAL_TYPE {
+		return result
+	}
+	return p.parseSubType(result)
+}
+
+func (p *Parser) parseBasicType() *Type {
+	tt := p.cur.TokenType()
+	t := basicTypeName(tt)
+	p.advance()
+	if t == ILLEGAL {
+		return ILLEGAL_TYPE
+	}
+	return &Type{Name: t}
+}
+
+func (p *Parser) parseSubType(parent *Type) *Type {
+	tt := p.cur.TokenType()
+	typeName := compositeTypeName(tt)
+	if typeName == ILLEGAL { // we have moved passed the type declaration
+		return parent
+	}
+	if !matchParen(tt, p.peek.Type) {
+		return ILLEGAL_TYPE
+	}
+	p.advance() // advance past opening token `[` or `{`
+	p.advance() // advance past closing token `]` or `}`
+	node := &Type{Name: typeName, Sub: parent}
+	return p.parseSubType(node)
+}

--- a/pkg/parser/type.go
+++ b/pkg/parser/type.go
@@ -1,6 +1,8 @@
 package parser
 
-import "foxygo.at/evy/pkg/lexer"
+import (
+	"foxygo.at/evy/pkg/lexer"
+)
 
 type TypeName int
 
@@ -52,21 +54,33 @@ func compositeTypeName(t lexer.TokenType) TypeName {
 	return ILLEGAL
 }
 
-var typeNameStrings = map[TypeName]string{
-	ILLEGAL: "ILLEGAL",
-	NUM:     "NUM",
-	STRING:  "STRING",
-	BOOL:    "BOOL",
-	ANY:     "ANY",
-	ARRAY:   "ARRAY",
-	MAP:     "MAP",
+type typeNameString struct {
+	string string
+	format string
+}
+
+var typeNameStrings = map[TypeName]typeNameString{
+	ILLEGAL: {string: "ILLEGAL", format: "ILLEGAL"},
+	NUM:     {string: "NUM", format: "num"},
+	STRING:  {string: "STRING", format: "string"},
+	BOOL:    {string: "BOOL", format: "bool"},
+	ANY:     {string: "ANY", format: "any"},
+	ARRAY:   {string: "ARRAY", format: "[]"},
+	MAP:     {string: "MAP", format: "{}"},
 }
 
 func (t TypeName) String() string {
 	if s, ok := typeNameStrings[t]; ok {
-		return s
+		return s.string
 	}
 	return "UNKNOWN"
+}
+
+func (t TypeName) Format() string {
+	if s, ok := typeNameStrings[t]; ok {
+		return s.format
+	}
+	return "<unknown>"
 }
 
 func (t TypeName) GoString() string {
@@ -83,6 +97,13 @@ func (t *Type) String() string {
 		return t.Name.String()
 	}
 	return t.Name.String() + " " + t.Sub.String()
+}
+
+func (t *Type) Format() string {
+	if t.Sub == nil {
+		return t.Name.Format()
+	}
+	return t.Sub.Format() + t.Name.Format()
 }
 
 func (t *Type) Accepts(t2 *Type) bool {


### PR DESCRIPTION
Implement composite literal - array and map - parsing. Add insertion
order field to map for deterministic map printing and testing. Improve
error messages and type formatting to be more easily read and
understood.

The tests are a bit wanting, there is another PR in the works that improves on
error messages and test coverage and it was a bit too much effort to bring
it in before this one.