### PR TITLE
go: Implement break statement

### DIFF
--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -139,7 +139,7 @@ func innerScopeWithArgs(scope *scope, fd *parser.FuncDecl, args []Value) *scope 
 
 func (e *Evaluator) evalReturn(scope *scope, ret *parser.Return) Value {
 	if ret.Value == nil {
-		return nil
+		return &ReturnValue{}
 	}
 	val := e.Eval(scope, ret.Value)
 	if isError(val) {

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -53,6 +53,8 @@ func (e *Evaluator) Eval(scope *scope, node parser.Node) Value {
 		return e.evalFunctionCall(scope, node)
 	case *parser.Return:
 		return e.evalReturn(scope, node)
+	case *parser.Break:
+		return e.evalBreak(scope, node)
 	case *parser.If:
 		return e.evalIf(scope, node)
 	case *parser.While:
@@ -71,7 +73,7 @@ func (e *Evaluator) evalStatments(scope *scope, statements []parser.Node) Value 
 	var result Value
 	for _, statement := range statements {
 		result = e.Eval(scope, statement)
-		if isError(result) || isReturn(result) {
+		if isError(result) || isReturn(result) || isBreak(result) {
 			return result
 		}
 	}
@@ -148,6 +150,10 @@ func (e *Evaluator) evalReturn(scope *scope, ret *parser.Return) Value {
 	return &ReturnValue{Val: val}
 }
 
+func (e *Evaluator) evalBreak(scope *scope, ret *parser.Break) Value {
+	return &Break{}
+}
+
 func (e *Evaluator) evalIf(scope *scope, i *parser.If) Value {
 	val, ok := e.evalConditionalBlock(scope, i.IfBlock)
 	if ok || isError(val) {
@@ -168,7 +174,7 @@ func (e *Evaluator) evalIf(scope *scope, i *parser.If) Value {
 func (e *Evaluator) evalWhile(scope *scope, w *parser.While) Value {
 	whileBlock := &w.ConditionalBlock
 	val, ok := e.evalConditionalBlock(scope, whileBlock)
-	for ok && !isError(val) && !isReturn(val) {
+	for ok && !isError(val) && !isReturn(val) && !isBreak(val) {
 		val, ok = e.evalConditionalBlock(scope, whileBlock)
 	}
 	return val

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -87,6 +87,51 @@ print f2
 	assert.Equal(t, want, b.String())
 }
 
+func TestBreak(t *testing.T) {
+	tests := []string{
+		`
+while true
+    print "🎈"
+    break
+end
+`, `
+while true
+    print "🎈"
+    if true
+        break
+    end
+    print "💣"
+end
+`, `
+stop := false
+while true
+    if stop
+        print "🎈"
+        break
+    end
+    stop = true
+end
+`, `
+continue := true
+while true
+    if continue
+        print "🎈"
+    else
+        break
+    end
+    continue = false
+end
+`,
+	}
+	for _, input := range tests {
+		b := bytes.Buffer{}
+		fn := func(s string) { b.WriteString(s) }
+		Run(input, fn)
+		want := "🎈\n"
+		assert.Equal(t, want, b.String(), input)
+	}
+}
+
 func TestAssignment(t *testing.T) {
 	prog := `
 f1:num

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -41,14 +41,23 @@ func fox:string
     return "🦊"
 end
 
+func fox2
+    if true
+        print "🦊2"
+        return
+    end
+    print "💣"
+end
+
 f := fox
 print f
 print f f
+fox2
 `
 	b := bytes.Buffer{}
 	fn := func(s string) { b.WriteString(s) }
 	Run(prog, fn)
-	want := "🦊\n🦊 🦊\n"
+	want := "🦊\n🦊 🦊\n🦊2\n"
 	assert.Equal(t, want, b.String())
 }
 

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -20,6 +20,7 @@ const (
 	ARRAY
 	MAP
 	RETURN_VALUE
+	BREAK
 	FUNCTION
 	BUILTIN
 )
@@ -76,6 +77,8 @@ type ReturnValue struct {
 	Val Value
 }
 
+type Break struct{}
+
 type Error struct {
 	Message string
 }
@@ -94,6 +97,9 @@ func (s *Bool) String() string {
 func (r *ReturnValue) Type() ValueType { return RETURN_VALUE }
 func (r *ReturnValue) String() string  { return r.Val.String() }
 
+func (r *Break) Type() ValueType { return BREAK }
+func (r *Break) String() string  { return "" }
+
 func (e *Error) Type() ValueType { return ERROR }
 func (e *Error) String() string  { return "ERROR: " + e.Message }
 func isError(val Value) bool { // TODO: replace with panic flow
@@ -102,6 +108,10 @@ func isError(val Value) bool { // TODO: replace with panic flow
 
 func isReturn(val Value) bool {
 	return val != nil && val.Type() == RETURN_VALUE
+}
+
+func isBreak(val Value) bool {
+	return val != nil && val.Type() == BREAK
 }
 
 func newError(msg string) *Error {

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -281,6 +281,10 @@ func (w *While) Type() *Type {
 	return w.ConditionalBlock.Type()
 }
 
+func (*While) AlwaysReturns() bool {
+	return false
+}
+
 func (c *ConditionalBlock) String() string {
 	condition := "(" + c.Condition.String() + ")"
 	return condition + " {\n" + c.Block.String() + "}"

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -13,8 +13,8 @@ type Node interface {
 }
 
 type Program struct {
-	Statements    []Node
-	alwaysReturns bool
+	Statements       []Node
+	alwaysTerminates bool
 }
 
 type FunctionCall struct {
@@ -88,9 +88,9 @@ type Var struct {
 }
 
 type BlockStatement struct {
-	Token         *lexer.Token // the NL before the first statement
-	Statements    []Node
-	alwaysReturns bool
+	Token            *lexer.Token // the NL before the first statement
+	Statements       []Node
+	alwaysTerminates bool
 }
 
 type Bool struct {
@@ -129,8 +129,8 @@ func (*Program) Type() *Type {
 	return NONE_TYPE
 }
 
-func (p *Program) AlwaysReturns() bool {
-	return p.alwaysReturns
+func (p *Program) AlwaysTerminates() bool {
+	return p.alwaysTerminates
 }
 
 func (f *FunctionCall) String() string {
@@ -176,7 +176,7 @@ func (r *Return) Type() *Type {
 	return r.T
 }
 
-func (*Return) AlwaysReturns() bool {
+func (*Return) AlwaysTerminates() bool {
 	return true
 }
 
@@ -224,15 +224,15 @@ func (i *If) Type() *Type {
 	return NONE_TYPE
 }
 
-func (i *If) AlwaysReturns() bool {
-	if i.Else == nil || !i.Else.AlwaysReturns() {
+func (i *If) AlwaysTerminates() bool {
+	if i.Else == nil || !i.Else.AlwaysTerminates() {
 		return false
 	}
-	if !i.IfBlock.AlwaysReturns() {
+	if !i.IfBlock.AlwaysTerminates() {
 		return false
 	}
 	for _, b := range i.ElseIfBlocks {
-		if !b.AlwaysReturns() {
+		if !b.AlwaysTerminates() {
 			return false
 		}
 	}
@@ -264,13 +264,13 @@ func (b *BlockStatement) Type() *Type {
 	return NONE_TYPE
 }
 
-func (b *BlockStatement) AlwaysReturns() bool {
-	return b.alwaysReturns
+func (b *BlockStatement) AlwaysTerminates() bool {
+	return b.alwaysTerminates
 }
 
-func alwaysReturns(n Node) bool {
-	r, ok := n.(interface{ AlwaysReturns() bool })
-	return ok && r.AlwaysReturns()
+func alwaysTerminates(n Node) bool {
+	r, ok := n.(interface{ AlwaysTerminates() bool })
+	return ok && r.AlwaysTerminates()
 }
 
 func (w *While) String() string {
@@ -281,7 +281,7 @@ func (w *While) Type() *Type {
 	return w.ConditionalBlock.Type()
 }
 
-func (*While) AlwaysReturns() bool {
+func (*While) AlwaysTerminates() bool {
 	return false
 }
 
@@ -294,8 +294,8 @@ func (c *ConditionalBlock) Type() *Type {
 	return NONE_TYPE
 }
 
-func (c *ConditionalBlock) AlwaysReturns() bool {
-	return c.Block.AlwaysReturns()
+func (c *ConditionalBlock) AlwaysTerminates() bool {
+	return c.Block.AlwaysTerminates()
 }
 
 func (b *Bool) String() string {

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -49,6 +49,10 @@ type Return struct {
 	T     *Type
 }
 
+type Break struct {
+	Token *lexer.Token
+}
+
 type FuncDecl struct {
 	Token         *lexer.Token // The 'func' token
 	Name          string
@@ -177,6 +181,18 @@ func (r *Return) Type() *Type {
 }
 
 func (*Return) AlwaysTerminates() bool {
+	return true
+}
+
+func (*Break) String() string {
+	return "break"
+}
+
+func (*Break) Type() *Type {
+	return NONE_TYPE
+}
+
+func (b *Break) AlwaysTerminates() bool {
 	return true
 }
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -104,12 +104,12 @@ func (p *Parser) parseProgram() *Program {
 		default:
 			tok := p.cur
 			stmt = p.parseStatement(scope)
-			if stmt != nil && program.AlwaysReturns() {
+			if stmt != nil && program.AlwaysTerminates() {
 				p.appendErrorForToken("unreachable code", tok)
 				stmt = nil
 			}
-			if alwaysReturns(stmt) {
-				program.alwaysReturns = true
+			if alwaysTerminates(stmt) {
+				program.alwaysTerminates = true
 			}
 		}
 		if stmt != nil {
@@ -138,7 +138,7 @@ func (p *Parser) parseFunc(scope *scope) Node {
 		p.appendError("redeclaration of function '" + funcName + "'")
 		return nil
 	}
-	if fd.ReturnType != NONE_TYPE && !block.AlwaysReturns() {
+	if fd.ReturnType != NONE_TYPE && !block.AlwaysTerminates() {
 		p.appendError("missing return")
 	}
 	p.assertEnd()
@@ -550,12 +550,12 @@ func (p *Parser) parseBlockWithEndTokens(scope *scope, endTokens map[lexer.Token
 		if stmt == nil {
 			continue
 		}
-		if block.AlwaysReturns() {
+		if block.AlwaysTerminates() {
 			p.appendErrorForToken("unreachable code", tok)
 			continue
 		}
-		if alwaysReturns(stmt) {
-			block.alwaysReturns = true
+		if alwaysTerminates(stmt) {
+			block.alwaysTerminates = true
 		}
 		block.Statements = append(block.Statements, stmt)
 	}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -220,12 +220,20 @@ func nums3
 	end
 end
 return "success"
+func nums4:num
+	a := 5
+	while true
+		return 1
+	end
+	print a "reachable"
+	return 0
+end
 `
 	parser := New(input, testBuiltins())
 	_ = parser.Parse()
 	assertNoParseError(t, parser, input)
 	builtinCnt := len(testBuiltins())
-	assert.Equal(t, builtinCnt+3, len(parser.funcs))
+	assert.Equal(t, builtinCnt+4, len(parser.funcs))
 	got := parser.funcs["nums1"]
 	assert.Equal(t, "nums1", got.Name)
 	assert.Equal(t, NUM_TYPE, got.ReturnType)
@@ -273,14 +281,15 @@ func nums:num
 end
 `: "line 12 column 2: unreachable code",
 		`
-func nums:num
-	a := 5
-	while true
+while true
+	if true
 		return 1
+	else
+		return 2
 	end
-	print "boom"
+	print "deadcode"
 end
-`: "line 7 column 2: unreachable code",
+`: "line 8 column 2: unreachable code",
 		`
 foo
 return false

--- a/pkg/parser/scope.go
+++ b/pkg/parser/scope.go
@@ -1,22 +1,26 @@
 package parser
 
 type scope struct {
-	vars  map[string]*Var
-	outer *scope
-
-	returnType *Type
+	vars       map[string]*Var
+	outer      *scope
+	block      Node
+	returnType *Type // TODO: maybe get rid of returnType and look up the scope chain for Func nodes and their return type
 }
 
-func newScope() *scope {
-	return &scope{vars: map[string]*Var{}, returnType: ANY_TYPE}
+func newScope(outer *scope, node Node) *scope {
+	if outer == nil {
+		return newScopeWithReturnType(nil, node, ANY_TYPE)
+	}
+	return newScopeWithReturnType(outer, node, outer.returnType)
 }
 
-func newInnerScope(outer *scope) *scope {
-	return &scope{vars: map[string]*Var{}, outer: outer, returnType: outer.returnType}
-}
-
-func newInnerScopeWithReturnType(outer *scope, returnType *Type) *scope {
-	return &scope{vars: map[string]*Var{}, outer: outer, returnType: returnType}
+func newScopeWithReturnType(outer *scope, node Node, returnType *Type) *scope {
+	return &scope{
+		vars:       map[string]*Var{},
+		block:      node,
+		outer:      outer,
+		returnType: returnType,
+	}
 }
 
 func (s *scope) inLocalScope(name string) bool {


### PR DESCRIPTION
Implement break statement in parser and evaluator ensuring it is only
used inside a loop. Use scope to keep track of enclosing AST node and
ensure that break's scope is within a loop (while) node's scope.
Implement unreachable code with block.AlwaysTerminates method on block.

Fix bare returns in evaluator as they accidentally got ignored and
didn't stop execution. This became apparent when thinking about breaks
in evaluator.

Also, fix AlwaysReturns method on While blocks. Loops may at times never
have their body executed so can _never_ always return.