### PR TITLE
evaluator: Add index and dot expression evaluation

### DIFF
--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -67,7 +67,7 @@ func lenFunc(args []Value) Value {
 	case *Map:
 		return &Num{Val: float64(len(arg.Pairs))}
 	case *Array:
-		return &Num{Val: float64(len(arg.Elements))}
+		return &Num{Val: float64(len(*arg.Elements))}
 	case *String:
 		return &Num{Val: float64(len(arg.Val))}
 	}

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -120,7 +120,7 @@ func (e *Evaluator) evalArrayLiteral(scope *scope, arr *parser.ArrayLiteral) Val
 	if len(elements) == 1 && isError(elements[0]) {
 		return elements[0]
 	}
-	return &Array{Elements: elements}
+	return &Array{Elements: &elements}
 }
 
 func (e *Evaluator) evalMapLiteral(scope *scope, m *parser.MapLiteral) Value {
@@ -132,7 +132,9 @@ func (e *Evaluator) evalMapLiteral(scope *scope, m *parser.MapLiteral) Value {
 		}
 		pairs[key] = val
 	}
-	return &Map{Pairs: pairs, Order: m.Order}
+	order := make([]string, len(m.Order))
+	copy(order, m.Order)
+	return &Map{Pairs: pairs, Order: &order}
 }
 
 func (e *Evaluator) evalFunctionCall(scope *scope, funcCall *parser.FunctionCall) Value {
@@ -158,7 +160,7 @@ func innerScopeWithArgs(scope *scope, fd *parser.FuncDecl, args []Value) *scope 
 		scope.set(param.Name, args[i])
 	}
 	if fd.VariadicParam != nil {
-		varArg := &Array{Elements: args}
+		varArg := &Array{Elements: &args}
 		scope.set(fd.VariadicParam.Name, varArg)
 	}
 	return scope

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -287,13 +287,13 @@ func (e *Evaluator) evalBinaryExpr(scope *scope, expr *parser.BinaryExpression) 
 	if op == parser.OP_NOT_EQ {
 		return &Bool{Val: !left.Equals(right)}
 	}
-	switch left := left.(type) {
+	switch l := left.(type) {
 	case *Num:
-		return evalBinaryNumExpr(op, left, right.(*Num))
+		return evalBinaryNumExpr(op, l, right.(*Num))
 	case *String:
-		return evalBinaryStringExpr(op, left, right.(*String))
+		return evalBinaryStringExpr(op, l, right.(*String))
 	case *Bool:
-		return evalBinaryBoolExpr(op, left, right.(*Bool))
+		return evalBinaryBoolExpr(op, l, right.(*Bool))
 	}
 	return newError("unknown binary operation: " + expr.String())
 }

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -317,6 +317,60 @@ a := [1 1+1 (three)]`: "[1 2 3]",
 	}
 }
 
+func TestIndex(t *testing.T) {
+	tests := map[string]string{
+		// x := ["a","b","c"]; x = "abc"
+		"print x[0]":  "a",
+		"print x[1]":  "b",
+		"print x[2]":  "c",
+		"print x[-1]": "c",
+		"print x[-2]": "b",
+		"print x[-3]": "a",
+		`
+		n1 := 1
+		print x[n1 - 1] x[1 + n1]
+		`: "a c",
+		`
+		m := {a: "bingo"}
+		print m[x[0]]
+		`: "bingo",
+	}
+	for in, want := range tests {
+		in, want := in, want
+		for _, decl := range []string{`x := ["a" "b" "c"]`, `x := "abc"`} {
+			input := decl + "\n" + in
+			t.Run(input, func(t *testing.T) {
+				b := bytes.Buffer{}
+				fn := func(s string) { b.WriteString(s) }
+				Run(input, fn)
+				assert.Equal(t, want+"\n", b.String())
+			})
+		}
+	}
+}
+
+func TestIndexErr(t *testing.T) {
+	tests := map[string]string{
+		// x := ["a","b","c"]; x = "abc"
+		"print x[3]":  "ERROR: index 3 out of bounds, should be between -3 and 2",
+		"print x[-4]": "ERROR: index -4 out of bounds, should be between -3 and 2",
+		`m := {}
+		print m[x[1]]`: "ERROR: no value for key b",
+	}
+	for in, want := range tests {
+		in, want := in, want
+		for _, decl := range []string{`x := ["a" "b" "c"]`, `x := "abc"`} {
+			input := decl + "\n" + in
+			t.Run(input, func(t *testing.T) {
+				b := bytes.Buffer{}
+				fn := func(s string) { b.WriteString(s) }
+				Run(input, fn)
+				assert.Equal(t, want, b.String())
+			})
+		}
+	}
+}
+
 func TestMapLit(t *testing.T) {
 	tests := map[string]string{
 		"a := {n:1}":                 "{n:1}",
@@ -342,6 +396,38 @@ a := {name:"fox" age:39+(three)}`: "{name:fox age:42}",
 			assert.Equal(t, want+"\n", b.String())
 		})
 	}
