### PR TITLE
docs: Update docs for whitespace and inverted types

### DIFF
--- a/docs/syntax_by_example.md
+++ b/docs/syntax_by_example.md
@@ -1,10 +1,9 @@
 # Evy Syntax by Example
 
-The following examples on various aspects of `evy`'s syntax give an
-intuitive understanding of the language. For a formal language
-specification see the [syntax grammar].
+The following examples give an intuitive understanding of various
+aspects of `evy`'s syntax. For a formal language specification see the
+[syntax grammar](syntax_grammar.md).
 
-[syntax grammar]: syntax_grammar.md
 
 ## Comment
 
@@ -12,7 +11,7 @@ specification see the [syntax grammar].
 
 ## Declaration
 
-    x:num     // declaration: num, string, bool, any, [] {}
+    x:num     // declaration: num, string, bool, any, []num, {}string
     y := 1    // declaration through type inference (num)
 
 ## Assignment
@@ -55,8 +54,6 @@ specification see the [syntax grammar].
 
 ## Loop statements
 
-
-
 ### `while` loop
 
     x := 0
@@ -80,18 +77,18 @@ specification see the [syntax grammar].
     end
 
     for x := range -10 
-        print x        // nothing. step always 1 by default.
+        print x        // nothing. step is 1 by default.
     end
 
 ### `for` … `range` array
 
-    for x := range num[ 1 2 3 ]
+    for x := range [1 2 3]
         print x        // 1 2 3
     end
 
 ### `for` … `range` map
 
-    m := string{ name:"Mali" sport:"climbing" }
+    m := { name:"Mali" sport:"climbing" }
     for key := range m
         print key m[key]
     end
@@ -133,53 +130,63 @@ specification see the [syntax grammar].
 
 ## Array
 
-    a1:num[]
-    a2:string[][]
-    a1 = num[ 1 2 3 4 ]
-    a2 = string[ ["1" "2"] ["a" "b"] ]
-    a3 := bool[ true false ]
-    a4 := num[ "s1"
-            "s2" ] // linebreak allowed
-    a5 := any[ "chars" 123 ]
+    a1:[]num
+    a2:[][]string
+    a1 = [1 2 3 4]             // type: num[]
+    a2 = [["1" "2"]["a" "b"]]  // type: string[][]
+    a3 := [true false]         // type: bool[]
+    a4 := ["s1"                // line break allowed
+           "s2"]               // type: string[]
+    a5 := ["chars" 123]        // type: any[]
+    a6:[]any                   // type: any[]
 
 ### Array element access
 
+    a1 := [1 2 3 4]
+    a2 := [["1" "2"]["a" "b"]]
     print a1[1]    // 2
     print a2[1][0] // "a"
 
 ### Concatenation, append, prepend
 
-    z = z + num[ 100 ] // [ 1 2 3 4 5 6 100 ]
-    z = append z 101       // [ 1 2 3 4 5 6 100 101 ]
-    z = prepend z 0        // [ 0 1 2 3 4 5 6 100 101 ]
+    z = z + [ 100 ]    // z: [1 2 3 4 5 6 100]; optional extra whitespace 
+    z = z + [101]      // z: [1 2 3 4 5 6 100 101]
+    append z 102       // z: [1 2 3 4 5 6 100 101 102]
+    prepend z 0        // z: [0 1 2 3 4 5 6 100 101 102]
 
 ### Slicing
 
-    x1 := x[:2] // [ 1 2 ]
+    x := [1 2 3]
+    x1 := x[:2] // [1 2]
     x2 = x[2]   // [3]
     x2 = x[1:2] // [2]
-    x2 = x[-1]  // [3]`
-    x2 = x[-2:] // [ 2 3 ]
+    x2 = x[-1]  // [3]
+    x2 = x[-2:] // [2 3]
 
 ## Map
 
-    m:any{}          // keys can only be identifiers
-    m.name = "fox"
-    m.age = 42
+    m1:{}any          // keys can only be identifiers, any value allowed
+    m2.name = "fox"
+    m2.age = 42
 
-    m1 := string{ letters:"abc" nums:"asdf" }
-    m2 := {} // short for any{}
-    m3 := any{
-            letters:"abc"
+    m3 := {letters:"abc" name:"Jill"}   // type: {}string
+    m4 := {}                            // type: {}any
+    m5 := {
+            letters:"abc"               // line break allowed
             nums:123
-          } // linebreak allowed
+          }                             // type: {}any
+    m6:{}[]num                          // map of array of numbers
+    m6.digits = [1 2 3]
+    m7:{}num
+    m7.x = "y"                          // invalid, only num values allows
 
 ### Map value access
 
+    m := {letters:"abc" name:"Jill"}   
     s := "letters"
-    print m2.letters    // abc
-    print m2[s]         // abc
-    print m2["letters"] // abc
+    print m.letters    // abc
+    print m[s]         // abc
+    print m["letters"] // abc
 
 ### Map value existence
 
@@ -190,33 +197,34 @@ specification see the [syntax grammar].
 
 ## Any
 
-    x:any  // any type
-    m1:{}  // any map value type
+    x:any     // any type
+    m1:{}any  // map with any value type
     m2 := { letter:"a" number:1 }
-    arr := any[ "b" 2 ]
+    arr1:[]any
+    arr2 := [ "b" 2 ]
    
 ## Type reflection
 
