### PR TITLE
parser: Add unused var check

### DIFF
--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -81,9 +81,10 @@ type EventHandler struct {
 }
 
 type Var struct {
-	Token *lexer.Token
-	Name  string
-	T     *Type
+	Token  *lexer.Token
+	Name   string
+	T      *Type
+	isUsed bool
 }
 
 type BlockStatement struct {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -293,7 +293,7 @@ func (p *Parser) parseFuncDeclSignature() *FuncDecl {
 
 func (p *Parser) parseTypedDeclStatement(scope *scope) Node {
 	decl := p.parseTypedDecl()
-	if decl.Type().Name != ILLEGAL && p.validateVar(scope, decl.Var, decl.Token) {
+	if decl.Type().Name != ILLEGAL && p.validateVarDecl(scope, decl.Var, decl.Token) {
 		scope.set(decl.Var.Name, decl.Var)
 		p.assertEOL()
 	}
@@ -321,7 +321,7 @@ func (p *Parser) parseTypedDecl() *Declaration {
 	return decl
 }
 
-func (p *Parser) validateVar(scope *scope, v *Var, tok *lexer.Token) bool {
+func (p *Parser) validateVarDecl(scope *scope, v *Var, tok *lexer.Token) bool {
 	if scope.inLocalScope(v.Name) { // already declared in current scope
 		p.appendErrorForToken("redeclaration of '"+v.Name+"'", tok)
 		return false
@@ -359,7 +359,7 @@ func (p *Parser) parseInferredDeclStatement(scope *scope) Node {
 		return nil
 	}
 	decl.Var.T = val.Type()
-	if !p.validateVar(scope, decl.Var, decl.Token) {
+	if !p.validateVarDecl(scope, decl.Var, decl.Token) {
 		return nil
 	}
 	decl.Value = val

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -246,11 +246,12 @@ func (p *Parser) parseAssignmentStatement(scope *scope) Node {
 }
 
 func (p *Parser) parseAssignable(scope *scope) Node {
+	tok := p.cur
 	name := p.cur.Literal
 	p.advance()
 	v, ok := scope.get(name)
 	if !ok {
-		p.appendError("unknown variable name '" + name + "'")
+		p.appendErrorForToken("unknown variable name '"+name+"'", tok)
 		return nil
 	}
 	return v

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -341,11 +341,11 @@ b = true
 		`
 a:= 1
 a = b
-`: "line 3 column 6: unknown variable name 'b'",
+`: "line 3 column 5: unknown variable name 'b'",
 		`
 a:= 1
 b = a
-`: "line 3 column 3: unknown variable name 'b'",
+`: "line 3 column 1: unknown variable name 'b'",
 		`
 a:= 1
 a = num[]

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -10,14 +10,15 @@ import (
 func TestParseDeclaration(t *testing.T) {
 	tests := map[string][]string{
 		"a := 1":     {"a=1"},
-		"b:bool":     {"b=false"},
-		"\nb:bool\n": {"b=false"},
+		"a:bool":     {"a=false"},
+		"\na:bool\n": {"a=false"},
 		`a := "abc"
 		b:bool
-		c := true`: {"a='abc'", "b=false", "c=true"},
+		c := true
+		print a b c`: {"a='abc'", "b=false", "c=true", "print(a, b, c)"},
 		"a:num[]":                      {"a=[]"},
 		"a:num[]{}":                    {"a={}"},
-		"abc:any[]{}":                  {"abc={}"},
+		"a:any[]{}":                    {"a={}"},
 		"a := bool[true]":              {"a=[true]"},
 		"a := num[]":                   {"a=[]"},
 		"a := num[][num[1 2]num[3 4]]": {"a=[[1, 2], [3, 4]]"},
@@ -32,6 +33,8 @@ func TestParseDeclaration(t *testing.T) {
 		"a := num{}[num{a:1}]":                          {"a=[{a:1}]"},
 	}
 	for input, wantSlice := range tests {
+		input += "\n print a"
+		wantSlice = append(wantSlice, "print(a)")
 		want := strings.Join(wantSlice, "\n") + "\n"
 		parser := New(input, testBuiltins())
 		got := parser.Parse()
@@ -91,14 +94,14 @@ func TestParseDeclarationError(t *testing.T) {
 
 func TestFunctionCall(t *testing.T) {
 	tests := map[string][]string{
-		"print":               {"print()"},
-		"print 123":           {"print(123)"},
-		`print 123 "abc"`:     {"print(123, 'abc')"},
-		"a:=1 \n print a":     {"a=1", "print(a)"},
-		`a := len "abc"`:      {"a=len('abc')"},
-		`len "abc"`:           {"len('abc')"},
-		`len num[]`:           {"len([])"},
-		"a:string \n print a": {"a=''", "print(a)"},
+		"print":                          {"print()"},
+		"print 123":                      {"print(123)"},
+		`print 123 "abc"`:                {"print(123, 'abc')"},
+		"a:=1 \n print a":                {"a=1", "print(a)"},
+		`a := len "abc"` + " \n print a": {"a=len('abc')", "print(a)"},
+		`len "abc"`:                      {"len('abc')"},
+		`len num[]`:                      {"len([])"},
+		"a:string \n print a":            {"a=''", "print(a)"},
 		`a:=true
 		b:string
 		print a b`: {"a=true", "b=''", "print(a, b)"},
@@ -177,12 +180,14 @@ print('TRUE')
 func TestToplevelExprFuncCall(t *testing.T) {
 	input := `
 x := len "123"
+print x
 `
 	parser := New(input, testBuiltins())
 	got := parser.Parse()
 	assertNoParseError(t, parser, input)
 	want := `
 x=len('123')
+print(x)
 `[1:]
 	assert.Equal(t, want, got.String())
 }
@@ -315,14 +320,17 @@ func TestFuncAssignment(t *testing.T) {
 a := 1
 b:num
 b = a
+print b
 `, `
 a:num
 b:num
 b = a
+print b
 `, `
 a:num
 b:any
 b = a
+print b
 `,
 	}
 	for _, input := range inputs {
@@ -376,28 +384,138 @@ func TestScope(t *testing.T) {
 x := 1
 func foo
 	x := "abc"
+	print x
 end
+print x
 `, `
 x := 1
 func foo x:string
 	x = "abc"
+	print x
+end
+print x
+`, `
+x := 1
+func foo
+	x = 2
+	print x
 end
 `, `
 x := 1
 func foo x:string...
 	print x
 end
+print x
 `, `
 x := 1
 if true
 	x := "abc" // block scope
+	print x
 end
+print x
 `,
 	}
 	for _, input := range inputs {
 		parser := New(input, testBuiltins())
 		_ = parser.Parse()
 		assertNoParseError(t, parser, input)
+	}
+}
+
+func TestUnusedErr(t *testing.T) {
+	inputs := map[string]string{
+		`
+x := 1
+`: "line 2 column 1: 'x' declared but not used",
+		`
+x := 1
+if true
+	x := 1
+end
+print x
+`: "line 4 column 2: 'x' declared but not used",
+		`
+x := 1
+if true
+	x := 1
+	print x
+end
+`: "line 2 column 1: 'x' declared but not used",
+		`
+x := 1
+if true
+	print "foo"
+else
+	x := 1
+	print x
+end
+`: "line 2 column 1: 'x' declared but not used",
+		`
+x := 1
+if true
+	print "foo"
+else
+	x := 1
+end
+print x
+`: "line 6 column 2: 'x' declared but not used",
+		`
+x := 1
+if true
+	print "foo"
+else if true
+	x := 1
+end
+print x
+`: "line 6 column 2: 'x' declared but not used",
+		`
+x := 1
+for i := range 10
+	x := 2
+	print x
+end
+`: "line 2 column 1: 'x' declared but not used",
+		`
+x := 1
+for i := range 10
+	x := 2
+end
+print x
+`: "line 4 column 2: 'x' declared but not used",
+		`
+x := 1
+while true
+	x := 2
+	print x
+end
+`: "line 2 column 1: 'x' declared but not used",
+		`
+x := 1
+while true
+	x := 2
+end
+print x
+`: "line 4 column 2: 'x' declared but not used",
+		`
+x := 1
+func foo
+	x := 2
+end
+print x
+`: "line 4 column 2: 'x' declared but not used",
+		`
+x := 1
+func foo
+	x := 2
+	print x
+end
+`: "line 2 column 1: 'x' declared but not used",
+	}
+	for input, wantErr := range inputs {
+		parser := New(input, testBuiltins())
+		_ = parser.Parse()
+		assertParseError(t, parser, input)
+		assert.Equal(t, wantErr, parser.MaxErrorsString(1))
 	}
 }
 


### PR DESCRIPTION
Add unused var check reporting an error if declared variable is never
used. This feature was yet again borrowed from go and piggy backed on
the scope data structure.

Refactor `validateVar` to `validateVarDecl` as it seems the more
appropriate name.