+}
+
+func TestDot(t *testing.T) {
+	tests := map[string]string{
+		// m := {name: "Greta"}
+		"print m.name":    "Greta",
+		`print m["name"]`: "Greta",
+		`s := "name"
+		print m[s]`: "Greta",
+	}
+	for in, want := range tests {
+		in, want := in, want
+		input := `m := {name: "Greta"}` + "\n" + in
+		t.Run(input, func(t *testing.T) {
+			b := bytes.Buffer{}
+			fn := func(s string) { b.WriteString(s) }
+			Run(input, fn)
+			assert.Equal(t, want+"\n", b.String())
+		})
+	}
+}
+
+func TestDotErr(t *testing.T) {
+	in := `
+m := {a:1}
+print m.missing_index
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(in, fn)
+	want := "ERROR: no value for key missing_index"
+	assert.Equal(t, want, b.String())
 }
 
 func TestDemo(t *testing.T) {

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -144,7 +144,6 @@ f1 = f3
 f2 = f1
 f3 = 4
 print f1 f2 f3
-
 `
 	b := bytes.Buffer{}
 	fn := func(s string) { b.WriteString(s) }

--- a/pkg/evaluator/scope.go
+++ b/pkg/evaluator/scope.go
@@ -23,16 +23,6 @@ func (s *scope) get(name string) (Value, bool) {
 	return s.outer.get(name)
 }
 
-func (s *scope) getScope(name string) (*scope, bool) {
-	if s == nil {
-		return nil, false
-	}
-	if _, ok := s.values[name]; ok {
-		return s, true
-	}
-	return s.outer.getScope(name)
-}
-
 func (s *scope) set(name string, val Value) {
 	s.values[name] = val
 }

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -69,12 +69,12 @@ type Any struct {
 }
 
 type Array struct {
-	Elements []Value
+	Elements *[]Value
 }
 
 type Map struct {
 	Pairs map[string]Value
-	Order []string
+	Order *[]string
 }
 
 type ReturnValue struct {
@@ -166,8 +166,8 @@ func (e *Error) Set(_ Value)         {}
 
 func (a *Array) Type() ValueType { return ARRAY }
 func (a *Array) String() string {
-	elements := make([]string, len(a.Elements))
-	for i, e := range a.Elements {
+	elements := make([]string, len(*a.Elements))
+	for i, e := range *a.Elements {
 		elements[i] = e.String()
 	}
 	return "[" + strings.Join(elements, " ") + "]"
@@ -175,11 +175,12 @@ func (a *Array) String() string {
 
 func (a *Array) Equals(v Value) bool {
 	if a2, ok := v.(*Array); ok {
-		if len(a.Elements) != len(a2.Elements) {
+		if len(*a.Elements) != len(*a2.Elements) {
 			return false
 		}
-		for i, e := range a.Elements {
-			e2 := a2.Elements[i]
+		elements2 := *a2.Elements
+		for i, e := range *a.Elements {
+			e2 := elements2[i]
 			if !e.Equals(e2) {
 				return false
 			}
@@ -198,7 +199,7 @@ func (a *Array) Set(v Value) {
 func (m *Map) Type() ValueType { return MAP }
 func (m *Map) String() string {
 	pairs := make([]string, 0, len(m.Pairs))
-	for _, key := range m.Order {
+	for _, key := range *m.Order {
 		pairs = append(pairs, key+":"+m.Pairs[key].String())
 	}
 	return "{" + strings.Join(pairs, " ") + "}"

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -144,6 +144,9 @@ func (p *Parser) parserIndexExpr(scope *scope, left Node) Node {
 		return nil
 	}
 	index := p.parseTopLevelExpr(scope)
+	if index == nil {
+		return nil
+	}
 	if !p.assertToken(lexer.RBRACKET) {
 		return nil
 	}

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -157,7 +157,11 @@ func (p *Parser) parserIndexExpr(scope *scope, left Node) Node {
 		p.appendError("map index expects string, found " + index.Type().Format())
 		return nil
 	}
-	return &IndexExpression{Token: tok, Left: left, Index: index, T: left.Type().Sub}
+	t := left.Type().Sub
+	if leftType == STRING {
+		t = STRING_TYPE
+	}
+	return &IndexExpression{Token: tok, Left: left, Index: index, T: t}
 }
 
 func (p *Parser) parserDotExpr(left Node) Node {

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -67,6 +67,7 @@ func TestParseTopLevelExpression(t *testing.T) {
 		`print (len "abc") 2`:         "print(len('abc'), 2)",
 		`print (len "abc") (len "x")`: "print(len('abc'), len('x'))",
 		`print s[1]`:                  "print((s[1]))",
+		"print map2[s]":               "print((map2[s]))",
 
 		// Index expression
 		"arr[1]":        "(arr[1])",
@@ -88,6 +89,7 @@ func TestParseTopLevelExpression(t *testing.T) {
 		"map3.ok[n1]":      "((map3.ok)[n1])",
 		"list[1].x":        "((list[1]).x)",
 		"list[n1][s]":      "((list[n1])[s])",
+		"map2[s]":          "(map2[s])",
 
 		// Array literals
 		"[]":          "[]",

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -66,6 +66,7 @@ func TestParseTopLevelExpression(t *testing.T) {
 		`print 1 (len "abc") 2`:       "print(1, len('abc'), 2)",
 		`print (len "abc") 2`:         "print(len('abc'), 2)",
 		`print (len "abc") (len "x")`: "print(len('abc'), len('x'))",
+		`print s[1]`:                  "print((s[1]))",
 
 		// Index expression
 		"arr[1]":        "(arr[1])",
@@ -76,6 +77,7 @@ func TestParseTopLevelExpression(t *testing.T) {
 		"map[s]":        "(map[s])",
 		`map["key"]`:    "(map['key'])",
 		`"abc"[1]`:      "('abc'[1])",
+		`s[1]`:          "(s[1])",
 
 		// Map access - dot expressions
 		"map.key":          "(map.key)",

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -79,6 +79,10 @@ func TestParseDeclarationError(t *testing.T) {
 		"a := {}[":      "line 1 column 9: unexpected end of input",
 		"a :num num":    "line 1 column 8: expected end of line, found 'num'",
 		"a :num{}num":   "line 1 column 7: expected end of line, found '{'",
+		`
+m := {name: "Greta"}
+s := name
+print m[s]`: "line 3 column 6: unknown variable name 'name'",
 	}
 	for input, err1 := range tests {
 		parser := New(input, testBuiltins())


### PR DESCRIPTION
Add index and dot expression evaluation in evaluator, similar to binary
expression evaluation.

Change Array.Elements and Map.Order to pointer. This is another preparatory
step for proper array and map manipulation so that two variables may
reference the same array or map and if one gets updated the other one will
get updated too.

Rework scoped Value updates such that instead of replacing the value in the
scope on assignment with scope.set(name, newValue), we now update the Value
field with scope.get(name).Set(newValue)

---

The first three commits are covered by PRs #37 and #38 .