### PR TITLE
parser: Implement whitespace sensitivity

### DIFF
--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -600,16 +600,16 @@ end
 for i := range 2 6 2
 	print "🍭" i
 end
-for i := range 5 3 (-1) // TODO: should work 5 3 -1 !
+for i := range 5 3 -1
 	print "🦊" i
 end
-for i := range 3 5 (-1)
+for i := range 3 5 -1
 	print "1💣" i
 end
-for i := range 3 (-1) 1
+for i := range 3 -1 1
 	print "2💣" i
 end
-for i := range 3 (-1)
+for i := range 3 -1
 	print "3💣" i
 end
 `

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -33,7 +33,6 @@ func New(input string) *Lexer {
 }
 
 func (l *Lexer) Next() *Token {
-	l.consumeHorizontalWhitespace()
 	l.advance()
 
 	tok := &Token{
@@ -42,6 +41,9 @@ func (l *Lexer) Next() *Token {
 		Col:    l.col,
 	}
 	switch l.cur {
+	case ' ', '\t':
+		l.consumeHorizontalWhitespace()
+		return tok.SetType(WS)
 	case '=':
 		if l.peekRune() == '=' {
 			l.advance()

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -78,26 +78,26 @@ func TestSingleTokenWithLiteral(t *testing.T) {
 		want *Token
 	}{
 		"IDENT": {
-			in:   "x",
+			in:   "x ",
 			want: &Token{Type: IDENT, Literal: "x", Offset: 0, Line: 1, Col: 1},
 		}, "IDENT whitespace": {
-			in:   "  x2 ",
-			want: &Token{Type: IDENT, Literal: "x2", Offset: 2, Line: 1, Col: 3},
+			in:   "x2\t",
+			want: &Token{Type: IDENT, Literal: "x2", Offset: 0, Line: 1, Col: 1},
 		}, "STRING": {
-			in:   `"xy"`,
+			in:   `"xy" `,
 			want: &Token{Type: STRING_LIT, Literal: "xy", Offset: 0, Line: 1, Col: 1},
 		}, "STRING whitespace": {
-			in:   ` " x y "  `,
-			want: &Token{Type: STRING_LIT, Literal: " x y ", Offset: 1, Line: 1, Col: 2},
+			in:   `" x y "  `,
+			want: &Token{Type: STRING_LIT, Literal: " x y ", Offset: 0, Line: 1, Col: 1},
 		}, "STRING WITH COMMENT TOKEN": {
-			in:   `"x//y"`,
+			in:   `"x//y" `,
 			want: &Token{Type: STRING_LIT, Literal: "x//y", Offset: 0, Line: 1, Col: 1},
 		}, "STRING escaped quote": {
-			in:   `"xy\""`,
+			in:   `"xy\""    `,
 			want: &Token{Type: STRING_LIT, Literal: `xy"`, Offset: 0, Line: 1, Col: 1},
 		}, "NUM": {
-			in:   " 1  ",
-			want: &Token{Type: NUM_LIT, Literal: "1", Offset: 1, Line: 1, Col: 2},
+			in:   "1  \t ",
+			want: &Token{Type: NUM_LIT, Literal: "1", Offset: 0, Line: 1, Col: 1},
 		}, "NUM2": {
 			in:   "12 ",
 			want: &Token{Type: NUM_LIT, Literal: "12", Offset: 0, Line: 1, Col: 1},
@@ -105,11 +105,11 @@ func TestSingleTokenWithLiteral(t *testing.T) {
 			in:   "12.3 ",
 			want: &Token{Type: NUM_LIT, Literal: "12.3", Offset: 0, Line: 1, Col: 1},
 		}, "NUM4": {
-			in:   "12.3.4 ",
+			in:   "12.3.4\t",
 			want: &Token{Type: NUM_LIT, Literal: "12.3.4", Offset: 0, Line: 1, Col: 1},
 		}, "COMMENT": {
-			in:   "  // x2 ",
-			want: &Token{Type: COMMENT, Literal: "// x2 ", Offset: 2, Line: 1, Col: 3},
+			in:   "// x2 ",
+			want: &Token{Type: COMMENT, Literal: "// x2 ", Offset: 0, Line: 1, Col: 1},
 		},
 	}
 
