### PR TITLE
go: Refactor builtins

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,8 +41,8 @@ func (c *cmdRun) Run() error {
 	if err != nil {
 		return err
 	}
-	print := func(s string) { fmt.Print(s) }
-	evaluator.Run(string(b), print)
+	printFunc := func(s string) { fmt.Print(s) }
+	evaluator.Run(string(b), printFunc)
 	return nil
 }
 
@@ -61,7 +61,9 @@ func (c *cmdParse) Run() error {
 	if err != nil {
 		return err
 	}
-	result := parser.Run(string(b))
+	printFunc := func(s string) { fmt.Print(s) }
+	builtins := evaluator.DefaultBuiltins(printFunc).Decls()
+	result := parser.Run(string(b), builtins)
 	fmt.Println(result)
 	return nil
 }

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -5,8 +5,11 @@ import (
 )
 
 func Run(input string, print func(string)) {
-	builtins := DefaultBuiltins(print)
-	p := parser.NewWithBuiltins(input, builtins.Decls())
+	RunWithBuiltins(input, print, DefaultBuiltins(print))
+}
+
+func RunWithBuiltins(input string, print func(string), builtins Builtins) {
+	p := parser.New(input, builtins.Decls())
 	prog := p.Parse()
 	if p.HasErrors() {
 		print(p.MaxErrorsString(8))

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -7,8 +7,8 @@ import (
 	"foxygo.at/evy/pkg/lexer"
 )
 
-func Run(input string) string {
-	parser := New(input)
+func Run(input string, builtins map[string]*FuncDecl) string {
+	parser := New(input, builtins)
 	prog := parser.Parse()
 	if len(parser.errors) > 0 {
 		errs := make([]string, len(parser.errors))
@@ -41,11 +41,7 @@ func (e Error) String() string {
 	return e.token.Location() + ": " + e.message
 }
 
-func New(input string) *Parser {
-	return NewWithBuiltins(input, builtins())
-}
-
-func NewWithBuiltins(input string, builtins map[string]*FuncDecl) *Parser {
+func New(input string, builtins map[string]*FuncDecl) *Parser {
 	l := lexer.New(input)
 	p := &Parser{funcs: builtins}
 
@@ -72,21 +68,6 @@ func NewWithBuiltins(input string, builtins map[string]*FuncDecl) *Parser {
 		}
 	}
 	return p
-}
-
-func builtins() map[string]*FuncDecl {
-	return map[string]*FuncDecl{
-		"print": &FuncDecl{
-			Name:          "print",
-			VariadicParam: &Var{Name: "a", T: ANY_TYPE},
-			ReturnType:    NONE_TYPE,
-		},
-		"len": &FuncDecl{
-			Name:       "len",
-			Params:     []*Var{{Name: "a", T: ANY_TYPE}},
-			ReturnType: NUM_TYPE,
-		},
-	}
 }
 
 func (p *Parser) Errors() []Error {

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -41,7 +41,8 @@ func jsTokenize(ptr *uint32, length int) {
 //export parse
 func jsParse(ptr *uint32, length int) {
 	s := getString(ptr, length)
-	jsPrint(parser.Run(s))
+	builtins := evaluator.DefaultBuiltins(jsPrint).Decls()
+	jsPrint(parser.Run(s, builtins))
 }
 
 // alloc pre-allocates memory used in string parameter passing.


### PR DESCRIPTION
Refactor builtins, such that parser package doesn't have any default
builtins other than for testing. Builtins need to be provided to parser
by caller. This ensures builtins are always only defined in one place.