### PR TITLE
go: Add assignment evaluation and parsing

### DIFF
--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -34,6 +34,8 @@ func (e *Evaluator) Eval(scope *scope, node parser.Node) Value {
 		return e.evalProgram(scope, node)
 	case *parser.Declaration:
 		return e.evalDeclaration(scope, node)
+	case *parser.Assignment:
+		return e.evalAssignment(scope, node)
 	case *parser.Var:
 		v := e.evalVar(scope, node)
 		return v
@@ -72,6 +74,15 @@ func (e *Evaluator) evalDeclaration(scope *scope, decl *parser.Declaration) Valu
 		return val
 	}
 	scope.set(decl.Var.Name, val)
+	return nil
+}
+
+func (e *Evaluator) evalAssignment(scope *scope, assignment *parser.Assignment) Value {
+	val := e.Eval(scope, assignment.Value)
+	if isError(val) {
+		return val
+	}
+	scope.set(assignment.Target.String(), val) // TODO: update when indexing and field selectors are implemented.
 	return nil
 }
 

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -77,6 +77,49 @@ print f2
 	assert.Equal(t, want, b.String())
 }
 
+func TestAssignment(t *testing.T) {
+	prog := `
+f1:num
+f2:num
+f3 := 3
+print f1 f2 f3
+f1 = 1
+print f1 f2 f3
+f1 = f3
+f2 = f1
+f3 = 4
+print f1 f2 f3
+
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := "0 0 3\n1 0 3\n3 3 4\n"
+	assert.Equal(t, want, b.String())
+}
+
+func TestAssignmentAny(t *testing.T) {
+	prog := `
+f1:any
+f2:num
+print f1 f2
+f1 = f2
+print f1 f2
+f1 = fox
+print f1 f2
+
+func fox:string
+       return "🦊"
+end
+
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := "false 0\n0 0\n🦊 0\n"
+	assert.Equal(t, want, b.String())
+}
+
 func TestDemo(t *testing.T) {
 	prog := `
 move 10 10

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -36,6 +36,12 @@ type Declaration struct {
 	Value Node // literal, expression, assignable, ...
 }
 
+type Assignment struct {
+	Token  *lexer.Token
+	Target Node // Variable, index or field expression
+	Value  Node // literal, expression, assignable, ...
+}
+
 type Return struct {
 	Token *lexer.Token
 	Value Node // literal, expression, assignable, ...
@@ -139,6 +145,13 @@ func (r *Return) String() string {
 }
 func (r *Return) Type() *Type {
 	return r.T
+}
+
+func (a *Assignment) String() string {
+	return a.Target.String() + " = " + a.Value.String()
+}
+func (a *Assignment) Type() *Type {
+	return a.Target.Type()
 }
 
 func (f *FuncDecl) String() string {

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -170,7 +170,7 @@ func (e *EventHandler) Type() *Type {
 }
 
 func (v *Var) String() string {
-	return v.Name + ":" + v.T.String()
+	return v.Name
 }
 func (v *Var) Type() *Type {
 	return v.T


### PR DESCRIPTION
Add assignment parsing and assignment AST node. Extract parseAssignable
from parseTerm to reuse here. This will be extended by indexed and
field selector expressions. Rework String() method for Node type
Var, so that it works better in errors messages.

Add assignment evaluation: assignment nodes only update scope for
existing variables.