@@ -119,6 +119,11 @@ func TestSingleTokenWithLiteral(t *testing.T) {
 			l := New(tt.in)
 			got := l.Next()
 			assert.Equal(t, tt.want, got)
+
+			if name != "COMMENT" {
+				got = l.Next()
+				assert.Equal(t, WS, got.Type, name)
+			}
 
 			eofOffset := len(tt.in)
 			want := &Token{Type: EOF, Literal: "", Offset: eofOffset, Line: 1, Col: eofOffset + 1}
@@ -131,24 +136,30 @@ func TestSingleTokenWithLiteral(t *testing.T) {
 func TestNums(t *testing.T) {
 	in := `
 y := 1
-y = y * ( 3 + 7)
+y = y*(3 + 7)
 `
 	wantTokens := []*Token{
 		{Type: NL, Literal: "", Offset: 0, Line: 1, Col: 1},
 		{Type: IDENT, Literal: "y", Offset: 1, Line: 2, Col: 1},
+		{Type: WS, Literal: "", Offset: 2, Line: 2, Col: 2},
 		{Type: DECLARE, Literal: "", Offset: 3, Line: 2, Col: 3},
+		{Type: WS, Literal: "", Offset: 5, Line: 2, Col: 5},
 		{Type: NUM_LIT, Literal: "1", Offset: 6, Line: 2, Col: 6},
 		{Type: NL, Literal: "", Offset: 7, Line: 2, Col: 7},
 		{Type: IDENT, Literal: "y", Offset: 8, Line: 3, Col: 1},
+		{Type: WS, Literal: "", Offset: 9, Line: 3, Col: 2},
 		{Type: ASSIGN, Literal: "", Offset: 10, Line: 3, Col: 3},
+		{Type: WS, Literal: "", Offset: 11, Line: 3, Col: 4},
 		{Type: IDENT, Literal: "y", Offset: 12, Line: 3, Col: 5},
-		{Type: ASTERISK, Literal: "", Offset: 14, Line: 3, Col: 7},
-		{Type: LPAREN, Literal: "", Offset: 16, Line: 3, Col: 9},
-		{Type: NUM_LIT, Literal: "3", Offset: 18, Line: 3, Col: 11},
-		{Type: PLUS, Literal: "", Offset: 20, Line: 3, Col: 13},
-		{Type: NUM_LIT, Literal: "7", Offset: 22, Line: 3, Col: 15},
-		{Type: RPAREN, Literal: "", Offset: 23, Line: 3, Col: 16},
-		{Type: NL, Literal: "", Offset: 24, Line: 3, Col: 17},
+		{Type: ASTERISK, Literal: "", Offset: 13, Line: 3, Col: 6},
+		{Type: LPAREN, Literal: "", Offset: 14, Line: 3, Col: 7},
+		{Type: NUM_LIT, Literal: "3", Offset: 15, Line: 3, Col: 8},
+		{Type: WS, Literal: "", Offset: 16, Line: 3, Col: 9},
+		{Type: PLUS, Literal: "", Offset: 17, Line: 3, Col: 10},
+		{Type: WS, Literal: "", Offset: 18, Line: 3, Col: 11},
+		{Type: NUM_LIT, Literal: "7", Offset: 19, Line: 3, Col: 12},
+		{Type: RPAREN, Literal: "", Offset: 20, Line: 3, Col: 13},
+		{Type: NL, Literal: "", Offset: 21, Line: 3, Col: 14},
 		{Type: EOF, Literal: "", Offset: len(in), Line: 4, Col: 1},
 	}
 	l := New(in)
@@ -171,17 +182,22 @@ s = s[:1] // "bc"`
 		{Type: NL, Literal: "", Offset: 9, Line: 2, Col: 9},
 
 		{Type: IDENT, Literal: "s", Offset: 10, Line: 3, Col: 1},
+		{Type: WS, Literal: "", Offset: 11, Line: 3, Col: 2},
 		{Type: ASSIGN, Literal: "", Offset: 12, Line: 3, Col: 3},
+		{Type: WS, Literal: "", Offset: 13, Line: 3, Col: 4},
 		{Type: STRING_LIT, Literal: "abc", Offset: 14, Line: 3, Col: 5},
 		{Type: NL, Literal: "", Offset: 19, Line: 3, Col: 10},
 
 		{Type: IDENT, Literal: "s", Offset: 20, Line: 4, Col: 1},
+		{Type: WS, Literal: "", Offset: 21, Line: 4, Col: 2},
 		{Type: ASSIGN, Literal: "", Offset: 22, Line: 4, Col: 3},
+		{Type: WS, Literal: "", Offset: 23, Line: 4, Col: 4},
 		{Type: IDENT, Literal: "s", Offset: 24, Line: 4, Col: 5},
 		{Type: LBRACKET, Literal: "", Offset: 25, Line: 4, Col: 6},
 		{Type: COLON, Literal: "", Offset: 26, Line: 4, Col: 7},
 		{Type: NUM_LIT, Literal: "1", Offset: 27, Line: 4, Col: 8},
 		{Type: RBRACKET, Literal: "", Offset: 28, Line: 4, Col: 9},
+		{Type: WS, Literal: "", Offset: 29, Line: 4, Col: 10},
 		{Type: COMMENT, Literal: `// "bc"`, Offset: 30, Line: 4, Col: 11},
 		{Type: EOF, Literal: "", Offset: len(in), Line: 4, Col: 18},
 	}
@@ -194,7 +210,7 @@ s = s[:1] // "bc"`
 
 func TestMapRange(t *testing.T) {
 	in := `
-m := string{ name:"Mali" sport:"climbing" }
+m := {name:"Mali" sport:"climbing"}
 for key := range m
     print key m[key] // Mali climbing
 end
@@ -202,36 +218,46 @@ end
 	wantTokens := []*Token{
 		{Type: NL, Literal: "", Offset: 0, Line: 1, Col: 1},
 		{Type: IDENT, Literal: "m", Offset: 1, Line: 2, Col: 1},
+		{Type: WS, Literal: "", Offset: 2, Line: 2, Col: 2},
 		{Type: DECLARE, Literal: "", Offset: 3, Line: 2, Col: 3},
-		{Type: STRING, Literal: "", Offset: 6, Line: 2, Col: 6},
-		{Type: LCURLY, Literal: "", Offset: 12, Line: 2, Col: 12},
-		{Type: IDENT, Literal: "name", Offset: 14, Line: 2, Col: 14},
-		{Type: COLON, Literal: "", Offset: 18, Line: 2, Col: 18},
-		{Type: STRING_LIT, Literal: "Mali", Offset: 19, Line: 2, Col: 19},
-		{Type: IDENT, Literal: "sport", Offset: 26, Line: 2, Col: 26},
-		{Type: COLON, Literal: "", Offset: 31, Line: 2, Col: 31},
-		{Type: STRING_LIT, Literal: "climbing", Offset: 32, Line: 2, Col: 32},
-		{Type: RCURLY, Literal: "", Offset: 43, Line: 2, Col: 43},
-		{Type: NL, Literal: "", Offset: 44, Line: 2, Col: 44},
+		{Type: WS, Literal: "", Offset: 5, Line: 2, Col: 5},
+		{Type: LCURLY, Literal: "", Offset: 6, Line: 2, Col: 6},
+		{Type: IDENT, Literal: "name", Offset: 7, Line: 2, Col: 7},
+		{Type: COLON, Literal: "", Offset: 11, Line: 2, Col: 11},
+		{Type: STRING_LIT, Literal: "Mali", Offset: 12, Line: 2, Col: 12},
+		{Type: WS, Literal: "", Offset: 18, Line: 2, Col: 18},
+		{Type: IDENT, Literal: "sport", Offset: 19, Line: 2, Col: 19},
+		{Type: COLON, Literal: "", Offset: 24, Line: 2, Col: 24},
+		{Type: STRING_LIT, Literal: "climbing", Offset: 25, Line: 2, Col: 25},
+		{Type: RCURLY, Literal: "", Offset: 35, Line: 2, Col: 35},
+		{Type: NL, Literal: "", Offset: 36, Line: 2, Col: 36},
 
-		{Type: FOR, Literal: "", Offset: 45, Line: 3, Col: 1},
-		{Type: IDENT, Literal: "key", Offset: 49, Line: 3, Col: 5},
-		{Type: DECLARE, Literal: "", Offset: 53, Line: 3, Col: 9},
-		{Type: RANGE, Literal: "", Offset: 56, Line: 3, Col: 12},
-		{Type: IDENT, Literal: "m", Offset: 62, Line: 3, Col: 18},
-		{Type: NL, Literal: "", Offset: 63, Line: 3, Col: 19},
+		{Type: FOR, Literal: "", Offset: 37, Line: 3, Col: 1},
+		{Type: WS, Literal: "", Offset: 40, Line: 3, Col: 4},
+		{Type: IDENT, Literal: "key", Offset: 41, Line: 3, Col: 5},
+		{Type: WS, Literal: "", Offset: 44, Line: 3, Col: 8},
+		{Type: DECLARE, Literal: "", Offset: 45, Line: 3, Col: 9},
+		{Type: WS, Literal: "", Offset: 47, Line: 3, Col: 11},
+		{Type: RANGE, Literal: "", Offset: 48, Line: 3, Col: 12},
+		{Type: WS, Literal: "", Offset: 53, Line: 3, Col: 17},
+		{Type: IDENT, Literal: "m", Offset: 54, Line: 3, Col: 18},
+		{Type: NL, Literal: "", Offset: 55, Line: 3, Col: 19},
 
-		{Type: IDENT, Literal: "print", Offset: 68, Line: 4, Col: 5},
-		{Type: IDENT, Literal: "key", Offset: 74, Line: 4, Col: 11},
-		{Type: IDENT, Literal: "m", Offset: 78, Line: 4, Col: 15},
-		{Type: LBRACKET, Literal: "", Offset: 79, Line: 4, Col: 16},
-		{Type: IDENT, Literal: "key", Offset: 80, Line: 4, Col: 17},
-		{Type: RBRACKET, Literal: "", Offset: 83, Line: 4, Col: 20},
-		{Type: COMMENT, Literal: "// Mali climbing", Offset: 85, Line: 4, Col: 22},
-		{Type: NL, Literal: "", Offset: 101, Line: 4, Col: 38},
+		{Type: WS, Literal: "", Offset: 56, Line: 4, Col: 1},
+		{Type: IDENT, Literal: "print", Offset: 60, Line: 4, Col: 5},
+		{Type: WS, Literal: "", Offset: 65, Line: 4, Col: 10},
+		{Type: IDENT, Literal: "key", Offset: 66, Line: 4, Col: 11},
+		{Type: WS, Literal: "", Offset: 69, Line: 4, Col: 14},
+		{Type: IDENT, Literal: "m", Offset: 70, Line: 4, Col: 15},
+		{Type: LBRACKET, Literal: "", Offset: 71, Line: 4, Col: 16},
+		{Type: IDENT, Literal: "key", Offset: 72, Line: 4, Col: 17},
+		{Type: RBRACKET, Literal: "", Offset: 75, Line: 4, Col: 20},
+		{Type: WS, Literal: "", Offset: 76, Line: 4, Col: 21},
+		{Type: COMMENT, Literal: "// Mali climbing", Offset: 77, Line: 4, Col: 22},
+		{Type: NL, Literal: "", Offset: 93, Line: 4, Col: 38},
 
-		{Type: END, Literal: "", Offset: 102, Line: 5, Col: 1},
-		{Type: NL, Literal: "", Offset: 105, Line: 5, Col: 4},
+		{Type: END, Literal: "", Offset: 94, Line: 5, Col: 1},
+		{Type: NL, Literal: "", Offset: 97, Line: 5, Col: 4},
 
 		{Type: EOF, Literal: "", Offset: len(in), Line: 6, Col: 1},
 	}
@@ -247,10 +273,10 @@ func TestIllegal(t *testing.T) {
 		in   string
 		want Token
 	}{
-		{in: "  , ", want: Token{Offset: 2, Literal: ",", Line: 1, Col: 3}},
+		{in: ",  ", want: Token{Offset: 0, Literal: ",", Line: 1, Col: 1}},
 		{in: `"unterminated`, want: Token{Offset: 0, Literal: `"`, Line: 1, Col: 1}},
-		{in: ` "newline in the
-		middle "`, want: Token{Offset: 1, Literal: `"`, Line: 1, Col: 2}},
+		{in: `"newline in the
+		middle "`, want: Token{Offset: 0, Literal: `"`, Line: 1, Col: 1}},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -269,10 +295,8 @@ func TestRun(t *testing.T) {
 	}{
 		{in: ":=", want: "DECLARE\n"},
 		{in: "", want: ""},
-		{in: "  ", want: ""},
 		{in: "\n", want: "NL\n"},
-		{in: " \n ", want: "NL\n"},
-		{in: ` "abc"`, want: "STRING_LIT 'abc'\n"},
+		{in: ` "abc"`, want: "WS\nSTRING_LIT 'abc'\n"},
 		{in: ",", want: "ILLEGAL 💥 ',' at line 1 column 1\n"},
 		{in: `"asdf `, want: "ILLEGAL 💥 '\"' at line 1 column 1\n"},
 	}
@@ -282,6 +306,26 @@ func TestRun(t *testing.T) {
 		t.Run(tt.in, func(t *testing.T) {
 			got := Run(tt.in)
 			want := tt.want + "EOF\n"
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestRunWS(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: ":= ", want: "DECLARE\n"},
+		{in: "  ", want: ""},
+		{in: " \n ", want: "WS\nNL\n"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.in, func(t *testing.T) {
+			got := Run(tt.in)
+			want := tt.want + "WS\nEOF\n"
 			assert.Equal(t, want, got)
 		})
 	}

--- a/pkg/lexer/token.go
+++ b/pkg/lexer/token.go
@@ -50,6 +50,7 @@ const (
 	RCURLY   // }
 
 	COLON // :
+	WS    // ' '
 	NL    // '\n'
 	DOT   // .
 	DOT3  // ...
@@ -134,6 +135,7 @@ var tokenStrings = map[TokenType]tokenString{
 	NOT_EQ:     {string: "NOT_EQ", format: "!="},
 	COLON:      {string: "COLON", format: ":"},
 	NL:         {string: "NL", format: "\n"},
+	WS:         {string: "WS", format: " "},
 	LPAREN:     {string: "LPAREN", format: "("},
 	RPAREN:     {string: "RPAREN", format: ")"},
 	LBRACKET:   {string: "LBRACKET", format: "["},

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -82,9 +82,9 @@ func (p *Parser) parseExpr(scope *scope, prec precedence) Node {
 		case isBinaryOp(tt):
 			left = p.parseBinaryExpr(scope, left)
 		case tt == lexer.LBRACKET:
-			left = p.parserIndexOrSliceExpr(scope, left, true)
+			left = p.parseIndexOrSliceExpr(scope, left, true)
 		case tt == lexer.DOT:
-			left = p.parserDotExpr(left)
+			left = p.parseDotExpr(left)
 		default:
 			return left
 		}
@@ -160,7 +160,7 @@ func (p *Parser) parseGroupedExpr(scope *scope) Node {
 	return exp
 }
 
-func (p *Parser) parserIndexOrSliceExpr(scope *scope, left Node, allowSlice bool) Node {
+func (p *Parser) parseIndexOrSliceExpr(scope *scope, left Node, allowSlice bool) Node {
 	p.pushWSS(false)
 	defer p.popWSS()
 	tok := p.cur
@@ -236,7 +236,7 @@ func (p *Parser) parseSlice(scope *scope, tok *lexer.Token, left, start Node) No
 	return &SliceExpression{Token: tok, Left: left, Start: start, End: end, T: t}
 }
 
-func (p *Parser) parserDotExpr(left Node) Node {
+func (p *Parser) parseDotExpr(left Node) Node {
 	tok := p.cur
 	if p.lookAt(p.pos-1).Type == lexer.WS {
 		p.appendError("unexpected whitespace before '.'")

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -74,7 +74,7 @@ func (p *Parser) parseExpr(scope *scope, prec precedence) Node {
 	case lexer.LPAREN:
 		left = p.parseGroupedExpr(scope)
 	default:
-		p.appendError("unexpected " + p.cur.FormatDetails())
+		p.unexpectedLeftTokenError()
 	}
 	for left != nil && !p.isAtExprEnd() && prec < precedences[p.cur.Type] {
 		tt := p.cur.Type
@@ -92,14 +92,37 @@ func (p *Parser) parseExpr(scope *scope, prec precedence) Node {
 	return left // nil for previous error
 }
 
+func (p *Parser) unexpectedLeftTokenError() {
+	if p.isWSS() {
+		tt := p.cur.Type
+		prevTT := p.lookAt(p.pos - 1).Type
+		if isBinaryOp(tt) && prevTT == lexer.WS {
+			p.appendError("unexpected whitespace before " + p.cur.FormatDetails())
+			return
+		}
+		if tt == lexer.WS && isBinaryOp(prevTT) {
+			prevToken := p.lookAt(p.pos - 1)
+			p.appendErrorForToken("unexpected whitespace after "+prevToken.FormatDetails(), prevToken)
+			return
+		}
+	}
+	p.appendError("unexpected " + p.cur.FormatDetails())
+}
+
 func (p *Parser) isAtExprEnd() bool {
-	return p.isAtEOL() // TODO: in WS mode include WS.
+	if p.isWSS() && p.cur.Type == lexer.WS {
+		return true
+	}
+	return p.isAtEOL()
 }
 
 func (p *Parser) parseUnaryExpr(scope *scope) Node {
 	tok := p.cur
 	unaryExp := &UnaryExpression{Token: tok, Op: op(tok)}
 	p.advance() // advance past operator
+	if p.lookAt(p.pos-1).Type == lexer.WS {
+		p.appendErrorForToken("unexpected whitespace after '"+unaryExp.Op.String()+"'", tok)
+	}
 	unaryExp.Right = p.parseExpr(scope, UNARY)
 	if unaryExp.Right == nil {
 		return nil // previous error
@@ -126,6 +149,8 @@ func (p *Parser) parseBinaryExpr(scope *scope, left Node) Node {
 }
 
 func (p *Parser) parseGroupedExpr(scope *scope) Node {
+	p.pushWSS(false)
+	defer p.popWSS()
 	p.advance() // advance past (
 	exp := p.parseTopLevelExpr(scope)
 	if !p.assertToken(lexer.RPAREN) {
@@ -136,8 +161,14 @@ func (p *Parser) parseGroupedExpr(scope *scope) Node {
 }
 
 func (p *Parser) parserIndexOrSliceExpr(scope *scope, left Node, allowSlice bool) Node {
-	tok := p.cur // TODO: ensure not prefixed by WS
-	p.advance()  // advance past [
+	p.pushWSS(false)
+	defer p.popWSS()
+	tok := p.cur
+	if p.lookAt(p.pos-1).Type == lexer.WS {
+		p.appendError("unexpected whitespace before '['")
+		return nil
+	}
+	p.advance() // advance past [
 	leftType := left.Type().Name
 	if leftType != ARRAY && leftType != MAP && leftType != STRING {
 		p.appendErrorForToken("only array, string and map type can be indexed found "+left.Type().Format(), tok)
@@ -206,8 +237,16 @@ func (p *Parser) parseSlice(scope *scope, tok *lexer.Token, left, start Node) No
 }
 
 func (p *Parser) parserDotExpr(left Node) Node {
-	tok := p.cur // TODO: ensure not prefixed by WS
-	p.advance()  // advance past .
+	tok := p.cur
+	if p.lookAt(p.pos-1).Type == lexer.WS {
+		p.appendError("unexpected whitespace before '.'")
+		return nil
+	}
+	if p.lookAt(p.pos+1).Type == lexer.WS {
+		p.appendError("unexpected whitespace after '.'")
+		return nil
+	}
+	p.advance() // advance past .
 	leftType := left.Type().Name
 	if leftType != MAP {
 		p.appendErrorForToken("field access with '.' expects map type, found "+left.Type().Format(), tok)
@@ -310,8 +349,10 @@ func (p *Parser) parseLiteral(scope *scope) Node {
 
 func (p *Parser) parseArrayLiteral(scope *scope) Node {
 	tok := p.cur
-	p.advance() // advance past [
+	p.advance()     // advance past [
+	p.advanceIfWS() // allow whitespace after `[`, eg [ 1 2 3 ]
 	elements := p.parseExprList(scope)
+
 	if elements == nil {
 		return nil // previous error
 	}
@@ -334,14 +375,21 @@ func (p *Parser) parseExprList(scope *scope) []Node {
 	list := []Node{}
 	tt := p.cur.TokenType()
 	for !p.isAtEOL() && tt != lexer.RPAREN && tt != lexer.RBRACKET {
-		n := p.parseExpr(scope, LOWEST)
+		n := p.parseExprWSS(scope, LOWEST)
 		if n == nil {
 			return nil // previous error
 		}
 		list = append(list, n)
+		p.advanceIfWS()
 		tt = p.cur.TokenType()
 	}
 	return list
+}
+
+func (p *Parser) parseExprWSS(scope *scope, prec precedence) Node {
+	p.pushWSS(true)
+	defer p.popWSS()
+	return p.parseExpr(scope, prec)
 }
 
 func (p *Parser) combineTypes(types []*Type) *Type {
@@ -360,6 +408,8 @@ func (p *Parser) combineTypes(types []*Type) *Type {
 }
 
 func (p *Parser) parseMapLiteral(scope *scope) Node {
+	p.pushWSS(false)
+	defer p.popWSS()
 	tok := p.cur
 	p.advance() // advance past {
 	pairs, order := p.parseMapPairs(scope)
@@ -399,7 +449,7 @@ func (p *Parser) parseMapPairs(scope *scope) (map[string]Node, []string) {
 		p.assertToken(lexer.COLON)
 		p.advance() // advance past COLON
 
-		n := p.parseExpr(scope, LOWEST)
+		n := p.parseExprWSS(scope, LOWEST)
 		if n == nil {
 			return nil, nil // previous error
 		}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -195,6 +195,9 @@ func (p *Parser) parseStatement(scope *scope) Node {
 	case lexer.NL, lexer.EOF, lexer.COMMENT:
 		p.advancePastNL()
 		return nil
+	case lexer.WS:
+		p.advance()
+		return nil
 	case lexer.IDENT:
 		switch p.peek.Type {
 		case lexer.ASSIGN, lexer.DOT:
@@ -519,6 +522,17 @@ func (p *Parser) parseBlockWithEndTokens(scope *scope, endTokens map[lexer.Token
 }
 
 func (p *Parser) advance() {
+	p.advanceWSS()
+	if p.cur.Type == lexer.WS {
+		p.advanceWSS()
+	}
+	if p.peek.Type == lexer.WS {
+		p.peek = p.lookAt(p.pos + 2)
+	}
+}
+
+// advanceWSS advances to the next token in whitespace sensitive (wss) manner.
+func (p *Parser) advanceWSS() {
 	p.pos++
 	p.cur = p.lookAt(p.pos)
 	p.peek = p.lookAt(p.pos + 1)
@@ -528,6 +542,9 @@ func (p *Parser) advanceTo(pos int) {
 	p.pos = pos
 	p.cur = p.lookAt(pos)
 	p.peek = p.lookAt(pos + 1)
+	if p.peek.Type == lexer.WS {
+		p.peek = p.lookAt(p.pos + 2)
+	}
 }
 
 func (p *Parser) lookAt(pos int) *lexer.Token {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -280,10 +280,10 @@ func (p *Parser) parseAssignmentTarget(scope *scope) Node {
 				p.appendErrorForToken("cannot index string on left side of '=', only on right", tok)
 				return nil
 			}
-			n = p.parserIndexOrSliceExpr(scope, n, false)
+			n = p.parseIndexOrSliceExpr(scope, n, false)
 		}
 		if p.cur.TokenType() == lexer.DOT {
-			n = p.parserDotExpr(n)
+			n = p.parseDotExpr(n)
 		}
 		tt = p.cur.TokenType()
 	}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -937,12 +937,17 @@ end
 for x := range 1 2 3 4
 	print "X"
 end
-`: "line 2 column 22: expected end of line, found 4",
+`: "line 2 column 10: range can take up to 3 num arguments, found 4",
 		`
 for x := range true
 	print "X"
 end
 `: "line 2 column 20: expected num, string, array or map after range, found bool",
+		`
+for x := range 1 true
+	print "X"
+end
+`: "line 2 column 10: range expects num type for 2nd argument, found bool",
 	}
 	for input, wantErr := range inputs {
 		parser := New(input, testBuiltins())


### PR DESCRIPTION
Update lexer to emit single WS token for horizontal whitespace.

Implement whitespace sensitivity in parser: 

1. Disallow whitespace after unary operator 
2. Disallow whitespace within the expressions of a list:
  - argument list of function call
  - elements of an array literal
  - values of map literal 
3. Regardless of context, allow whitespace within (), [] and {}