### PR TITLE
go: Implement return statements

### DIFF
--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -3,30 +3,63 @@ package evaluator
 import (
 	"strconv"
 	"strings"
+
+	"foxygo.at/evy/pkg/parser"
 )
 
-type Builtin func(args []Value) Value
+type Builtin struct {
+	Func BuiltinFunc
+	Decl *parser.FuncDecl
+}
 
-func (b Builtin) Type() ValueType { return BUILTIN }
-func (b Builtin) String() string  { return "builtin function" }
+type Builtins map[string]Builtin
 
-func newBuiltins(e *Evaluator) map[string]Builtin {
-	return map[string]Builtin{
-		"print": Builtin(e.Print),
-		"len":   Builtin(Len),
+func (b Builtins) Decls() map[string]*parser.FuncDecl {
+	decls := make(map[string]*parser.FuncDecl, len(b))
+	for name, builtin := range b {
+		decls[name] = builtin.Decl
+	}
+	return decls
+}
+
+type BuiltinFunc func(args []Value) Value
+
+func (b BuiltinFunc) Type() ValueType { return BUILTIN }
+func (b BuiltinFunc) String() string  { return "builtin function" }
+
+func DefaultBuiltins(print func(string)) Builtins {
+	return Builtins{
+		"print": {Func: printFunc(print), Decl: printDecl},
+		"len":   {Func: BuiltinFunc(lenFunc), Decl: lenDecl},
+		"move":  {Func: moveFunc(print), Decl: moveDecl},
+		"line":  {Func: lineFunc(print), Decl: lineDecl},
 	}
 }
 
-func (e *Evaluator) Print(args []Value) Value {
-	argList := make([]string, len(args))
-	for i, arg := range args {
-		argList[i] = arg.String()
-	}
-	e.print(strings.Join(argList, " "))
-	return nil
+var printDecl = &parser.FuncDecl{
+	Name:          "print",
+	VariadicParam: &parser.Var{Name: "a", T: parser.ANY_TYPE},
+	ReturnType:    parser.NONE_TYPE,
 }
 
-func Len(args []Value) Value {
+func printFunc(printFn func(string)) BuiltinFunc {
+	return func(args []Value) Value {
+		argList := make([]string, len(args))
+		for i, arg := range args {
+			argList[i] = arg.String()
+		}
+		printFn(strings.Join(argList, " ") + "\n")
+		return nil
+	}
+}
+
+var lenDecl = &parser.FuncDecl{
+	Name:       "len",
+	Params:     []*parser.Var{{Name: "a", T: parser.ANY_TYPE}},
+	ReturnType: parser.NUM_TYPE,
+}
+
+func lenFunc(args []Value) Value {
 	if len(args) != 1 {
 		return newError("'len' takes 1 argument not " + strconv.Itoa(len(args)))
 	}
@@ -37,8 +70,38 @@ func Len(args []Value) Value {
 		return &Num{Val: float64(len(arg.Elements))}
 	case *String:
 		return &Num{Val: float64(len(arg.Val))}
-	default:
-		return newError("'len' takes 1 argument of type 'string', array '[]' or map '{}' not " + args[0].Type().String())
 	}
+	return newError("'len' takes 1 argument of type 'string', array '[]' or map '{}' not " + args[0].Type().String())
+}
 
+var moveDecl = &parser.FuncDecl{
+	Name: "move",
+	Params: []*parser.Var{
+		&parser.Var{Name: "x", T: parser.NUM_TYPE},
+		&parser.Var{Name: "y", T: parser.NUM_TYPE},
+	},
+	ReturnType: parser.NUM_TYPE,
+}
+
+func moveFunc(printFn func(string)) BuiltinFunc {
+	return func(args []Value) Value {
+		printFn("'move' not yet implemented\n")
+		return nil
+	}
+}
+
+var lineDecl = &parser.FuncDecl{
+	Name: "line",
+	Params: []*parser.Var{
+		&parser.Var{Name: "x", T: parser.NUM_TYPE},
+		&parser.Var{Name: "y", T: parser.NUM_TYPE},
+	},
+	ReturnType: parser.NUM_TYPE,
+}
+
+func lineFunc(printFn func(string)) BuiltinFunc {
+	return func(args []Value) Value {
+		printFn("'line' not yet implemented\n")
+		return nil
+	}
 }

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -9,7 +9,7 @@ func Run(input string, print func(string)) {
 	prog := p.Parse()
 	e := &Evaluator{print: print}
 	e.builtins = newBuiltins(e)
-	val := e.Eval(prog, NewScope())
+	val := e.Eval(prog, newScope())
 	if isError(val) {
 		print(val.String())
 	}
@@ -20,7 +20,7 @@ type Evaluator struct {
 	builtins map[string]Builtin
 }
 
-func (e *Evaluator) Eval(node parser.Node, scope *Scope) Value {
+func (e *Evaluator) Eval(node parser.Node, scope *scope) Value {
 	switch node := node.(type) {
 	case *parser.Program:
 		return e.evalProgram(node, scope)
@@ -43,7 +43,7 @@ func (e *Evaluator) Eval(node parser.Node, scope *Scope) Value {
 	return nil
 }
 
-func (e *Evaluator) evalProgram(program *parser.Program, scope *Scope) Value {
+func (e *Evaluator) evalProgram(program *parser.Program, scope *scope) Value {
 	var result Value
 	for _, statement := range program.Statements {
 		result = e.Eval(statement, scope)
@@ -54,16 +54,16 @@ func (e *Evaluator) evalProgram(program *parser.Program, scope *Scope) Value {
 	return result
 }
 
-func (e *Evaluator) evalDeclaration(decl *parser.Declaration, scope *Scope) Value {
+func (e *Evaluator) evalDeclaration(decl *parser.Declaration, scope *scope) Value {
 	val := e.Eval(decl.Value, scope)
 	if isError(val) {
 		return val
 	}
-	scope.Set(decl.Var.Name, val)
+	scope.set(decl.Var.Name, val)
 	return nil
 }
 
-func (e *Evaluator) evalFunctionCall(funcCall *parser.FunctionCall, scope *Scope) Value {
+func (e *Evaluator) evalFunctionCall(funcCall *parser.FunctionCall, scope *scope) Value {
 	args := e.evalTerms(funcCall.Arguments, scope)
 	if len(args) == 1 && isError(args[0]) {
 		return args[0]
@@ -75,18 +75,18 @@ func (e *Evaluator) evalFunctionCall(funcCall *parser.FunctionCall, scope *Scope
 	return builtin(args)
 }
 
-func (e *Evaluator) evalVar(v *parser.Var, scope *Scope) Value {
-	if val, ok := scope.Get(v.Name); ok {
+func (e *Evaluator) evalVar(v *parser.Var, scope *scope) Value {
+	if val, ok := scope.get(v.Name); ok {
 		return val
 	}
 	return newError("cannot find variable " + v.Name)
 }
 
-func (e *Evaluator) evalTerm(term parser.Node, scope *Scope) Value {
+func (e *Evaluator) evalTerm(term parser.Node, scope *scope) Value {
 	return e.Eval(term, scope)
 }
 
-func (e *Evaluator) evalTerms(terms []parser.Node, scope *Scope) []Value {
+func (e *Evaluator) evalTerms(terms []parser.Node, scope *scope) []Value {
 	result := make([]Value, len(terms))
 
 	for i, t := range terms {

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -8,6 +8,10 @@ func Run(input string, print func(string)) {
 	builtins := DefaultBuiltins(print)
 	p := parser.NewWithBuiltins(input, builtins.Decls())
 	prog := p.Parse()
+	if p.HasErrors() {
+		print(p.MaxErrorsString(8))
+		return
+	}
 	e := &Evaluator{print: print}
 	e.builtins = builtins
 	val := e.Eval(prog, newScope())

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -5,10 +5,11 @@ import (
 )
 
 func Run(input string, print func(string)) {
-	p := parser.New(input)
+	builtins := DefaultBuiltins(print)
+	p := parser.NewWithBuiltins(input, builtins.Decls())
 	prog := p.Parse()
 	e := &Evaluator{print: print}
-	e.builtins = newBuiltins(e)
+	e.builtins = builtins
 	val := e.Eval(prog, newScope())
 	if isError(val) {
 		print(val.String())
@@ -72,7 +73,7 @@ func (e *Evaluator) evalFunctionCall(funcCall *parser.FunctionCall, scope *scope
 	if !ok {
 		return newError("cannot find builtin function " + funcCall.Name)
 	}
-	return builtin(args)
+	return builtin.Func(args)
 }
 
 func (e *Evaluator) evalVar(v *parser.Var, scope *scope) Value {

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -35,6 +35,48 @@ func TestParseDeclaration(t *testing.T) {
 	}
 }
 
+func TestReturn(t *testing.T) {
+	prog := `
+func fox:string
+       return "🦊"
+end
+
+f := fox
+print f
+print f f
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := "🦊\n🦊 🦊\n"
+	assert.Equal(t, want, b.String())
+}
+
+func TestReturnScope(t *testing.T) {
+	prog := `
+f := 1
+func fox1:string
+       f := "🦊"
+       return f
+end
+
+func fox2:string
+       return fox1
+end
+
+print f
+f1 := fox1
+print f1
+f2 := fox2
+print f2
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := "1\n🦊\n🦊\n"
+	assert.Equal(t, want, b.String())
+}
+
 func TestDemo(t *testing.T) {
 	prog := `
 move 10 10

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestBasicEval(t *testing.T) {
 	in := "a:=1\n print a 2"
-	want := "1 2"
+	want := "1 2\n"
 	b := bytes.Buffer{}
 	fn := func(s string) { b.WriteString(s) }
 	Run(in, fn)
@@ -30,7 +30,7 @@ func TestParseDeclaration(t *testing.T) {
 			b := bytes.Buffer{}
 			fn := func(s string) { b.WriteString(s) }
 			Run(in, fn)
-			assert.Equal(t, want, b.String())
+			assert.Equal(t, want+"\n", b.String())
 		})
 	}
 }
@@ -48,6 +48,10 @@ end`
 	b := bytes.Buffer{}
 	fn := func(s string) { b.WriteString(s) }
 	Run(prog, fn)
-	want := "x: 12"
+	want := `
+'move' not yet implemented
+'line' not yet implemented
+x: 12
+`[1:]
 	assert.Equal(t, want, b.String())
 }

--- a/pkg/evaluator/scope.go
+++ b/pkg/evaluator/scope.go
@@ -1,29 +1,25 @@
 package evaluator
 
-type Scope struct {
-	store map[string]Value
-	outer *Scope
+type scope struct {
+	values map[string]Value
+	outer  *scope
 }
 
-func NewScope() *Scope {
-	return &Scope{store: map[string]Value{}}
+func newScope() *scope {
+	return &scope{values: map[string]Value{}}
 }
 
-func NewEnclosedScope(outer *Scope) *Scope {
-	return &Scope{store: map[string]Value{}, outer: outer}
-}
-
-func (s *Scope) Get(name string) (Value, bool) {
+func (s *scope) get(name string) (Value, bool) {
 	if s == nil {
 		return nil, false
 	}
-	if val, ok := s.store[name]; ok {
+	if val, ok := s.values[name]; ok {
 		return val, ok
 	}
-	return s.outer.Get(name)
+	return s.outer.get(name)
 }
 
-func (s *Scope) Set(name string, val Value) Value {
-	s.store[name] = val
+func (s *scope) set(name string, val Value) Value {
+	s.values[name] = val
 	return val
 }

--- a/pkg/evaluator/scope.go
+++ b/pkg/evaluator/scope.go
@@ -9,6 +9,10 @@ func newScope() *scope {
 	return &scope{values: map[string]Value{}}
 }
 
+func newInnerScope(outer *scope) *scope {
+	return &scope{values: map[string]Value{}, outer: outer}
+}
+
 func (s *scope) get(name string) (Value, bool) {
 	if s == nil {
 		return nil, false

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -20,13 +20,13 @@ type FunctionCall struct {
 	Token     *lexer.Token // The IDENT of the function
 	Name      string
 	Arguments []Node
-	nType     *Type
+	T         *Type
 }
 
 type Term struct {
 	Token *lexer.Token
 	Value Node
-	nType *Type
+	T     *Type
 }
 
 type Declaration struct {
@@ -52,7 +52,7 @@ type EventHandler struct {
 type Var struct {
 	Token *lexer.Token
 	Name  string
-	nType *Type
+	T     *Type
 }
 
 type BlockStatement struct {
@@ -78,14 +78,14 @@ type StringLiteral struct {
 type ArrayLiteral struct {
 	Token    *lexer.Token
 	Elements []Node
-	nType    *Type
+	T        *Type
 }
 
 type MapLiteral struct {
 	Token *lexer.Token
 	Pairs map[string]Node
 	Order []string // Track insertion order of keys for deterministic output.
-	nType *Type
+	T     *Type
 }
 
 func (p *Program) String() string {
@@ -104,14 +104,14 @@ func (f *FunctionCall) String() string {
 	return f.Name + "(" + args + ")"
 }
 func (f *FunctionCall) Type() *Type {
-	return f.nType
+	return f.T
 }
 
 func (t *Term) String() string {
 	return t.Value.String()
 }
 func (t *Term) Type() *Type {
-	return t.nType
+	return t.T
 }
 
 func (d *Declaration) String() string {
@@ -121,7 +121,7 @@ func (d *Declaration) String() string {
 	return d.Var.String() + "=" + d.Value.String()
 }
 func (d *Declaration) Type() *Type {
-	return d.Var.nType
+	return d.Var.T
 }
 
 func (f *FuncDecl) String() string {
@@ -153,10 +153,10 @@ func (e *EventHandler) Type() *Type {
 }
 
 func (v *Var) String() string {
-	return v.Name + ":" + v.nType.String()
+	return v.Name + ":" + v.T.String()
 }
 func (v *Var) Type() *Type {
-	return v.nType
+	return v.T
 }
 
 func (b *BlockStatement) String() string {
@@ -195,7 +195,7 @@ func (a *ArrayLiteral) String() string {
 	return "[" + strings.Join(elements, ", ") + "]"
 }
 func (a *ArrayLiteral) Type() *Type {
-	return a.nType
+	return a.T
 }
 
 func (m *MapLiteral) String() string {
@@ -207,7 +207,7 @@ func (m *MapLiteral) String() string {
 	return "{" + strings.Join(pairs, ", ") + "}"
 }
 func (m *MapLiteral) Type() *Type {
-	return m.nType
+	return m.T
 }
 
 func newlineList(nodes []Node) string {

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -20,6 +20,7 @@ type FunctionCall struct {
 	Token     *lexer.Token // The IDENT of the function
 	Name      string
 	Arguments []Node
+	FuncDecl  *FuncDecl
 	T         *Type
 }
 

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -35,6 +35,12 @@ type Declaration struct {
 	Value Node // literal, expression, assignable, ...
 }
 
+type Return struct {
+	Token *lexer.Token
+	Value Node // literal, expression, assignable, ...
+	T     *Type
+}
+
 type FuncDecl struct {
 	Token         *lexer.Token // The 'func' token
 	Name          string
@@ -122,6 +128,16 @@ func (d *Declaration) String() string {
 }
 func (d *Declaration) Type() *Type {
 	return d.Var.T
+}
+
+func (r *Return) String() string {
+	if r.Value == nil {
+		return "return"
+	}
+	return "return " + r.Value.String()
+}
+func (r *Return) Type() *Type {
+	return r.T
 }
 
 func (f *FuncDecl) String() string {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -352,7 +352,11 @@ func (p *Parser) parseTerm(scope *scope) Node {
 		p.advance()
 		v, ok := scope.get(varName)
 		if !ok {
-			p.appendError("unknown variable name '" + varName + "'")
+			if _, ok := p.funcs[varName]; ok {
+				p.appendError("function call must be parenthesized: (" + varName + " ...)")
+			} else {
+				p.appendError("unknown variable name '" + varName + "'")
+			}
 			return nil
 		}
 		return v
@@ -394,6 +398,7 @@ func (p *Parser) parseFuncCall(scope *scope) Node {
 		Name:      funcName,
 		Token:     funcToken,
 		Arguments: args,
+		FuncDecl:  decl,
 		T:         decl.ReturnType,
 	}
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -15,7 +15,7 @@ func Run(input string) string {
 		for i, e := range parser.errors {
 			errs[i] = e.String()
 		}
-		return parser.errorsString() + "\n\n" + prog.String()
+		return parser.MaxErrorsString(8) + "\n\n" + prog.String()
 	}
 	return prog.String()
 }
@@ -87,6 +87,14 @@ func builtins() map[string]*FuncDecl {
 			ReturnType: NUM_TYPE,
 		},
 	}
+}
+
+func (p *Parser) Errors() []Error {
+	return p.errors
+}
+
+func (p *Parser) HasErrors() bool {
+	return len(p.errors) != 0
 }
 
 func (p *Parser) Parse() *Program {
@@ -502,12 +510,24 @@ func (p *Parser) lookAt(pos int) *lexer.Token {
 	return p.tokens[pos]
 }
 
-func (p *Parser) errorsString() string {
-	errs := make([]string, len(p.errors))
-	for i, err := range p.errors {
-		errs[i] = err.String()
+func (p *Parser) MaxErrorsString(n int) string {
+	errs := p.errors
+	if n != -1 && len(errs) > n {
+		errs = errs[:n]
 	}
-	return strings.Join(errs, "\n")
+	return errString(errs)
+}
+
+func (p *Parser) ErrorsString() string {
+	return errString(p.errors)
+}
+
+func errString(errs []Error) string {
+	errsSrings := make([]string, len(errs))
+	for i, err := range errs {
+		errsSrings[i] = err.String()
+	}
+	return strings.Join(errsSrings, "\n")
 }
 
 //TODO: implemented

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -200,7 +200,7 @@ func (p *Parser) parseStatement(scope *scope) Node {
 		p.advancePastNL()
 		return nil
 	case lexer.RETURN:
-		return p.parseReturnStatment(scope) // TODO
+		return p.parseReturnStatment(scope)
 	case lexer.BREAK:
 		return p.parseBreakStatment() // TODO
 	case lexer.FOR:
@@ -530,10 +530,22 @@ func errString(errs []Error) string {
 	return strings.Join(errsSrings, "\n")
 }
 
-//TODO: implemented
 func (p *Parser) parseReturnStatment(scope *scope) Node {
+	ret := &Return{Token: p.cur}
+	p.advance()      // advance past RETURN token
+	if p.isAtEOL() { // no return value, we are done
+		ret.T = NONE_TYPE
+		return ret
+	}
+	ret.Value = p.parseTopLevelExpression(scope)
+	if ret.Value == nil {
+		ret.T = ILLEGAL_TYPE
+	} else {
+		ret.T = ret.Value.Type()
+		p.assertEOL()
+	}
 	p.advancePastNL()
-	return nil
+	return ret
 }
 
 //TODO: implemented

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -78,12 +78,12 @@ func builtins() map[string]*FuncDecl {
 	return map[string]*FuncDecl{
 		"print": &FuncDecl{
 			Name:          "print",
-			VariadicParam: &Var{Name: "a", nType: ANY_TYPE},
+			VariadicParam: &Var{Name: "a", T: ANY_TYPE},
 			ReturnType:    NONE_TYPE,
 		},
 		"len": &FuncDecl{
 			Name:       "len",
-			Params:     []*Var{{Name: "a", nType: ANY_TYPE}},
+			Params:     []*Var{{Name: "a", T: ANY_TYPE}},
 			ReturnType: NUM_TYPE,
 		},
 	}
@@ -269,7 +269,7 @@ func (p *Parser) parseTypedDecl() *Declaration {
 	p.advance() // advance past IDENT
 	p.advance() // advance past `:`
 	v := p.parseType()
-	decl.Var.nType = v
+	decl.Var.T = v
 	decl.Value = zeroValue(v.Name)
 	if v == ILLEGAL_TYPE {
 		p.appendErrorForToken("invalid type declaration for '"+varName+"'", decl.Token)
@@ -314,7 +314,7 @@ func (p *Parser) parseInferredDeclStatement(scope *scope) Node {
 		p.appendError("invalid declaration, function '" + valToken.Literal + "' has no return value")
 		return nil
 	}
-	decl.Var.nType = val.Type()
+	decl.Var.T = val.Type()
 	if !p.validateVar(scope, decl.Var, decl.Token) {
 		return nil
 	}
@@ -386,7 +386,7 @@ func (p *Parser) parseFuncCall(scope *scope) Node {
 		Name:      funcName,
 		Token:     funcToken,
 		Arguments: args,
-		nType:     decl.ReturnType,
+		T:         decl.ReturnType,
 	}
 }
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -123,7 +123,7 @@ func (p *Parser) parseFunc(scope *scope) Node {
 
 	p.advancePastNL() // // advance past signature, already parsed into p.funcs earlier
 	fd := p.funcs[funcName]
-	scope = newEnclosedScope(scope)
+	scope = newInnerScope(scope)
 	p.addParamsToScope(scope, fd)
 	block := p.parseBlock(scope) // parse to "end"
 
@@ -524,7 +524,7 @@ func (p *Parser) parseBreakStatment() Node {
 
 //TODO: implemented
 func (p *Parser) parseForStatment(scope *scope) Node {
-	scope = newEnclosedScope(scope)
+	scope = newInnerScope(scope)
 	p.advancePastNL()
 	p.parseBlock(scope)
 	return nil
@@ -532,7 +532,7 @@ func (p *Parser) parseForStatment(scope *scope) Node {
 
 //TODO: implemented
 func (p *Parser) parseWhileStatment(scope *scope) Node {
-	scope = newEnclosedScope(scope)
+	scope = newInnerScope(scope)
 	p.advancePastNL()
 	p.parseBlock(scope)
 	return nil
@@ -540,7 +540,7 @@ func (p *Parser) parseWhileStatment(scope *scope) Node {
 
 //TODO: implemented
 func (p *Parser) parseIfStatment(scope *scope) Node {
-	scope = newEnclosedScope(scope)
+	scope = newInnerScope(scope)
 	p.advancePastNL()
 	p.parseBlock(scope)
 	return nil

--- a/pkg/parser/parser_literal.go
+++ b/pkg/parser/parser_literal.go
@@ -46,14 +46,14 @@ func (p *Parser) parseCompositeLiteral(scope *scope) Node {
 	switch litType.Name {
 	case ARRAY:
 		elements := p.parseArrayElements(scope, litType.Sub)
-		return &ArrayLiteral{Token: tok, Elements: elements, nType: litType}
+		return &ArrayLiteral{Token: tok, Elements: elements, T: litType}
 	case MAP:
 		pairs, order := p.parseMapPairs(scope, litType.Sub)
 		return &MapLiteral{
 			Token: tok,
 			Pairs: pairs,
 			Order: order,
-			nType: litType,
+			T:     litType,
 		}
 	}
 	p.appendError("unknown literal " + tok.String())

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -85,7 +85,7 @@ func TestParseDeclarationError(t *testing.T) {
 		parser := New(input)
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
-		assert.Equal(t, err1, parser.errors[0].String(), "input: %s\nerrors:\n%s", input, parser.errorsString())
+		assert.Equal(t, err1, parser.errors[0].String(), "input: %s\nerrors:\n%s", input, parser.ErrorsString())
 	}
 }
 
@@ -138,7 +138,7 @@ func TestFunctionCallError(t *testing.T) {
 		parser := NewWithBuiltins(input, builtins)
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
-		assert.Equal(t, err1, parser.errors[0].String(), "input: %s\nerrors:\n%s", input, parser.errorsString())
+		assert.Equal(t, err1, parser.errors[0].String(), "input: %s\nerrors:\n%s", input, parser.ErrorsString())
 	}
 }
 
@@ -338,5 +338,5 @@ func assertParseError(t *testing.T, parser *Parser, input string) {
 
 func assertNoParseError(t *testing.T, parser *Parser, input string) {
 	t.Helper()
-	assert.Equal(t, 0, len(parser.errors), "Unexpected parser error\n input: %s\nerrors:\n%s", input, parser.errorsString())
+	assert.Equal(t, 0, len(parser.errors), "Unexpected parser error\n input: %s\nerrors:\n%s", input, parser.ErrorsString())
 }

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -182,7 +182,7 @@ func add:num n1:num n2:num
 	if c > 10
 	    print c
 	end
-	return n1 + n2
+	return n1 // + n2
 end
 on mousedown
 	if c > 10
@@ -204,7 +204,9 @@ end
 	n1 := got.Params[0]
 	assert.Equal(t, "n1", n1.Name)
 	assert.Equal(t, NUM_TYPE, n1.Type())
-	assert.Equal(t, 0, len(got.Body.Statements))
+	assert.Equal(t, 1, len(got.Body.Statements)) // return statement; if statement not yet implemented.
+	returnStmt := got.Body.Statements[0]
+	assert.Equal(t, "return n1:NUM", returnStmt.String())
 }
 
 func TestScope(t *testing.T) {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -115,11 +115,11 @@ func TestFunctionCall(t *testing.T) {
 func TestFunctionCallError(t *testing.T) {
 	builtins := builtins()
 	builtins["f0"] = &FuncDecl{Name: "f0", ReturnType: NONE_TYPE}
-	builtins["f1"] = &FuncDecl{Name: "f1", VariadicParam: &Var{Name: "a", nType: NUM_TYPE}, ReturnType: NONE_TYPE}
-	builtins["f2"] = &FuncDecl{Name: "f2", Params: []*Var{&Var{Name: "a", nType: NUM_TYPE}}, ReturnType: NONE_TYPE}
+	builtins["f1"] = &FuncDecl{Name: "f1", VariadicParam: &Var{Name: "a", T: NUM_TYPE}, ReturnType: NONE_TYPE}
+	builtins["f2"] = &FuncDecl{Name: "f2", Params: []*Var{&Var{Name: "a", T: NUM_TYPE}}, ReturnType: NONE_TYPE}
 	builtins["f3"] = &FuncDecl{
 		Name:       "f3",
-		Params:     []*Var{&Var{Name: "a", nType: NUM_TYPE}, &Var{Name: "b", nType: STRING_TYPE}},
+		Params:     []*Var{&Var{Name: "a", T: NUM_TYPE}, &Var{Name: "b", T: STRING_TYPE}},
 		ReturnType: NONE_TYPE,
 	}
 	tests := map[string]string{

--- a/pkg/parser/scope.go
+++ b/pkg/parser/scope.go
@@ -9,7 +9,7 @@ func newScope() *scope {
 	return &scope{vars: map[string]*Var{}}
 }
 
-func newEnclosedScope(outer *scope) *scope {
+func newInnerScope(outer *scope) *scope {
 	return &scope{vars: map[string]*Var{}, outer: outer}
 }
 


### PR DESCRIPTION
Implement return statements in ast, parser and evaluator. With this we
can more carefully test valid scoping in the evaluator.

Add pointer to FuncDecl in FuncCall node for easier evaluation.