-    reflect "abc"              // {type: "string"}
-    reflect true               // {type: "bool"}
-    reflect num[ 1 2 ]         // {type: "array",
-                               //  sub:  {type: "num"}
-                               // }
-    reflect num[ [1 2] [3 4] ] // {
-                               //   type: "array",
-                               //   sub:  {
-                               //     type: "array"
-                               //     sub: {
-                               //       type: "num"
-                               //     }
-                               //   }
-                               // }
+    reflect "abc"         // {type: "string"}
+    reflect true          // {type: "bool"}
+    reflect [ 1 2 ]       // {type: "array",
+                          //  sub:  {type: "num"}
+                          // }
+    reflect [[1 2] [3 4]] // {
+                          //   type: "array",
+                          //   sub:  {
+                          //     type: "array"
+                          //     sub: {
+                          //       type: "num"
+                          //     }
+                          //   }
+                          // }
 
 ### Type reflection Usage Example
 
     v:any
     v = "asdf"
-    if (reflect v).type == "string" 
+    if (reflect v) == {type: "string"}
         print "v is a string:" v
     end
 
@@ -230,8 +238,8 @@ specification see the [syntax grammar].
 ## Type assertion
 
     x:any
-    x = num[ 1 2 3 4 ]  // concrete type num[]
-    s := num[] x
+    x = [ 1 2 3 4 ]  // concrete type num[]
+    s := x.([]num)
 
 ## Variadic functions
 
@@ -249,7 +257,7 @@ specification see the [syntax grammar].
 
 ## Event handling 
 
-    on animate
+    on frame
         draw
     end
 
@@ -265,16 +273,22 @@ specification see the [syntax grammar].
 
 ### Print
     
-    print  "abc" 123 // abc 123 \n
+    print  "abc" 123 // abc 123\n
     prints "abc" 123 // print string: abc123
-    printq "abc"     // print quoted, reuse as value: "abc"
+    printq "abc" 123  // print quoted, reuse as value: "abc"
+
+Returning a string:
+
+    sprint  "abc" 123 // returns "abc 123\n"
+    sprints "abc" 123 // returns "abc123"
+    sprintq "abc"     // returns "\"abc\""
 
 ### Strings
     
     "Hello"[2]                // "l"
     "Hello world"[1:5]        // "ello"
     join [ "one" "two" ] ", " // "one, two"
-    split "hi there" " "      // [ "hi" "there" ]
+    split "hi there"          // [ "hi" "there" ]
 
 ### Length
  
@@ -284,6 +298,13 @@ specification see the [syntax grammar].
 
     append x 100   // [ 1 2 3 100 ]
     prepend x -100 // [ -100 1 2 3 100 ]
+
+### Maps
+ 
+    m := {name: "abc"}
+    has m "abc" // true
+    del m "abc"
+    has m "abc" // false
 
 ### Conversion
 
@@ -303,9 +324,9 @@ specification see the [syntax grammar].
     
     now                                 // return unix time in seconds
     format_time now                     // "2022-08-28T23:59:05Z" Z is time zone zero
-    format_time2 now "06/01/02 15:04"   // "22/01/02 15:04" 
+    format_timef now "06/01/02 15:04"   // "22/01/02 15:04" 
     parse_time "2022-08-28T23:59:05Z"   // internal representation as unix seconds
-    parse_time2 value format
+    parse_timef value format
     sleep 10                            // sleep 10 seconds
 
 See Go's [time.Layout] for further details on formatting and parsing.
@@ -327,9 +348,9 @@ No support for custom events.
     circle radius
     line end_x end_y
     rect width height
-    curve ?
-    polygon num[ x1 y2 x2 y2 x3 y3 ]
-    polyline num[ x1 y1 x2 y2 x3 y3 ]
+    curve // TBD
+    polygon [x1 y2] [x2 y2] [x3 y3]
+    polyline [x1 y1] [x2 y2] [x3 y3]
 
     color  900   // CSS    #ff0000
     colors "red" // CSS color keywords:     #ff0000

--- a/docs/syntax_grammar.md
+++ b/docs/syntax_grammar.md
@@ -2,7 +2,7 @@
 
 `evy` is a [statically typed], [garbage collected],
 [procedural] programming language. Its main design goal is to help
-learn programming. `evy` strives for simplicity and directness in its
+learn programming. `evy` aims for simplicity and directness in its
 tooling and syntax. Several features typical of modern programming
 languages are purposefully left out.
 
@@ -50,7 +50,7 @@ Here is a WSN defining itself:
     identifier = LETTER { LETTER } .
     literal    = """ CHARACTER { CHARACTER } """ .
     LETTER     = "a" … "z" | "A" … "Z" | "_" .
-    CHARACER   = /* an arbitrary Unicode code point */ .
+    CHARACTER  = /* an arbitrary Unicode code point */ .
 
 By convention, upper case production names identify _terminal tokens_.
 Terminal tokens are the leaves in the grammar that cannot be expanded
@@ -58,18 +58,27 @@ further. Lower case production names identify _non-terminals_, which
 are production names that may be expanded further. Lexical tokens are
 enclosed in double quotes `""`. Comments are fenced by `/* … */`.
 
