### PR TITLE
evaluator: Add expression evaluation for basic types

### DIFF
--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -109,7 +109,7 @@ func (e *Evaluator) evalAssignment(scope *scope, assignment *parser.Assignment) 
 }
 
 func (e *Evaluator) evalFunctionCall(scope *scope, funcCall *parser.FunctionCall) Value {
-	args := e.evalExpressions(scope, funcCall.Arguments)
+	args := e.evalExprList(scope, funcCall.Arguments)
 	if len(args) == 1 && isError(args[0]) {
 		return args[0]
 	}
@@ -201,7 +201,7 @@ func (e *Evaluator) evalVar(scope *scope, v *parser.Var) Value {
 	return newError("cannot find variable " + v.Name)
 }
 
-func (e *Evaluator) evalExpressions(scope *scope, terms []parser.Node) []Value {
+func (e *Evaluator) evalExprList(scope *scope, terms []parser.Node) []Value {
 	result := make([]Value, len(terms))
 
 	for i, t := range terms {

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -262,6 +262,35 @@ end
 	assert.Equal(t, "🍭\n🎈\n🎈\n", b.String())
 }
 
+func TestExpr(t *testing.T) {
+	tests := map[string]string{
+		"a := 1 + 2 * 2":                    "5",
+		"a := (1 + 2) * 2":                  "6",
+		"a := (1 + 2) / 2":                  "1.5",
+		"a := (1 + 2) / 2 > 1":              "true",
+		"a := (1 + 2) / 2 > 1 and 2 == 2*2": "false",
+		"a := (1 + 2) / 2 < 1 or 2 == 2*2":  "false",
+		"a := (1 + 2) / 2 < 1 or 2 != 2*2":  "true",
+		`a := "abc" + "d"`:                  "abcd",
+		`a := "abc" + "d" < "efg"`:          "true",
+		`a := "abc" + "d" == "abcd"`:        "true",
+		`a := "abc" + "d" != "abcd"`:        "false",
+		`a := !(1 == 1)`:                    "false",
+		`a := -(3 + 5)`:                     "-8",
+		`a := -3 +5`:                        "2",
+	}
+	for in, want := range tests {
+		in, want := in, want
+		t.Run(in, func(t *testing.T) {
+			in += "\n print a"
+			b := bytes.Buffer{}
+			fn := func(s string) { b.WriteString(s) }
+			Run(in, fn)
+			assert.Equal(t, want+"\n", b.String())
+		})
+	}
+}
+
 func TestDemo(t *testing.T) {
 	prog := `
 move 10 10
@@ -269,7 +298,7 @@ line 20 20
 
 x := 12
 print "x:" x
-if true //TODO: x > 10
+if x > 10
     print "🍦 big x"
 end`
 	b := bytes.Buffer{}


### PR DESCRIPTION
Add expression evaluation for basic types, including arithmetic operations,
logical operations, comparison operations, string concatenations, unary
operators and grouping with (). Still outstanding are all array and map
operations.