### PR TITLE
go: Crank up the linting settings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,40 @@
+issues:
+   exclude-use-default: false
+   exclude:
+    - "^don't use ALL_CAPS"
+    - "^ST1003: should not use ALL_CAPS"
+    - "^G304: Potential file inclusion via variable"
+
+linters:
+  enable-all: true
+  disable:
+    - cyclop
+    - exhaustive
+    - exhaustivestruct
+    - exhaustruct
+    - forbidigo
+    - forcetypeassert
+    - funlen
+    - gochecknoglobals
+    - gocyclo
+    - godox
+    - golint
+    - gomnd
+    - ifshort
+    - interfacer
+    - ireturn
+    - lll
+    - maligned
+    - nlreturn
+    - nosnakecase
+    - paralleltest
+    - revive
+    - rowserrcheck
+    - scopelint
+    - sqlclosecheck
+    - structcheck
+    - testpackage
+    - varnamelen
+    - wastedassign
+    - wrapcheck
+    - wsl

--- a/main.go
+++ b/main.go
@@ -29,9 +29,11 @@ type config struct {
 type cmdRun struct {
 	Source string `arg:"" help:"Source file. Default stdin" default:"-"`
 }
+
 type cmdTokenize struct {
 	Source string `arg:"" help:"Source file. Default stdin" default:"-"`
 }
+
 type cmdParse struct {
 	Source string `arg:"" help:"Source file. Default stdin" default:"-"`
 }

--- a/pkg/assert/assert.go
+++ b/pkg/assert/assert.go
@@ -1,3 +1,6 @@
+// Package assert is a testing utility package for online assertion that
+// also work with TinyGo which has only limited support for
+// reflection.
 package assert
 
 import (
@@ -7,18 +10,18 @@ import (
 )
 
 func NoError(t *testing.T, err error, msgAndArgs ...interface{}) {
+	t.Helper()
 	if err == nil {
 		return
 	}
-	t.Helper()
 	fatalf(t, "err: %v%s", err, format(msgAndArgs...))
 }
 
 func Equal(t *testing.T, want, got any, msgAndArgs ...interface{}) {
+	t.Helper()
 	if equal(want, got) {
 		return
 	}
-	t.Helper()
 	fatalf(t, "want != got\n%#v\n%#v%s", want, got, format(msgAndArgs...))
 }
 

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -27,12 +27,12 @@ type BuiltinFunc func(args []Value) Value
 func (b BuiltinFunc) Type() ValueType { return BUILTIN }
 func (b BuiltinFunc) String() string  { return "builtin function" }
 
-func DefaultBuiltins(print func(string)) Builtins {
+func DefaultBuiltins(printFn func(string)) Builtins {
 	return Builtins{
-		"print": {Func: printFunc(print), Decl: printDecl},
+		"print": {Func: printFunc(printFn), Decl: printDecl},
 		"len":   {Func: BuiltinFunc(lenFunc), Decl: lenDecl},
-		"move":  {Func: moveFunc(print), Decl: moveDecl},
-		"line":  {Func: lineFunc(print), Decl: lineDecl},
+		"move":  {Func: moveFunc(printFn), Decl: moveDecl},
+		"line":  {Func: lineFunc(printFn), Decl: lineDecl},
 	}
 }
 
@@ -77,8 +77,8 @@ func lenFunc(args []Value) Value {
 var moveDecl = &parser.FuncDecl{
 	Name: "move",
 	Params: []*parser.Var{
-		&parser.Var{Name: "x", T: parser.NUM_TYPE},
-		&parser.Var{Name: "y", T: parser.NUM_TYPE},
+		{Name: "x", T: parser.NUM_TYPE},
+		{Name: "y", T: parser.NUM_TYPE},
 	},
 	ReturnType: parser.NUM_TYPE,
 }
@@ -93,8 +93,8 @@ func moveFunc(printFn func(string)) BuiltinFunc {
 var lineDecl = &parser.FuncDecl{
 	Name: "line",
 	Params: []*parser.Var{
-		&parser.Var{Name: "x", T: parser.NUM_TYPE},
-		&parser.Var{Name: "y", T: parser.NUM_TYPE},
+		{Name: "x", T: parser.NUM_TYPE},
+		{Name: "y", T: parser.NUM_TYPE},
 	},
 	ReturnType: parser.NUM_TYPE,
 }

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -1,25 +1,28 @@
+// Package evaluator evaluates a given syntax tree as created by the
+// parser packages. It also exports a Run and RunWithBuiltings function
+// which creates and calls a Parser.
 package evaluator
 
 import (
 	"foxygo.at/evy/pkg/parser"
 )
 
-func Run(input string, print func(string)) {
-	RunWithBuiltins(input, print, DefaultBuiltins(print))
+func Run(input string, printFn func(string)) {
+	RunWithBuiltins(input, printFn, DefaultBuiltins(printFn))
 }
 
-func RunWithBuiltins(input string, print func(string), builtins Builtins) {
+func RunWithBuiltins(input string, printFn func(string), builtins Builtins) {
 	p := parser.New(input, builtins.Decls())
 	prog := p.Parse()
 	if p.HasErrors() {
-		print(p.MaxErrorsString(8))
+		printFn(p.MaxErrorsString(8))
 		return
 	}
-	e := &Evaluator{print: print}
+	e := &Evaluator{print: printFn}
 	e.builtins = builtins
 	val := e.Eval(newScope(), prog)
 	if isError(val) {
-		print(val.String())
+		printFn(val.String())
 	}
 }
 

--- a/pkg/evaluator/scope.go
+++ b/pkg/evaluator/scope.go
@@ -33,7 +33,6 @@ func (s *scope) getScope(name string) (*scope, bool) {
 	return s.outer.getScope(name)
 }
 
-func (s *scope) set(name string, val Value) Value {
+func (s *scope) set(name string, val Value) {
 	s.values[name] = val
-	return val
 }

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -99,9 +99,11 @@ func (e *Error) String() string  { return "ERROR: " + e.Message }
 func isError(val Value) bool { // TODO: replace with panic flow
 	return val != nil && val.Type() == ERROR
 }
+
 func isReturn(val Value) bool {
 	return val != nil && val.Type() == RETURN_VALUE
 }
+
 func newError(msg string) *Error {
 	return &Error{Message: msg}
 }

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -1,3 +1,7 @@
+// Package lexer tokenizes input and lets follow up phases in compiler,
+// such as parser, iterate over tokens via Lexer.Next() function. The
+// lexer package also exposes a Run method for debugging the lexing
+// phase only.
 package lexer
 
 import (

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -11,13 +11,45 @@ func TestSingleToken(t *testing.T) {
 		in   string
 		want TokenType
 	}{
-		{in: ":=", want: DECLARE}, {in: "=", want: ASSIGN}, {in: "+", want: PLUS}, {in: "-", want: MINUS}, {in: "!", want: BANG}, {in: "*", want: ASTERISK}, {in: "/", want: SLASH},
-		{in: "==", want: EQ}, {in: "!=", want: NOT_EQ}, {in: "<", want: LT}, {in: ">", want: GT}, {in: "<=", want: LTEQ}, {in: ">=", want: GTEQ},
-		{in: "(", want: LPAREN}, {in: ")", want: RPAREN}, {in: "[", want: LBRACKET}, {in: "]", want: RBRACKET}, {in: "{", want: LCURLY}, {in: "}", want: RCURLY},
-		{in: ":", want: COLON}, {in: ".", want: DOT}, {in: "...", want: DOT3},
-		{in: "num", want: NUM}, {in: "string", want: STRING}, {in: "bool", want: BOOL}, {in: "any", want: ANY},
-		{in: "true", want: TRUE}, {in: "false", want: FALSE}, {in: "and", want: AND}, {in: "or", want: OR},
-		{in: "if", want: IF}, {in: "else", want: ELSE}, {in: "func", want: FUNC}, {in: "return", want: RETURN}, {in: "for", want: FOR}, {in: "range", want: RANGE}, {in: "while", want: WHILE}, {in: "break", want: BREAK}, {in: "end", want: END},
+		{in: ":=", want: DECLARE},
+		{in: "=", want: ASSIGN},
+		{in: "+", want: PLUS},
+		{in: "-", want: MINUS},
+		{in: "!", want: BANG},
+		{in: "*", want: ASTERISK},
+		{in: "/", want: SLASH},
+		{in: "==", want: EQ},
+		{in: "!=", want: NOT_EQ},
+		{in: "<", want: LT},
+		{in: ">", want: GT},
+		{in: "<=", want: LTEQ},
+		{in: ">=", want: GTEQ},
+		{in: "(", want: LPAREN},
+		{in: ")", want: RPAREN},
+		{in: "[", want: LBRACKET},
+		{in: "]", want: RBRACKET},
+		{in: "{", want: LCURLY},
+		{in: "}", want: RCURLY},
+		{in: ":", want: COLON},
+		{in: ".", want: DOT},
+		{in: "...", want: DOT3},
+		{in: "num", want: NUM},
+		{in: "string", want: STRING},
+		{in: "bool", want: BOOL},
+		{in: "any", want: ANY},
+		{in: "true", want: TRUE},
+		{in: "false", want: FALSE},
+		{in: "and", want: AND},
+		{in: "or", want: OR},
+		{in: "if", want: IF},
+		{in: "else", want: ELSE},
+		{in: "func", want: FUNC},
+		{in: "return", want: RETURN},
+		{in: "for", want: FOR},
+		{in: "range", want: RANGE},
+		{in: "while", want: WHILE},
+		{in: "break", want: BREAK},
+		{in: "end", want: END},
 	}
 
 	for _, tt := range tests {
@@ -101,7 +133,7 @@ func TestNums(t *testing.T) {
 y := 1
 y = y * ( 3 + 7)
 `
-	wantTokens := []Token{
+	wantTokens := []*Token{
 		{Type: NL, Literal: "", Offset: 0, Line: 1, Col: 1},
 		{Type: IDENT, Literal: "y", Offset: 1, Line: 2, Col: 1},
 		{Type: DECLARE, Literal: "", Offset: 3, Line: 2, Col: 3},
@@ -122,7 +154,7 @@ y = y * ( 3 + 7)
 	l := New(in)
 	for _, want := range wantTokens {
 		got := l.Next()
-		assert.Equal(t, &want, got)
+		assert.Equal(t, want, got)
 	}
 }
 
@@ -131,7 +163,7 @@ func TestStrings(t *testing.T) {
 s:string
 s = "abc"
 s = s[:1] // "bc"`
-	wantTokens := []Token{
+	wantTokens := []*Token{
 		{Type: NL, Literal: "", Offset: 0, Line: 1, Col: 1},
 		{Type: IDENT, Literal: "s", Offset: 1, Line: 2, Col: 1},
 		{Type: COLON, Literal: "", Offset: 2, Line: 2, Col: 2},
@@ -156,7 +188,7 @@ s = s[:1] // "bc"`
 	l := New(in)
 	for _, want := range wantTokens {
 		got := l.Next()
-		assert.Equal(t, &want, got)
+		assert.Equal(t, want, got)
 	}
 }
 
@@ -167,7 +199,7 @@ for key := range m
     print key m[key] // Mali climbing
 end
 `
-	wantTokens := []Token{
+	wantTokens := []*Token{
 		{Type: NL, Literal: "", Offset: 0, Line: 1, Col: 1},
 		{Type: IDENT, Literal: "m", Offset: 1, Line: 2, Col: 1},
 		{Type: DECLARE, Literal: "", Offset: 3, Line: 2, Col: 3},
@@ -206,7 +238,7 @@ end
 	l := New(in)
 	for _, want := range wantTokens {
 		got := l.Next()
-		assert.Equal(t, &want, got)
+		assert.Equal(t, want, got)
 	}
 }
 

--- a/pkg/lexer/token.go
+++ b/pkg/lexer/token.go
@@ -20,12 +20,12 @@ const (
 	EOF
 	COMMENT // `// a comment`
 
-	// Identifiers and Literals
+	// Identifiers and Literals.
 	IDENT      // some_identifier
 	NUM_LIT    // 123 456.78
 	STRING_LIT // "a string 🧵"
 
-	// Operators
+	// Operators.
 	DECLARE  // :=
 	ASSIGN   // =
 	PLUS     // +
@@ -41,7 +41,7 @@ const (
 	LTEQ   // <=
 	GTEQ   // >=
 
-	// Delimiters
+	// Delimiters.
 	LPAREN   // (
 	RPAREN   // )
 	LBRACKET // [
@@ -54,7 +54,7 @@ const (
 	DOT   // .
 	DOT3  // ...
 
-	// Keywords
+	// Keywords.
 	NUM    // num
 	STRING // string
 	BOOL   // bool

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -123,9 +123,11 @@ type MapLiteral struct {
 func (p *Program) String() string {
 	return newlineList(p.Statements)
 }
+
 func (*Program) Type() *Type {
 	return NONE_TYPE
 }
+
 func (p *Program) AlwaysReturns() bool {
 	return p.alwaysReturns
 }
@@ -138,6 +140,7 @@ func (f *FunctionCall) String() string {
 	args := strings.Join(s, ", ")
 	return f.Name + "(" + args + ")"
 }
+
 func (f *FunctionCall) Type() *Type {
 	return f.T
 }
@@ -145,6 +148,7 @@ func (f *FunctionCall) Type() *Type {
 func (t *Term) String() string {
 	return t.Value.String()
 }
+
 func (t *Term) Type() *Type {
 	return t.T
 }
@@ -155,6 +159,7 @@ func (d *Declaration) String() string {
 	}
 	return d.Var.String() + "=" + d.Value.String()
 }
+
 func (d *Declaration) Type() *Type {
 	return d.Var.T
 }
@@ -165,9 +170,11 @@ func (r *Return) String() string {
 	}
 	return "return " + r.Value.String()
 }
+
 func (r *Return) Type() *Type {
 	return r.T
 }
+
 func (*Return) AlwaysReturns() bool {
 	return true
 }
@@ -175,6 +182,7 @@ func (*Return) AlwaysReturns() bool {
 func (a *Assignment) String() string {
 	return a.Target.String() + " = " + a.Value.String()
 }
+
 func (a *Assignment) Type() *Type {
 	return a.Target.Type()
 }
@@ -195,6 +203,7 @@ func (f *FuncDecl) String() string {
 	}
 	return signature + "{\n" + body + "}\n"
 }
+
 func (f *FuncDecl) Type() *Type {
 	return f.ReturnType
 }
@@ -213,6 +222,7 @@ func (i *If) String() string {
 func (i *If) Type() *Type {
 	return NONE_TYPE
 }
+
 func (i *If) AlwaysReturns() bool {
 	if i.Else == nil || !i.Else.AlwaysReturns() {
 		return false
@@ -232,6 +242,7 @@ func (e *EventHandler) String() string {
 	body := e.Body.String()
 	return "on " + e.Name + " {\n" + body + "}\n"
 }
+
 func (e *EventHandler) Type() *Type {
 	return NONE_TYPE
 }
@@ -239,6 +250,7 @@ func (e *EventHandler) Type() *Type {
 func (v *Var) String() string {
 	return v.Name
 }
+
 func (v *Var) Type() *Type {
 	return v.T
 }
@@ -246,9 +258,11 @@ func (v *Var) Type() *Type {
 func (b *BlockStatement) String() string {
 	return newlineList(b.Statements)
 }
+
 func (b *BlockStatement) Type() *Type {
 	return NONE_TYPE
 }
+
 func (b *BlockStatement) AlwaysReturns() bool {
 	return b.alwaysReturns
 }
@@ -270,9 +284,11 @@ func (c *ConditionalBlock) String() string {
 	condition := "(" + c.Condition.String() + ")"
 	return condition + " {\n" + c.Block.String() + "}"
 }
+
 func (c *ConditionalBlock) Type() *Type {
 	return NONE_TYPE
 }
+
 func (c *ConditionalBlock) AlwaysReturns() bool {
 	return c.Block.AlwaysReturns()
 }
@@ -280,6 +296,7 @@ func (c *ConditionalBlock) AlwaysReturns() bool {
 func (b *Bool) String() string {
 	return strconv.FormatBool(b.Value)
 }
+
 func (b *Bool) Type() *Type {
 	return BOOL_TYPE
 }
@@ -287,6 +304,7 @@ func (b *Bool) Type() *Type {
 func (n *NumLiteral) String() string {
 	return strconv.FormatFloat(n.Value, 'f', -1, 64)
 }
+
 func (n *NumLiteral) Type() *Type {
 	return NUM_TYPE
 }
@@ -294,6 +312,7 @@ func (n *NumLiteral) Type() *Type {
 func (s *StringLiteral) String() string {
 	return "'" + s.Value + "'"
 }
+
 func (s *StringLiteral) Type() *Type {
 	return STRING_TYPE
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1,3 +1,9 @@
+// Package parser creates an abstract syntax tree (ast) from input
+// string in parser.Run() function. The parser is also responsible for
+// type analysis, unreachable code analysis, unused variable analysis
+// and other semantic checks. The generated ast is syntactically and
+// semantically correct and may not contain any further compile time
+// errors, only potential run time errors.
 package parser
 
 import (
@@ -83,7 +89,7 @@ func (p *Parser) Parse() *Program {
 }
 
 // function names matching `parsePROCUTION` align with production names
-// in grammar doc/syntax_grammar.md
+// in grammar doc/syntax_grammar.md.
 func (p *Parser) parseProgram(scope *scope) *Program {
 	program := &Program{}
 	p.advanceTo(0)
@@ -296,7 +302,7 @@ func (p *Parser) parseTypedDeclStatement(scope *scope) Node {
 }
 
 // parseTypedDecl parses declarations like
-// `x:num` or `y:any[]{}`
+// `x:num` or `y:any[]{}`.
 func (p *Parser) parseTypedDecl() *Declaration {
 	p.assertToken(lexer.IDENT)
 	varName := p.cur.Literal
@@ -375,7 +381,7 @@ func (p *Parser) parseExpression(scope *scope) Node {
 }
 
 func (p *Parser) parseTerm(scope *scope) Node {
-	//TODO: UNARY_OP Term; composite literals; assignable; slice; type_assertion; "(" toplevel_expr ")"
+	// TODO: UNARY_OP Term; composite literals; assignable; slice; type_assertion; "(" toplevel_expr ")"
 	tt := p.cur.TokenType()
 	if tt == lexer.IDENT {
 		if p.isFuncCall(p.cur) {
@@ -395,7 +401,6 @@ func (p *Parser) parseTerm(scope *scope) Node {
 	p.appendError("unexpected " + tt.FormatDetails())
 	p.advance()
 	return nil
-
 }
 
 func (p *Parser) isFuncCall(tok *lexer.Token) bool {
@@ -494,19 +499,14 @@ func (p *Parser) assertToken(tt lexer.TokenType) bool {
 	return true
 }
 
-func (p *Parser) assertEOL() bool {
+func (p *Parser) assertEOL() {
 	if !p.isAtEOL() {
 		p.appendError("expected end of line, found " + p.cur.FormatDetails())
-		return false
 	}
-	return true
 }
 
-func (p *Parser) assertEnd() bool {
-	if !p.assertToken(lexer.END) {
-		return false
-	}
-	return isEOL(p.peek.TokenType())
+func (p *Parser) assertEnd() {
+	p.assertToken(lexer.END)
 }
 
 func (p *Parser) appendError(message string) {
@@ -615,13 +615,13 @@ func (p *Parser) parseReturnStatement(scope *scope) Node {
 	return ret
 }
 
-//TODO: implemented
+// TODO: implemented.
 func (p *Parser) parseBreakStatement() Node {
 	p.advancePastNL()
 	return nil
 }
 
-//TODO: implemented
+// TODO: implemented.
 func (p *Parser) parseForStatement(scope *scope) Node {
 	scope = newInnerScope(scope)
 	p.advancePastNL()

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -9,27 +9,27 @@ import (
 
 func TestParseDeclaration(t *testing.T) {
 	tests := map[string][]string{
-		"a := 1":     []string{"a=1"},
-		"b:bool":     []string{"b=false"},
-		"\nb:bool\n": []string{"b=false"},
+		"a := 1":     {"a=1"},
+		"b:bool":     {"b=false"},
+		"\nb:bool\n": {"b=false"},
 		`a := "abc"
 		b:bool
-		c := true`: []string{"a='abc'", "b=false", "c=true"},
-		"a:num[]":                      []string{"a=[]"},
-		"a:num[]{}":                    []string{"a={}"},
-		"abc:any[]{}":                  []string{"abc={}"},
-		"a := bool[true]":              []string{"a=[true]"},
-		"a := num[]":                   []string{"a=[]"},
-		"a := num[][num[1 2]num[3 4]]": []string{"a=[[1, 2], [3, 4]]"},
-		"a := num{a:1 b:2}":            []string{"a={a:1, b:2}"},
-		"a := num[]{digits: num[1 2 3] nums: num[4 5]}": []string{"a={digits:[1, 2, 3], nums:[4, 5]}"},
-		"a := num[]{digits: num[] nums: num[4]}":        []string{"a={digits:[], nums:[4]}"},
-		"a := num[]{digits: num[4] nums: num[]}":        []string{"a={digits:[4], nums:[]}"},
-		"a := num{}[]":                                  []string{"a=[]"},
-		"a := num{}[num{}]":                             []string{"a=[{}]"},
-		"a := any{a:1 b:true}":                          []string{"a={a:1, b:true}"},
-		"a := any{a:1 b:true c:num[1]}":                 []string{"a={a:1, b:true, c:[1]}"},
-		"a := num{}[num{a:1}]":                          []string{"a=[{a:1}]"},
+		c := true`: {"a='abc'", "b=false", "c=true"},
+		"a:num[]":                      {"a=[]"},
+		"a:num[]{}":                    {"a={}"},
+		"abc:any[]{}":                  {"abc={}"},
+		"a := bool[true]":              {"a=[true]"},
+		"a := num[]":                   {"a=[]"},
+		"a := num[][num[1 2]num[3 4]]": {"a=[[1, 2], [3, 4]]"},
+		"a := num{a:1 b:2}":            {"a={a:1, b:2}"},
+		"a := num[]{digits: num[1 2 3] nums: num[4 5]}": {"a={digits:[1, 2, 3], nums:[4, 5]}"},
+		"a := num[]{digits: num[] nums: num[4]}":        {"a={digits:[], nums:[4]}"},
+		"a := num[]{digits: num[4] nums: num[]}":        {"a={digits:[4], nums:[]}"},
+		"a := num{}[]":                                  {"a=[]"},
+		"a := num{}[num{}]":                             {"a=[{}]"},
+		"a := any{a:1 b:true}":                          {"a={a:1, b:true}"},
+		"a := any{a:1 b:true c:num[1]}":                 {"a={a:1, b:true, c:[1]}"},
+		"a := num{}[num{a:1}]":                          {"a=[{a:1}]"},
 	}
 	for input, wantSlice := range tests {
 		want := strings.Join(wantSlice, "\n") + "\n"
@@ -91,17 +91,17 @@ func TestParseDeclarationError(t *testing.T) {
 
 func TestFunctionCall(t *testing.T) {
 	tests := map[string][]string{
-		"print":               []string{"print()"},
-		"print 123":           []string{"print(123)"},
-		`print 123 "abc"`:     []string{"print(123, 'abc')"},
-		"a:=1 \n print a":     []string{"a=1", "print(a)"},
-		`a := len "abc"`:      []string{"a=len('abc')"},
-		`len "abc"`:           []string{"len('abc')"},
-		`len num[]`:           []string{"len([])"},
-		"a:string \n print a": []string{"a=''", "print(a)"},
+		"print":               {"print()"},
+		"print 123":           {"print(123)"},
+		`print 123 "abc"`:     {"print(123, 'abc')"},
+		"a:=1 \n print a":     {"a=1", "print(a)"},
+		`a := len "abc"`:      {"a=len('abc')"},
+		`len "abc"`:           {"len('abc')"},
+		`len num[]`:           {"len([])"},
+		"a:string \n print a": {"a=''", "print(a)"},
 		`a:=true
 		b:string
-		print a b`: []string{"a=true", "b=''", "print(a, b)"},
+		print a b`: {"a=true", "b=''", "print(a, b)"},
 	}
 	for input, wantSlice := range tests {
 		want := strings.Join(wantSlice, "\n") + "\n"
@@ -236,7 +236,8 @@ return "success"
 }
 
 func TestReturnErr(t *testing.T) {
-	inputs := map[string]string{`
+	inputs := map[string]string{
+		`
 func add:num
 	return 1
 	print "boom"
@@ -309,7 +310,8 @@ end
 }
 
 func TestFuncAssignment(t *testing.T) {
-	inputs := []string{`
+	inputs := []string{
+		`
 a := 1
 b:num
 b = a
@@ -331,7 +333,8 @@ b = a
 }
 
 func TestFuncAssignmentErr(t *testing.T) {
-	inputs := map[string]string{`
+	inputs := map[string]string{
+		`
 b:num
 b = true
 `: "line 3 column 3: 'b' accepts values of type num, found bool",
@@ -368,7 +371,8 @@ fn = 3
 }
 
 func TestScope(t *testing.T) {
-	inputs := []string{`
+	inputs := []string{
+		`
 x := 1
 func foo
 	x := "abc"
@@ -656,12 +660,12 @@ func assertNoParseError(t *testing.T, parser *Parser, input string) {
 
 func testBuiltins() map[string]*FuncDecl {
 	return map[string]*FuncDecl{
-		"print": &FuncDecl{
+		"print": {
 			Name:          "print",
 			VariadicParam: &Var{Name: "a", T: ANY_TYPE},
 			ReturnType:    NONE_TYPE,
 		},
-		"len": &FuncDecl{
+		"len": {
 			Name:       "len",
 			Params:     []*Var{{Name: "a", T: ANY_TYPE}},
 			ReturnType: NUM_TYPE,

--- a/pkg/parser/scope.go
+++ b/pkg/parser/scope.go
@@ -34,7 +34,6 @@ func (s *scope) get(name string) (*Var, bool) {
 	return s.outer.get(name)
 }
 
-func (s *scope) set(name string, v *Var) *Var {
+func (s *scope) set(name string, v *Var) {
 	s.vars[name] = v
-	return v
 }

--- a/pkg/parser/type.go
+++ b/pkg/parser/type.go
@@ -104,7 +104,7 @@ func (t *Type) Accepts(t2 *Type) bool {
 	return false
 }
 
-// any[] (ARRAY ANY) DOES NOT accept num[] (ARRAY NUM)
+// any[] (ARRAY ANY) DOES NOT accept num[] (ARRAY NUM).
 func (t *Type) acceptsStrict(t2 *Type) bool {
 	n, n2 := t.Name, t2.Name
 	if n == ILLEGAL || n2 == ILLEGAL {

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -1,4 +1,5 @@
 //go:build tinygo
+
 package main
 
 import (
@@ -10,9 +11,7 @@ import (
 	"foxygo.at/evy/pkg/parser"
 )
 
-var (
-	version string
-)
+var version string
 
 func main() {
 }
@@ -26,6 +25,7 @@ func jsPrint(string)
 // See:
 // * https://www.wasm.builders/k33g_org/an-essay-on-the-bi-directional-exchange-of-strings-between-the-wasm-module-with-tinygo-and-nodejs-with-wasi-support-3i9h
 // * https://www.alcarney.me/blog/2020/passing-strings-between-tinygo-wasm/
+//
 //export evaluate
 func jsEvaluate(ptr *uint32, length int) {
 	s := getString(ptr, length)
@@ -46,6 +46,7 @@ func jsParse(ptr *uint32, length int) {
 }
 
 // alloc pre-allocates memory used in string parameter passing.
+//
 //export alloc
 func alloc(size uint32) *byte {
 	buf := make([]byte, size)


### PR DESCRIPTION
Crank up the linting settings so that linter runs in stricter mode and
catches more errors, before the codebase gets too big. Disable quite a few
annoying linters.