### PR TITLE
docs: Enforce at least one statement in blocks

### DIFF
--- a/docs/syntax_grammar.md
+++ b/docs/syntax_grammar.md
@@ -70,6 +70,35 @@ not allowed.
                  return_stmt | break_stmt |
                  for_stmt | while_stmt | if_stmt  .
 
+    /* --- Functions and Event handlers ---- */
+    func            = "func" ident func_signature NL
+                          { statement }
+                      "end" NL .
+    func_signature  = [ ":" type ] params .
+    params          = { typed_decl } | variadic_param .
+    variadic_param  = typed_decl "..." .
+
+    event_handler   = "on" ident NL
+                          { statement }
+                      "end" NL .
+
+    /* --- Control flow --- */
+    if_stmt = "if" toplevel_expr NL
+                    { statement }
+              { "else" "if" toplevel_expr NL
+                    { statement } }
+              [ "else" NL
+                    { statement } ]
+              "end" NL .
+
+    for_stmt   = "for" range NL
+                    { statement }
+                 "end" NL .
+    range      = ident ( ":=" | "=" ) "range" range_args .
+    range_args = term [ term [ term ] ] .
+    while_stmt = "while" toplevel_expr NL
+                     { statement }
+                 "end" NL .
 
     /* --- Statement ---- */
     empty_stmt = NL .
@@ -126,36 +155,6 @@ not allowed.
     array_elems = { term [NL] }
     map_lit     = [type] "{" map_elems "}" .
     map_elems   = { ident ":" term [NL] } .
-    
-    /* --- Control flow --- */
-    for_stmt   = "for" range NL
-                    { statement }
-                 "end" NL .
-    range      = ident ( ":=" | "=" ) "range" range_args .
-    range_args = term [ term [ term ] ] .
-    while_stmt = "while" toplevel_expr NL
-                     { statement }
-                 "end" NL .
-
-    if_stmt = "if" toplevel_expr NL
-                    { statement }
-              { "else" "if" toplevel_expr NL
-                    { statement } }
-              [ "else" NL
-                    { statement } ]
-              "end" NL .
-
-    /* --- Functions ---- */
-    func            = "func" ident func_signature NL
-                          { statement }
-                      "end" NL .
-    func_signature  = [ ":" type ] params .
-    params          = { typed_decl } | variadic_param .
-    variadic_param  = typed_decl "..." .
-
-    event_handler   = "on" ident NL
-                          { statement }
-                      "end" NL .
 
     /* --- Terminals --- */
     LETTER         = UNICODE_LETTER | "_" .

--- a/docs/syntax_grammar.md
+++ b/docs/syntax_grammar.md
@@ -64,6 +64,7 @@ The `evy` source code is UTF-8 encoded. The NUL character `U+0000` is
 not allowed.
 
     program    = { statement | func | event_handler } .
+    statements = statement { statement }
     statement  = empty_stmt | 
                  assign_stmt | typed_decl_stmt | inferred_decl_stmt |
                  func_call_stmt | 
@@ -72,32 +73,32 @@ not allowed.
 
     /* --- Functions and Event handlers ---- */
     func            = "func" ident func_signature NL
-                          { statement }
+                          statements
                       "end" NL .
     func_signature  = [ ":" type ] params .
     params          = { typed_decl } | variadic_param .
     variadic_param  = typed_decl "..." .
 
     event_handler   = "on" ident NL
-                          { statement }
+                          statements
                       "end" NL .
 
     /* --- Control flow --- */
     if_stmt = "if" toplevel_expr NL
-                    { statement }
+                    statements
               { "else" "if" toplevel_expr NL
-                    { statement } }
+                    statements }
               [ "else" NL
-                    { statement } ]
+                    statements ]
               "end" NL .
 
     for_stmt   = "for" range NL
-                    { statement }
+                    statements
                  "end" NL .
     range      = ident ( ":=" | "=" ) "range" range_args .
     range_args = term [ term [ term ] ] .
     while_stmt = "while" toplevel_expr NL
-                     { statement }
+                     statements
                  "end" NL .
 
     /* --- Statement ---- */


### PR DESCRIPTION
Update grammar to enforce at least one statement in blocks. This means
each function declaration, if statement, while statement etc. need to
have at least one statement in the inner block. Like in Go's "variable
declared but not used" error message we want to catch accidental
omissions and limit the set of "valid programs" to provide more guide
rails.

The parser will be updated in a follow up PR.

While at it, reorder the production rules in the grammar to flow more
naturally from higher order constructs, to single line statements,
expressions and TERMINALS.