### PR TITLE
parser: Add scoped typed analysis to declarations

### DIFF
--- a/pkg/parser/scope.go
+++ b/pkg/parser/scope.go
@@ -1,0 +1,34 @@
+package parser
+
+type scope struct {
+	vars  map[string]*Var
+	outer *scope
+}
+
+func newScope() *scope {
+	return &scope{vars: map[string]*Var{}}
+}
+
+func newEnclosedScope(outer *scope) *scope {
+	return &scope{vars: map[string]*Var{}, outer: outer}
+}
+
+func (s *scope) inLocalScope(name string) bool {
+	_, ok := s.vars[name]
+	return ok
+}
+
+func (s *scope) get(name string) (*Var, bool) {
+	if s == nil {
+		return nil, false
+	}
+	if v, ok := s.vars[name]; ok {
+		return v, ok
+	}
+	return s.outer.get(name)
+}
+
+func (s *scope) set(name string, v *Var) *Var {
+	s.vars[name] = v
+	return v
+}


### PR DESCRIPTION
Add scoped typed analysis to declarations, ensuring that variables or
parameters do not get redeclared in same block. Variables may be
re-declared in inner scope of a new block with a new type which does not
affect the outer scope. Add detailed tests for various scenarios.

As the parser will also take care of type analysis this is a necessary
addition and patches a whole in the previous global type analysis for
redeclaration.

Add a minor test refactor for parse error assertions