### PR TITLE
evaluator: Array concatenation

### DIFF
--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -294,6 +294,8 @@ func (e *Evaluator) evalBinaryExpr(scope *scope, expr *parser.BinaryExpression) 
 		return evalBinaryStringExpr(op, l, right.(*String))
 	case *Bool:
 		return evalBinaryBoolExpr(op, l, right.(*Bool))
+	case *Array:
+		return evalBinaryArrayExpr(op, l, right.(*Array))
 	}
 	return newError("unknown binary operation: " + expr.String())
 }
@@ -344,6 +346,16 @@ func evalBinaryBoolExpr(op parser.Operator, left, right *Bool) Value {
 		return &Bool{Val: left.Val || right.Val}
 	}
 	return newError("unknown bool operation: " + op.String())
+}
+
+func evalBinaryArrayExpr(op parser.Operator, left, right *Array) Value {
+	if op != parser.OP_PLUS {
+		return newError("unknown array operation: " + op.String())
+	}
+	result := left.Copy()
+	rightElemnts := *right.Copy().Elements
+	*result.Elements = append(*result.Elements, rightElemnts...)
+	return result
 }
 
 func (e *Evaluator) evalIndexExpr(scope *scope, expr *parser.IndexExpression) Value {

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -2,6 +2,7 @@ package evaluator
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"foxygo.at/evy/pkg/assert"
@@ -428,6 +429,54 @@ print m.missing_index
 	Run(in, fn)
 	want := "ERROR: no value for key missing_index"
 	assert.Equal(t, want, b.String())
+}
+
+func TestArrayConcatenation(t *testing.T) {
+	prog := `
+arr1 := [1]
+arr2 := arr1
+arr3 := arr1 + arr1
+arr4 := arr1 + [2]
+arr5 := arr1 + []
+arr6 := [] + []
+print "1 arr1" arr1
+print "1 arr2" arr2
+print "1 arr3" arr3
+print "1 arr4" arr4
+print "1 arr5" arr5
+print "1 arr6" arr6
+print
+
+arr1[0] = 2
+print "2 arr1" arr1
+print "2 arr2" arr2
+print "2 arr3" arr3
+print "2 arr4" arr4
+print "2 arr5" arr5
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := []string{
+		"1 arr1 [1]",
+		"1 arr2 [1]",
+		"1 arr3 [1 1]",
+		"1 arr4 [1 2]",
+		"1 arr5 [1]",
+		"1 arr6 []",
+		"",
+		"2 arr1 [2]",
+		"2 arr2 [2]",
+		"2 arr3 [1 1]",
+		"2 arr4 [1 2]",
+		"2 arr5 [1]",
+		"",
+	}
+	got := strings.Split(b.String(), "\n")
+	assert.Equal(t, len(want), len(got), b.String())
+	for i := range want {
+		assert.Equal(t, want[i], got[i])
+	}
 }
 
 func TestDemo(t *testing.T) {

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -217,6 +217,33 @@ func (a *Array) Index(idx Value) Value {
 	return elements[i]
 }
 
+func (a *Array) Copy() *Array {
+	elements := make([]Value, len(*a.Elements))
+	for i, v := range *a.Elements {
+		elements[i] = passedVal(v)
+	}
+	return &Array{Elements: &elements}
+}
+
+// passedVal is a pass by reference or copy of the value depending on type.
+func passedVal(val Value) Value {
+	switch v := val.(type) {
+	case *Num:
+		return &Num{Val: v.Val}
+	case *String:
+		return &String{Val: v.Val}
+	case *Bool:
+		return &Bool{Val: v.Val}
+	case *Any:
+		return &Any{Val: passedVal(v.Val)}
+	case *Array:
+		return v
+	case *Map:
+		return v
+	}
+	return nil // TODO: panic
+}
+
 func (m *Map) Type() ValueType { return MAP }
 func (m *Map) String() string {
 	pairs := make([]string, 0, len(m.Pairs))

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -219,7 +219,7 @@ func (p *Parser) validateBinaryType(binaryExp *BinaryExpression) {
 
 	leftType := binaryExp.Left.Type()
 	rightType := binaryExp.Right.Type()
-	if !leftType.Equals(rightType) {
+	if !leftType.Matches(rightType) {
 		p.appendErrorForToken("mismatched type for "+op.String()+": "+leftType.Format()+", "+rightType.Format(), tok)
 		return
 	}

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -124,6 +124,14 @@ func TestParseTopLevelExpression(t *testing.T) {
 		"{a: [1] b:2+n2 c: 1+2}": "{a:[1], b:(2+n2), c:(1+2)}",
 		"{a: 1}.a":               "({a:1}.a)",
 		`{a: 1}["a"]`:            "({a:1}['a'])",
+
+		// Array concatenation
+		"[1] + [2]":            "([1]+[2])",
+		"[true] + [false]":     "([true]+[false])",
+		"[1 true] + [2 false]": "([1, true]+[2, false])",
+		"[1] + []":             "([1]+[])",
+		"[] + [1]":             "([]+[1])",
+		"[] + []":              "([]+[])",
 	}
 	for input, want := range tests {
 		parser := New(input, testBuiltins())
@@ -179,9 +187,10 @@ func TestParseTopLevelExpressionErr(t *testing.T) {
 		`[1 2 3]["a"]`: "line 1 column 13: array index expects num, found string",
 		"{a:2}[2]":     "line 1 column 9: map index expects string, found num",
 
-		"{a:}":    "line 1 column 4: unexpected '}'",
-		"{:a}":    "line 1 column 2: expected map key, found ':'",
-		"[1 [2]]": "line 1 column 4: only array, string and map type can be indexed, found num",
+		"{a:}": "line 1 column 4: unexpected '}'",
+		"{:a}": "line 1 column 2: expected map key, found ':'",
+
+		"[1] + [false]": "line 1 column 5: mismatched type for +: num[], bool[]",
 	}
 	for input, wantErr := range tests {
 		parser := New(input, testBuiltins())

--- a/pkg/parser/type.go
+++ b/pkg/parser/type.go
@@ -104,7 +104,7 @@ func (t *Type) Accepts(t2 *Type) bool {
 	return false
 }
 
-func (t *Type) Equals(t2 *Type) bool {
+func (t *Type) Matches(t2 *Type) bool {
 	if t == t2 {
 		return true
 	}
@@ -117,7 +117,10 @@ func (t *Type) Equals(t2 *Type) bool {
 	if t.Sub == nil || t2.Sub == nil {
 		return false
 	}
-	return t.Sub.Equals(t2.Sub)
+	if t == EMPTY_ARRAY || t == EMPTY_MAP || t2 == EMPTY_ARRAY || t2 == EMPTY_MAP {
+		return true
+	}
+	return t.Sub.Matches(t2.Sub)
 }
 
 func (t *Type) Infer() *Type {


### PR DESCRIPTION
Add array concatenation for `+` operator. Ensure a copy of both operands is
made.

Fix parse error for array concatenation with empty arrays.

---

Only the last two commits of this PR are relevant. The rest depends on merging PRs 36-39.