+There are two special fencing tokens in evy's grammar related to
+horizontal whitespace, `<-` … `->` and `<+` … `+>`. `<-` … `->` means
+no horizontal whitespace is allowed between the terminals of the
+enclosed expression, e.g. `3+5` inside `<-` … `->` is allowed, but
+`3 + 5` is not. The fencing tokens `<+` … `+>` are the default and mean
+horizontal whitespace is allowed (again) between terminals. 
+
+See section [whitespace](#whitespace) for further details.
+
 ## Evy syntax grammar
 
 The `evy` source code is UTF-8 encoded. The NUL character `U+0000` is
 not allowed.
 
-    program    = { statement | func | event_handler } .
-    statements = statement { statement }
-    statement  = empty_stmt | 
-                 assign_stmt | typed_decl_stmt | inferred_decl_stmt |
+    program    = { statement | func | event_handler | NL } .
+    statements = statement { statement } .
+    statement  = typed_decl_stmt | inferred_decl_stmt |
+                 assign_stmt | 
                  func_call_stmt | 
                  return_stmt | break_stmt |
-                 for_stmt | while_stmt | if_stmt  .
+                 if_stmt | for_stmt | while_stmt .
 
     /* --- Functions and Event handlers ---- */
     func            = "func" ident func_signature NL
@@ -96,54 +105,57 @@ not allowed.
                     statements
                  "end" NL .
     range      = ident ( ":=" | "=" ) "range" range_args .
-    range_args = term [ term [ term ] ] .
+    range_args = <- expr -> [ <- expr -> [ <- expr -> ] ] .
     while_stmt = "while" toplevel_expr NL
                      statements
                  "end" NL .
 
-    /* --- Statement ---- */
-    empty_stmt = NL .
-
-    assign_stmt        = assignable "=" expr NL .
-    typed_decl_stmt    = typed_decl NL .
-    inferred_decl_stmt = ident ":=" toplevel_expr NL .
-
-    func_call_stmt = func_call NL.
-
     return_stmt = "return" [ toplevel_expr ] NL.
     break_stmt  = "break" NL .
 
+    /* --- Statement ---- */
+    assign_stmt        = assignable "=" toplevel_expr NL .
+    typed_decl_stmt    = typed_decl NL .
+    inferred_decl_stmt = ident ":=" toplevel_expr NL .
+    func_call_stmt     = func_call NL.
+
     /* --- Assignment --- */
-    assignable     = ident { selector } .
+    assignable     = <- ident | index_expr | dot_expr -> . /* no WS around `[…]` and `.` */
     ident          = LETTER { LETTER | UNICODE_DIGIT } .
-    selector       = index | dot_selector .
-    index          = "[" expr "]" .
-    dot_selector   = "." ident .
+    index_expr     = assignable "[" expr "]" .
+    dot_expr       = assignable "." ident .
 
     /* --- Type --- */
-    typed_decl         = ident ":" type .
-
-    type       = BASIC_TYPE | array_type | map_type | "any" .
-    BASIC_TYPE = "num" | "string" | "bool" .
-    array_type = type "[]" .
-    map_type   = [type] "{}" .
+    typed_decl     = <- ident ":" type -> . /* no WS allowed. */
+    type           = BASIC_TYPE | DYNAMIC_TYPE | COMPOSITE_TYPE .
+    BASIC_TYPE     = "num" | "string" | "bool" .
+    DYNAMIC_TYPE   = "any" 
+    COMPOSITE_TYPE = array_type | map_type
+    array_type     = "[]" type .
+    map_type       = "{}" type .
 
     /* --- Expressions --- */
     toplevel_expr = func_call | expr .
 
     func_call = ident args .
-    args      = { term } .
+    args      = { tight_expr } .  /* no WS within single arg, WS is arg separator */
 
-    type_assertion = assignable "." "(" type ")" .
+    tight_expr = <- expr ->       /* no WS allowed unless within `(…)`, `[…]`, or `{…}` */
+    expr       = operand | unary_expr | binary_expr .
 
-    expr       = term | expr OP expr .
-    term       = operand | UNARY_OP term .
-    operand    = literal | assignable | slice | type_assertion | "(" toplevel_expr ")" .
-    UNARY_OP   = "+" | "-" | "!" .
-    OP         = "or" | "and" | REL_OP | ADD_OP | MUL_OP .
-    REL_OP     = "==" | "!=" | "<" | "<=" | ">" | ">=" .
-    ADD_OP     = "+" | "-" .
-    MUL_OP     = "*" | "/" | "%" .
+    operand    = literal | assignable | slice | type_assertion | group_expr .
+    group_expr = "(" <+ toplevel_expr +> ")" /* WS can be used freely within `(…)` */
+    type_assertion = <- assignable "." "(" type ")" -> .
+    
+    unary_expr = <- UNARY_OP -> expr  /* WS not allowed after UNARY_OP */
+    UNARY_OP   = "-" | "!" .
+
+    binary_expr   = expr BINARY_OP expr
+    BINARY_OP     = LOGICAL_OP | COMPARISON_OP | ADD_OP | MUL_OP .
+    LOGICAL_OP    = "or" | "and"
+    COMPARISON_OP = "==" | "!=" | "<" | "<=" | ">" | ">=" .
+    ADD_OP        = "+" | "-" .
+    MUL_OP        = "*" | "/" | "%" .
 
     /* --- Slice and Literals --- */
     slice       = assignable "[" [expr] : [expr] "]" .
@@ -152,10 +164,10 @@ not allowed.
                   DECIMAL_DIGIT { DECIMAL_DIGIT } "." { DECIMAL_DIGIT } .
     string_lit  = """ { UNICODE_CHAR } """ .
     BOOL_CONST  = "true" | "false" .
-    array_lit   = type "[" array_elems "]" .
-    array_elems = { term [NL] }
-    map_lit     = [type] "{" map_elems "}" .
-    map_elems   = { ident ":" term [NL] } .
+    array_lit   = "[" <+ array_elems +> "]" . /* WS can be used freely within `[…], but not inside the elements` */
+    array_elems = { tight_expr [NL]  }
+    map_lit     = "{" <+ map_elems +> "}" .   /* WS can be used freely within `{…}, but not inside the values` */
+    map_elems   = { ident ":" tight_expr [NL]  } .
 
     /* --- Terminals --- */
     LETTER         = UNICODE_LETTER | "_" .
@@ -163,59 +175,15 @@ not allowed.
     UNICODE_DIGIT  = /* a Unicode code point categorized as "Number, decimal digit" */ .
     UNICODE_CHAR   = /* an arbitrary Unicode code point except newline */ .
     DECIMAL_DIGIT  = "0" … "9" .
-    NL             = "\n" .
+    NL             = "\n" {"\n"} .
+    WS             = " "|"\t" {" "|"\t"}
+
 
 ## Comments
 
 There is only one type of comment, the line comment which starts with
 `//` and stops at the end of the line. Line comments cannot start
 inside string literals.
-
-## Variables and Zero values
-
-A variable is a storage location for holding a value. The set of
-permissible values is determined by the variable's [type](#types).
-
-A variable must be _declared_ before it can be used either in
-an _inferred declaration_ or in a _typed declaration_.
-
-With the inferred declaration the type is not given but inferred from
-the value. For example `a := 2` declares variable `a` of type `num`
-holding the value `2`. `num` is the inferred type.
-
-Variables declared via typed declaration are not given a value, for
-example `x:num`. They are initialised to the zero value of their type:
-
-    Type        Zero
-    num         0
-    string      ""
-    bool        false
-    any[]       [] // empty array
-    any{}       {} // empty map
-
-## Assignment and Expressions
-
-When a variable is assigned to a new variable or passed as an argument
-to a function, a copy of its value is made. Modifying the copy does not
-change the original, for example:
-
-    arr1 := [ 1 2 ]
-    arr2 := arr1
-    arr2[0] = 2
-    print arr1 arr2 // [ 1 2 ] [ 2 2 ]
-
-The following assignment statement is ambiguous `a := b - 1`. Does the
-expression `b - 1` represent a function call of function `b` with
-argument `-1`? Or is `b` a variable so that `b - 1` becomes the
-arithmetic expression "`b` minus `1`"?
-
-`evy` resolves this ambiguity by tracking identifiers in a symbol table
-and annotating them as _variable_ or _function_ names. If `b` has not
-been declared as a variable or function by the point where the
-expression `b - 1` is seen it is assumed that `b` is the name of a
-function. This allows for [mutual recursion] of functions.
-
-[mutual recursion]: https://en.wikipedia.org/wiki/Mutual_recursion
 
 ## Types
 
@@ -224,7 +192,8 @@ composite types: [arrays](#arrays) `[]` and [maps](#maps) `{}`.
 The _dynamic_ type `any` can hold any of the previously listed
 types.
 
-Composite types can nest further composite types, for example `num[][]{}`.
+Composite types can nest further composite types, for example 
+`[]{}string` is an array of maps with string values.
 
 A `bool` value is either `true` or `false`.
 
@@ -233,6 +202,135 @@ Internally a number is represented as a [double-precision floating-point number]
 according to the IEEE-754 64-bit floating point standard.
 
 [double-precision floating-point number]: https://en.wikipedia.org/wiki/Double-precision_floating-point_format
+
+## Variables and Declarations
+
+Variables hold values of the type specified in the variable declaration.
+
+Variables must be _declared_ before they can be used. A variable
+declaration can either be an _inferred declaration_ or a _typed
+declaration_. With the inferred declaration the type is not given but
+inferred from the value. With typed declaration the type is explicitly
+specified and the variable is initialised to its type's zero value.
+
+    a1 := 1 // inferred declaration of variable 'a1' 
+            // with type 'num' and value 1.
+    a2:num  // typed declaration of variable 'a2'
+            // with type 'num' and zero value 0.
+
+`arr := []` infers an array of type any, `[]any`. `map := {}` infers a
+map of type any, `{}any`. The strictest possible type is inferred for
+composite types:
+
+    arr := [ 1 2 3 ]     // type: []num
+    arr := [ 1 "a" ]     // type: []any
+    arr := [ [1] ["a"] ] // type: [][]any
+    arr := []            // type: []any
+    arr := [ 1 ] + []    // type: []num
+    m := {}              // type: {}any
+    m := {age: 10}       // type: {}num
+
+## Zero Values
+
+Variables declared via typed declaration are initialised to the zero
+value of their type:
+
+    Type        Zero
+    num         0
+    string      ""
+    bool        false
+    []ANY       [] // empty array of given type, if no type given: array of any
+    {}ANY       {} // empty map of given type, if no type given: map of any
+
+## Assignments
+
+Assignments are defined by an equal sign `=`. The left hand side of the
+`=` must contain an _assignable_, a variable, an indexed array 
+(`arr[1] = "abc"`) or a map field (`person.age = 42`), see [Arrays](#Arrays) 
+and [Maps](#Maps) for further details. Before the assignment
+the variable must be declared via inferred (`:=`)or typed declaration
+(`:TYPE`). Only values of the correct type can be assigned to a
+variable.
+
+    a := 1
+    print a // prints 1
+    a = 2
+    print a // prints 2
+    a = "abc" // compile time error, wrong type
+
+## Copy and reference
+
+When a variable of a basic type `num`, `string`, or `bool` is the value
+of an assignment, a copy of its value is made. A copy is also made when
+a variable of basic type is used as the value in an inferred
+declaration or passed as an argument to a function.
+
+    a := 1
+    b := a
+    print a b // 1 1
+    a = 2
+    print a b // 2 1 - `b` keeps its initial value
+
+By contrast, composite types - maps and arrays - are passed by
+reference and no copy is made. Modifying the contents of an array
+referenced by one variable also modifies the contents of the array
+referenced by another variable. This is also true for argument passing
+and inferred declarations:
+
+    a := [1]
+    b := a
+    print a b // [1] [1]
+    a[0] = 2
+    print a b // [2] [2] - b also has updated contents
+
+For the dynamic type `any`, a copy is made if the value is of basic type
+and the variable is passed by reference if the value is a composite type.
+
+See [Functions](#Functions), [Maps](#Maps) and [Arrays](#Arrays) for
+further details.
+
+## Scope
+
+Functions can only be defined at the top level of the program, known
+as _global scope_. A function does not have to be defined before it can
+be used. This allows for [mutual recursion] of functions - `func a`
+calling `b` and `func b` calling func `a`.
+
+Variables by contrast must be declared and given an unchangeable type
+before they can be used. Variables can be declared at the top level of
+the program, at _global scope_, or within a block-statement, at _block
+scope_. 
+
+A _block-statement_ is a block of statements that ends with the keyword
+`end`. A function body following the line starting with `func` is a
+block-statement. The statements between `if` and `else` are a block
+(statement). The statements between `while`/`for`/`else` and `end` are
+a block. Blocks can be nested within other blocks.
+
+A variable declared inside a block only exists until the end of the
+block and may not be used outside the block. 
+
+Variable names in an inner block can shadow or override the same
+variable name from an outer block, which makes the variable of the
+outer block inaccessible to the inner block. However, when the inner
+block is finished the variable from the outer block is restored and
+unchanged:
+
+    x := "outer"
+    print "1" x
+    for i := range 1
+        x := true
+        print "2" x
+    end
+    print "3" x
+
+This program will print
+    
+    1 outer
+    2 true
+    3 outer
+
+[mutual recursion]: https://en.wikipedia.org/wiki/Mutual_recursion
 
 ## Strings
 
@@ -253,23 +351,47 @@ by index. Strings can be concatenated with the `+` operator.
 ## Arrays
 
 Arrays are declared with brackets `[]`. Their elements have a type, for
-example `arr := num[ 1 2 3 ]` is an array of `num`. Arrays can be
-nested `arr:num[][]{}`.
+example `arr := [1 2 3]` and `arr:[]num` are arrays of type `num`.
+Arrays can be nested `arr:[]{}string`.
 
-An array of type `any` can be composed of different types:
+An array composed of different types becomes an array of `any`:
 
-    arr := any[ "abc" 123 ]
+    arr := ["abc" 123] // type: []any
 
 `len arr` returns the length of the array. `for el := range arr`
-iterates over all elements of the array. `arr = append arr 1` and `arr
-= prepend arr 0` add a new element to beginning or end of the array.
+iterates over all elements of the array in order. `append arr 1` and
+`prepend arr 0` add a new element to end or beginning of the array.
 Arrays can be concatenated with the `+` operator `arr2 := arr + arr`.
+
+The elements of an array can be accessed via index starting at 0. In the
+example above the first element in the array `arr[0]` is `"abc"`.
+
+The empty arrays becomes `[]any` in inferred declarations, otherwise the
+empty array literal assumes the type required. `arr:[]any` and `arr :=
+[]` are equivalent.
+
+In order to distinguish between array literals and array indices, there
+cannot be any whitespace between array variable and index.
+
+    arr := ["a" "b"]
+    print arr[1]  // index:   a
+    print arr [1] // literal: [a b] [1]
+    arr[0] = "A"
+    arr [1] = "B" // invalid
+
+See section [whitespace](#whitespace) for further details.
 
 ## Maps
 
+Maps are key-value stores, where the values can be looked up by their
+key
+
+    m := { key1:"value1" key2:"value2" }
+
 Map keys must be strings that match the grammars `ident` production. Map
-values can be accessed with the dot selector, for example `map.key`.
-They can also be accessed with a key expression and the index selector:
+values can be accessed with the dot expression, for example `map.key`.
+Map values can also be accessed with an index which allows for
+evaluation and variable usage:
 
     m := { letters: "abc" }
     print m.letters    // abc
@@ -280,130 +402,42 @@ They can also be accessed with a key expression and the index selector:
 
 The `has` function tests for the existence of a key in a map:
 
-    has m "letters"    // true
-    has m "digits"     // false
+    has m "letters"     // true
+    has m "digits"      // false
 
-`for key := range map` iterates over all map keys.
+The `del` function deletes a key from a map if it exists:
+
+    del m "letters"    // m == {}
+
+`for key := range map` iterates over all map keys. It is safe to delete
+values from the map with the builtin function `del` while iterating.
+The keys are iterated in the order in which they are inserted. Any
+values inserted into the map during the iteration will not be included
+in the iteration.
 
 `len m` returns the number of values in the map.
 
-When leaving out the value type of a map, `any` is inferred. Therefore
-`m:any{}`, `m:{}`, `m := any{}` and `m := {}` are all equivalent.
+The empty map literal becomes `{}any` in inferred declarations,
+otherwise the empty map literal assumes the type required. 
+`m:{}any` and `m := {}` are equivalent.
 
-## Operators
-
-Binary operations can only be executed with operands of the same type.
-There is no automated type conversion of operands.
-
-    operands   operators      result
-    num        + - * / % ^    num
-    string     +              string
-    array      +              array
-    bool       and or         bool
-    num        <  <=  >  >=   bool
-    string     <  <=  >  >=   bool
-
-`==` and `!=` compare to operands of the same type for equality and
-have a `bool` result.
-
-`+` `-` `*` `/` `%` stand for addition, subtraction, multiplication,
-division and the [modulo operator]. `+` may also be used as
-concatenation operator with `string` and `array`.
-
-Boolean operators `and`, `or` stand for [logical conjunction (AND)] and
-[logical disjunction (OR)]. Comparison operators `<`  `<=`  `>`  `>=`
-stand for less, less or equal, greater, greater or equal. Their
-operands may be `num` or `string` values. For `string`
-[lexicographical comparison] is used.
-
-The unary operator `-` stands for the negative sign and can only be used
-with `num`. The unary operator `!` stands for [logical negation] and
-can only be used with `bool`.
-
-[modulo operator]: https://en.wikipedia.org/wiki/Modulo_operation
-[logical conjunction (AND)]: https://en.wikipedia.org/wiki/Truth_table#Logical_conjunction_(AND)
-[logical disjunction (OR)]: https://en.wikipedia.org/wiki/Truth_table#Logical_disjunction_(OR)
-[logical negation]: https://en.wikipedia.org/wiki/Truth_table#Logical_negation
-[lexicographical comparison]: https://en.wikipedia.org/wiki/Lexicographic_order
-
-## Precedence
-
-Unary operators, `( … )` and selectors `a[i]`, `a.b` have the highest
-precedence, followed by binary operators. The binary operators have the
-following order of precedence:
-
-    precedence    Operator
-        5             *  /  %
-        4             +  -
-        3             ==  !=  <  <=  >  >=
-        2             and
-        1             or
-
-## Comments
-
-There is only one type of comment, the line comment which starts with
-`//` and stops at the end of the line. Line comments cannot start
-inside string literals.
-
-## Variables and Zero values
-
-Variables hold values of type `num`, `string`, `bool`, array or map.
-They must be _declared_ before they can be used. A variable declaration
-can either be an _inferred declaration_ or a _typed delaration_.
-
-With the inferred declaration the type is not given but inferred from
-the value. For example `a := 2` declares variable `a` of type `num`
-holding the value `2`. `num` is the inferred type.
-
-Variables declared via typed declaration are not given a value, for
-example `x:num`. They are initialised to the zero value of their type:
-
-    Type        Zero
-    num         0
-    string      ""
-    bool        false
-    any[]       [] // empty array
-    any{}       {} // empty map
-
-## Arrays
-
-Arrays are declared with brackets `[]`. Their elements have a type, for
-example `arr := int[ 1 2 3]` is an array of `num`. Arrays can be nested
-`arr:num[][]{}`.
-
-An array of type `any` can be composed of different types:
-
-    arr := any[ "abc" 123]
-
-`len arr` returns the length of the array. `for el := range arr`
-iterates over all elements of the array. `arr = append arr 1` and `arr
-= prepend arr 0` add a new element to beginning or end of the array.
-Arrays can be concatenated with the `+` operator `arr2 := arr + arr`.
-
-## Strings
-
-`len str` returns the number of Unicode code points, _characters_, in
-the string. `for ch := range str` iterates over all characters of the
-string. Individual characters of a string can be addressed and updated
-by index. Strings can be concatenated with the `+` operator.
-
-    str := "hello!"
-    str[0] = "H"             // Hello
-    str1 := str + ", " + str // Hello, Hello
+The dot expression `.` and the index expression `[ "key" ]` must not be
+surrounded by any whitespace. See section [whitespace](#whitespace) for
+further details.
 
 ## Index and Slice
 
 The first index of an array or string is `0`. A negative index `-i` is a
-short hand for `(len a) - i`, for example `a[-1]` references the last
-element. When trying to index an array or string out of bounds a
-[run-time panic](#run-time-panics-and-recoverable-errors) occurs.
+short hand for `(len a) - i`. Therefore `arr[-1]` references the last
+element of `arr`. When trying to index an array or string out of bounds
+a [run-time panic](#run-time-panics-and-recoverable-errors) occurs.
 
 Portions of an array or string can be copied with the slice selector,
 for example `a[1:3]`. `a[start : end]` copies a substring or subarray,
 a _slice_, starting with the value at `a[start]`. The length of the
 slice is `end - start`. The end index `a[end]` is not included in the
 slice. If `start` is left out it defaults to 0. If `end` is left out it
-defaults to `len a`, for example:
+defaults to `len a`.
 
     s := "abcd"
     print s[1:3] // bc
@@ -414,48 +448,141 @@ defaults to `len a`, for example:
 
 Slices may not be sliced further, `a[:2][1:]` is illegal.
 
-## Maps
+Slice expressions must nut be preceded by whitespace, like array or
+string indexing. See section [whitespace](#whitespace) for further
+details.
 
-Map keys can only be strings shaped like identifiers so that map values
-can be accessed via dot selector, `map.key`. They may also
-use a key expression with the index selector:
+## Operators
 
-    m := { letters: "abc" }
-    print m.letters    // abc
-    print m["letters"] // abc
+Binary operations can only be executed with operands of the same type.
+There is no automated type conversion of operands.
 
-    s := "letters"
-    print m[s]         // abc
+    operands   operators      result
+    num        + - * / %      num
+    string     +              string
+    array      +              array
+    bool       and or         bool
+    num        <  <=  >  >=   bool
+    string     <  <=  >  >=   bool
 
-The `has` function tests for the existence of a key in a map:
+`==` and `!=` compare two operands of the same type for equality and
+have a `bool` result.
 
-    has m "letters"    // true
-    has m "digits"     // false
+`+` `-` `*` `/` `%` stand for addition, subtraction, multiplication,
+division and the [modulo operator]. `+` may also be used as
+concatenation operator for `string` and `array` types. 
 
-`for key := range map` iterates over all map keys.
+Boolean operators `and`, `or` stand for [logical conjunction (AND)] and
+[logical disjunction (OR)]. Comparison operators `<`  `<=`  `>`  `>=`
+stand for less, less or equal, greater, greater or equal. Their
+operands may be `num` or `string` values. For `string` types
+[lexicographical comparison] is used.
 
-`len m` returns the number of values in the map.
+The unary operator `-` stands for the negative sign and can only be used
+with `num`. The unary operator `!` stands for [logical negation] and
+can only be used with `bool`. Unary operators `-` and `!` must not be
+followed by horizontal whitespace.
 
-When leaving out the value type of a map, `any` is inferred. Therefore
-`m:any{}`, `m:{}`, `m := any{}` and `m := {}` are all equivalent.
+    a := 1
+    b := 2
+    print a-b     // -1
+    print (a - b) // -1
+    print a -b    // 1 -2
+    print a - b   // compile time error
 
-## Assignment
+See section [whitespace](#whitespace) for further details.
 
-When a variable of any type is assigned to a new variable or passed as
-an argument to a function, a copy is made. Modifying the copy does not
-change the original, for example:
+[modulo operator]: https://en.wikipedia.org/wiki/Modulo_operation
+[logical conjunction (AND)]: https://en.wikipedia.org/wiki/Truth_table#Logical_conjunction_(AND)
+[logical disjunction (OR)]: https://en.wikipedia.org/wiki/Truth_table#Logical_disjunction_(OR)
+[logical negation]: https://en.wikipedia.org/wiki/Truth_table#Logical_negation
+[lexicographical comparison]: https://en.wikipedia.org/wiki/Lexicographic_order
 
-    arr1 := [ 1 2 ]
-    arr2 := arr1
-    arr2[0] = 2
-    print arr1 arr2 // [ 1 2 ] [ 2 2 ]
+## Precedence
 
-## Break and Return
+The index `a[i]`, dot `a.b` and group `(` … `)`expressions have the
+highest precedence, followed by the unary operators `-` and `!`.
+Finally, binary operators have the following order of precedence:
 
-`break` and `return` are terminating statements. They interrupt the
-regular flow of control. `break` is used to exit from the inner-most
-loop body. `return` is used to exit from a function and may be followed
-by an expression whose value is returned by the function call.
+    precedence    Operator
+        6             *  /  %
+        5             +  -
+        4             <  <=  >  >=
+        3             ==  !=  
+        2             and
+        1             or
+
+## Whitespace
+
+Vertical whitespace is newlines, `NL` in the grammar. It delimits
+statements. Array and map literals are the exception as they can be
+very large and allow for whitespace `NL` within:
+
+    person := {
+        name: "Jane Goddall"
+        born: 1934
+    }               // valid map declaration
+    x := 1 +
+         2          // compile time error
+
+Horizontal whitespace is tabs or spaces, `WS` in the grammar. `WS` is
+used as a separator between elements in lists and cannot be
+used _within_ an element. These lists include argument list to a
+function call and the element lists of array literals or map literals.
+To further avoid confusion, whitespace within index expression, dot
+expressions or unary expressions is not allowed.
+
+More formally, `WS` between tokens or terminals as defined in the
+grammar is ignored except for the following cases:
+
+1. `WS` is not allowed in assignables, around `DOT`, or before array or
+map index. Invalid: `person .name`, `person. name`, `array [1] = 2`.
+Valid: `person.name`, `array[1] = 2`.
+
+2. `WS` is not allowed following the unary operators `-` and `!`.
+
+3. `WS` is used as the separator in expression lists in function call
+arguments and array elements. `WS` is therefore _not_ allowed within
+the expressions of an expression list, including the values of map
+literal definitions.
+
+4. `WS` is allowed within the expression of an expression list if the
+expression is surrounded by `()`, `[]` or `{}`, `e.g. [ ( 2 + 3 ) ]`,
+not `WS` directly after `[` and within `( … )`
+
+5. `WS` can be freely used in single expressions for assignments,
+inferred declarations, return statements, `if` conditions and `while`
+conditions, as well as within parentheses `(…)`
+
+
+Examples:
+
+    print -5      // -5
+    print - 5     // invalid
+    print 2-1     // 1
+    print 2 -1    // 2 -1
+    print 2 - 1   // invalid
+    a := 2 - 1    // valid!
+
+    arr := ["a" "b"]
+    print arr[1]        // b
+    print arr [1]       // [a b] [1]
+    arr [0] = "A"       // invalid
+    arr2 :=[ 1   ]      // valid 
+    arr3 := [[1][2]]    // valid
+    arr3 := [[1] [ 2] ] // valid
+    arr3 := [1 + 1 ]    // invalid
+
+    m1 := { age:3+6 name:"mary"+"anne" }     // valid
+    m2 := {age:  12 name:"mary"}             // valid
+    m1.address = "10 Downing" + "Street"     // valid
+    m3 := {address: "10 Downing" + "Street"} // invalid
+
+    func add:num n1:num n2:num
+        return n1 + n2 // valid
+    end
+    print (add 1 2)  // 3
+    print add 1 2    // invalid
 
 ## Functions
 
@@ -473,6 +600,23 @@ The example above has a function name of `is_valid`, input parameters
 `text` of type `string` and `cap` of type `num`. The return type is
 `bool`.
 
+A variable may not use the same name as a function.
+
+Function calls used as arguments to another function call must be
+parenthesized to avoid ambiguity, for example:
+
+    print "valid:" (is_valid "abc" 5)
+
+Bare returns in functions without result types are allowed
+
+    func validate m:{}any
+        if m == {}
+            return
+        end
+        // further validation
+    end
+
+
 ## Variadic functions
 
 A function with a single parameter may have a type suffixed with `...`.
@@ -480,7 +624,7 @@ A function with such a parameter is called variadic and may be invoked
 with zero or more arguments for that parameter.
 
 If `f` is variadic with a parameter `p` of type `T...`, then within `f`
-the type of `p` is equivalent to type `T[]`. The length of the array is
+the type of `p` is equivalent to type `[]T`. The length of the array is
 the number of arguments bound to `p` and may differ for each call.
 
 For example, `my_print` is a variadic function
@@ -497,58 +641,52 @@ It can be called as `my_print "hello" "world" true 42`
 Unlike other languages, arrays cannot be turned into variadic arguments
 at the call site. The call arguments must be listed individually.
 
-## Reflection
+## Break and Return
 
-Reflection retrieves the type of the value held by a variable. This is
-particularly useful for a variable of type `any`, `any[]`, `any
-{}`, `any[][]` etc. The function call `reflect val` returns a map with
-keys `type` and optionally `sub`. The `type` value is one of `"num"`,
-`"string"`, `"bool"`, `"any"`, `"array"`, `"map"`. For `"array"` and
-`"map"` the key `"sub"` contains another map with keys `type` and
-optionally `sub` representing the type of the array elements or map
-values.
+`break` and `return` are terminating statements. They interrupt the
+regular flow of control. `break` is used to exit from the inner-most
+loop body. `return` is used to exit from a function and may be followed
+by an expression whose value is returned by the function call.
 
-    reflect "abc"              // {type: "string"}
-    reflect true               // {type: "bool"}
-    reflect num[ 1 2 ]         // {type: "array",
-                               //  sub:  {type: "num"}
-                               // }
-    reflect num[ [1 2] [3 4] ] // {
-                               //   type: "array",
-                               //   sub:  {
-                               //     type: "array"
-                               //     sub: {
-                               //       type: "num"
-                               //     }
-                               //   }
-                               // }
+## Typeof
+
+`typeof` returns the concrete type of a value held by a variable as a
+string. It returns one of `"num"`, `"string"`, `"bool"`, `"array"`, or
+`"map"`.
+
+    typeof "abc"        // string
+    typeof true         // bool
+    arr := [ "abc" 1 ]
+    typeof arr          // array
+    typeof arr[0]       // string
+    typeof arr[1]       // num
+    typeof {}           // map
 
 ## Type assertion
 
 A type assertion `ident.(type)` asserts that the value of the variable
-`ident` is of the given `type`. This is particularly useful for a
-variable of type `any`, `any[]`, `any{}`, `any[][]` etc. The value
-returned by the assertion is of given `type` and can be used in a
-declaration, assignment or function call. If the assertion does not hold
-a [run-time panic](#run-time-panics-and-recoverable-errors) panic occurs.
+`ident` is of the given `type`. If the assertion does not hold a
+[run-time panic](#run-time-panics-and-recoverable-errors) occurs.
 
     x:any
-    x = num[ 1 2 3 4 ]  
-    num_array := x.(num[])
+    x = [ 1 2 3 4 ]  
+    num_array := x.([]num)
     x = "abc"
     str := x.(string)
 
-Only variables or variable selectors of type `any` can be type asserted.
-That means an array of type `any`, _cannot_ be type assert
-to be an array of type `num` or other concrete type:
+Only values of type `any` can be type asserted. That means an array of
+type any, `[]any`, _cannot_ be type assert to be an array of type `num`
+or other concrete type:
 
-    x:any[]
+    x:[]
     x = [1 2]
     // x.([]num) // compile time error
     x[1] = [3 4 5]
+    x[0].(num)    // valid
+    x[0].(string) // run time panic
 
-However, the elements of `x` can be type assert, e.g. `x[0].(num)`, `x
-[1].([]num)`.
+However, the elements of `x` can be type assert, e.g. `x[0].(num)`, 
+`x[1].([]num)`.
 
 ## Event Handler
 
@@ -556,7 +694,7 @@ An event handler starts with `on`, followed by an event name and a block
 of statements. The statements get executed when the given event is
 triggered. Events can be triggered by user interaction, for example
 clicking the mouse or tapping the keyboard or by the system, for
-example `animate` when a new frame is painted.
+example `frame` when a new frame is painted.
 
 There is a limited, predefined set of events. It is not possible to
 create custom events.
@@ -565,11 +703,11 @@ create custom events.
         print mouse_x mouse_y
     end
 
-    on animate
+    on frame
         draw
     end
 
-The `animate` event is triggered every 2 Milliseconds, 50 times per
+The `frame` event is triggered every 2 Milliseconds, 50 times per
 second.
 
 ## Run-time Panics and Recoverable Errors


### PR DESCRIPTION
Update docs for whitespace. While at it, remove a bunch of duplicated
sections in grammar. We are now making horizontal whitespace `WS`
significant in certain places which allows us to remove the somewhat
awkward array and map typing in favour of derived and inferred types
for literals.

Remove `term` from grammar as it is not used in code, we only work with
expression. Introduce `<- ->` and  `<+ +>` tokens to annotated
whitespace inside grammar: expressions in expression lists, such as
function calls or array elements may not contain whitespace, as
whitespace is used as list separator.

Invert types so that types read as variables are being access:

        m:[]{}string
        m[0].name = "Joe"

Also add note on pass by reference for maps and arrays and pass by value
for string, num and bool.

---
For easier review:
https://github.com/foxygoat/evy/blob/docs-ws/docs/syntax_by_example.md
https://github.com/foxygoat/evy/blob/docs-ws/docs/syntax_grammar.md