### PR TITLE
parser: Rename PREFIX to UNARY in precedence enum

### DIFF
--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -24,7 +24,7 @@ const (
 	LESSGREATER            // > or <
 	SUM                    // +
 	PRODUCT                // *
-	PREFIX                 // -x  !x
+	UNARY                  // -x  !x
 	INDEX                  // array[i]
 )
 
@@ -100,7 +100,7 @@ func (p *Parser) parseUnaryExpr(scope *scope) Node {
 	tok := p.cur
 	unaryExp := &UnaryExpression{Token: tok, Op: op(tok)}
 	p.advance() // advance past operator
-	unaryExp.Right = p.parseExpr(scope, PREFIX)
+	unaryExp.Right = p.parseExpr(scope, UNARY)
 	if unaryExp.Right == nil {
 		return nil // previous error
 	}


### PR DESCRIPTION
Rename `PREFIX` to `UNARY` in precedence enum. This has been an oversight
when renaming prefix to unary and infix to binary earlier on during the
Pratt parser implementation.