### PR TITLE
parser: Harden return statements

### DIFF
--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -37,8 +37,7 @@ func (e *Evaluator) Eval(scope *scope, node parser.Node) Value {
 	case *parser.Assignment:
 		return e.evalAssignment(scope, node)
 	case *parser.Var:
-		v := e.evalVar(scope, node)
-		return v
+		return e.evalVar(scope, node)
 	case *parser.Term:
 		return e.evalTerm(scope, node)
 	case *parser.NumLiteral:
@@ -62,10 +61,14 @@ func (e *Evaluator) Eval(scope *scope, node parser.Node) Value {
 }
 
 func (e *Evaluator) evalProgram(scope *scope, program *parser.Program) Value {
+	return e.evalStatments(scope, program.Statements)
+}
+
+func (e *Evaluator) evalStatments(scope *scope, statements []parser.Node) Value {
 	var result Value
-	for _, statement := range program.Statements {
+	for _, statement := range statements {
 		result = e.Eval(scope, statement)
-		if isError(result) {
+		if isError(result) || isReturn(result) {
 			return result
 		}
 	}
@@ -181,13 +184,7 @@ func (e *Evaluator) evalConditionalBlock(scope *scope, condBlock *parser.Conditi
 }
 
 func (e *Evaluator) evalBlockStatment(scope *scope, block *parser.BlockStatement) Value {
-	for _, statement := range block.Statements {
-		result := e.Eval(scope, statement)
-		if isError(result) || isReturn(result) {
-			return result
-		}
-	}
-	return nil
+	return e.evalStatments(scope, block.Statements)
 }
 
 func (e *Evaluator) evalVar(scope *scope, v *parser.Var) Value {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -130,6 +130,9 @@ func (p *Parser) parseFunc(scope *scope) Node {
 		p.appendError("redeclaration of function '" + funcName + "'")
 		return nil
 	}
+	if fd.ReturnType != NONE_TYPE && !block.AlwaysReturns() {
+		p.appendError("missing return")
+	}
 	p.assertEnd()
 	p.advancePastNL()
 	fd.Body = block

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -283,6 +283,22 @@ func foo
 end
 print "do i run?"
 `: "line 7 column 1: unreachable code",
+		`
+func nums:num
+	while true
+		if true
+			return 1
+		end
+	end
+end
+`: "line 8 column 1: missing return",
+		`
+func nums:num
+	if true
+		return 1
+	end
+end
+`: "line 6 column 1: missing return",
 	}
 	for input, wantErr := range inputs {
 		parser := New(input, testBuiltins())

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -189,10 +189,11 @@ x=len('123')
 
 func TestFuncDecl(t *testing.T) {
 	input := `
-c := add 1 2
-func add:num n1:num n2:num
+c := 1
+func nums1:num n1:num n2:num
 	if true //TODO: > 10
 	    print c
+	    return n1
 	end
 	return n1 // + n2
 end
@@ -201,14 +202,28 @@ on mousedown
 	    print c
 	end
 end
+func nums2:num n1:num n2:num
+	if true //TODO: > 10
+		return n1
+	else
+		return n2
+	end
+end
+func nums3
+	if true
+		return
+	end
+end
+
+return "success"
 `
 	parser := New(input, testBuiltins())
 	_ = parser.Parse()
 	assertNoParseError(t, parser, input)
 	builtinCnt := len(testBuiltins())
-	assert.Equal(t, builtinCnt+1, len(parser.funcs))
-	got := parser.funcs["add"]
-	assert.Equal(t, "add", got.Name)
+	assert.Equal(t, builtinCnt+3, len(parser.funcs))
+	got := parser.funcs["nums1"]
+	assert.Equal(t, "nums1", got.Name)
 	assert.Equal(t, NUM_TYPE, got.ReturnType)
 	var wantVariadicParam *Var = nil
 	assert.Equal(t, wantVariadicParam, got.VariadicParam)
@@ -266,7 +281,7 @@ b:any
 a = b
 `: "line 4 column 3: 'a' accepts values of type num, found any",
 		`
-func fn
+func fn:bool
 	return true
 end
 fn = 3

--- a/pkg/parser/scope.go
+++ b/pkg/parser/scope.go
@@ -3,14 +3,20 @@ package parser
 type scope struct {
 	vars  map[string]*Var
 	outer *scope
+
+	returnType *Type
 }
 
 func newScope() *scope {
-	return &scope{vars: map[string]*Var{}}
+	return &scope{vars: map[string]*Var{}, returnType: ANY_TYPE}
 }
 
 func newInnerScope(outer *scope) *scope {
-	return &scope{vars: map[string]*Var{}, outer: outer}
+	return &scope{vars: map[string]*Var{}, outer: outer, returnType: outer.returnType}
+}
+
+func newInnerScopeWithReturnType(outer *scope, returnType *Type) *scope {
+	return &scope{vars: map[string]*Var{}, outer: outer, returnType: returnType}
 }
 
 func (s *scope) inLocalScope(name string) bool {

--- a/pkg/parser/type.go
+++ b/pkg/parser/type.go
@@ -53,7 +53,7 @@ var typeNameStrings = map[TypeName]typeNameString{
 	ANY:     {string: "ANY", format: "any"},
 	ARRAY:   {string: "ARRAY", format: "[]"},
 	MAP:     {string: "MAP", format: "{}"},
-	NONE:    {string: "NONE", format: ""},
+	NONE:    {string: "NONE", format: "none"},
 }
 
 func (t TypeName) String() string {
@@ -107,7 +107,7 @@ func (t *Type) Accepts(t2 *Type) bool {
 // any[] (ARRAY ANY) DOES NOT accept num[] (ARRAY NUM)
 func (t *Type) acceptsStrict(t2 *Type) bool {
 	n, n2 := t.Name, t2.Name
-	if n == ILLEGAL || n == NONE || n2 == ILLEGAL || n2 == NONE {
+	if n == ILLEGAL || n2 == ILLEGAL {
 		return false
 	}
 	if n != n2 {


### PR DESCRIPTION
Harden return statements such that there is an error when there is
unreachable code after a return statement or a return statement is of
the wrong type.