### PR TITLE
go: Add slice expression

### DIFF
--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -69,6 +69,8 @@ func (e *Evaluator) Eval(scope *scope, node parser.Node) Value {
 		return e.evalBinaryExpr(scope, node)
 	case *parser.IndexExpression:
 		return e.evalIndexExpr(scope, node)
+	case *parser.SliceExpression:
+		return e.evalSliceExpr(scope, node)
 	case *parser.DotExpression:
 		return e.evalDotExpr(scope, node)
 	}
@@ -393,4 +395,26 @@ func (e *Evaluator) evalDotExpr(scope *scope, expr *parser.DotExpression) Value 
 		return newError("expected map before '.', found " + left.String())
 	}
 	return m.Get(expr.Key)
+}
+
+func (e *Evaluator) evalSliceExpr(scope *scope, expr *parser.SliceExpression) Value {
+	left := e.Eval(scope, expr.Left)
+	if isError(left) {
+		return left
+	}
+	start := e.Eval(scope, expr.Start)
+	if isError(start) {
+		return start
+	}
+	end := e.Eval(scope, expr.End)
+	if isError(end) {
+		return end
+	}
+	switch left := left.(type) {
+	case *Array:
+		return left.Slice(start, end)
+	case *String:
+		return left.Slice(start, end)
+	}
+	return newError("cannot slice " + left.String())
 }

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -504,6 +504,73 @@ print "2 arr5" arr5
 	}
 }
 
+func TestArraySlice(t *testing.T) {
+	prog := `
+arr := [1 2 3]
+print "1" arr[1:3]
+print "2" arr[1:]
+print "3" arr[1:2]
+print "4" arr[1:1]
+print "5" arr[:1]
+print
+
+arr2 := arr[:]
+arr2[0] = 11
+print "6" arr arr2
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := []string{
+		"1 [2 3]",
+		"2 [2 3]",
+		"3 [2]",
+		"4 []",
+		"5 [1]",
+		"",
+		"6 [1 2 3] [11 2 3]",
+		"",
+	}
+	got := strings.Split(b.String(), "\n")
+	assert.Equal(t, len(want), len(got), b.String())
+	for i := range want {
+		assert.Equal(t, want[i], got[i])
+	}
+}
+
+func TestStringSlice(t *testing.T) {
+	prog := `
+s := "abc"
+print "1" s[1:3]
+print "2" s[1:]
+print "3" s[1:2]
+print "4" s[1:1]
+print "5" s[:1]
+print
+
+s2 := "A" + s[1:]
+print "6" s s2
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := []string{
+		"1 bc",
+		"2 bc",
+		"3 b",
+		"4 ",
+		"5 a",
+		"",
+		"6 abc Abc",
+		"",
+	}
+	got := strings.Split(b.String(), "\n")
+	assert.Equal(t, len(want), len(got), b.String())
+	for i := range want {
+		assert.Equal(t, want[i], got[i])
+	}
+}
+
 func TestDemo(t *testing.T) {
 	prog := `
 move 10 10

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -45,6 +45,14 @@ type IndexExpression struct {
 	Index Node
 }
 
+type SliceExpression struct {
+	T     *Type
+	Token *lexer.Token // The [ token
+	Left  Node
+	Start Node
+	End   Node
+}
+
 type DotExpression struct {
 	T     *Type
 	Token *lexer.Token // The . token
@@ -196,6 +204,22 @@ func (i *IndexExpression) String() string {
 
 func (i *IndexExpression) Type() *Type {
 	return i.T
+}
+
+func (s *SliceExpression) String() string {
+	start := ""
+	if s.Start != nil {
+		start = s.Start.String()
+	}
+	end := ""
+	if s.End != nil {
+		end = s.End.String()
+	}
+	return "(" + s.Left.String() + "[" + start + ":" + end + "])"
+}
+
+func (s *SliceExpression) Type() *Type {
+	return s.T
 }
 
 func (d *DotExpression) String() string {

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -132,6 +132,12 @@ func TestParseTopLevelExpression(t *testing.T) {
 		"[1] + []":             "([1]+[])",
 		"[] + [1]":             "([]+[1])",
 		"[] + []":              "([]+[])",
+
+		// Slices
+		"arr[1:2]": "(arr[1:2])",
+		"arr[1:]":  "(arr[1:])",
+		"arr[:2]":  "(arr[:2])",
+		"arr[:]":   "(arr[:])",
 	}
 	for input, want := range tests {
 		parser := New(input, testBuiltins())
@@ -183,9 +189,9 @@ func TestParseTopLevelExpressionErr(t *testing.T) {
 		"(1+]2":        "line 1 column 4: unexpected ']'",
 		"(1+2]":        "line 1 column 5: expected ')', got ']'",
 
-		`"abc"["a"]`:   "line 1 column 11: string index expects num, found string",
-		`[1 2 3]["a"]`: "line 1 column 13: array index expects num, found string",
-		"{a:2}[2]":     "line 1 column 9: map index expects string, found num",
+		`"abc"["a"]`:   "line 1 column 6: string index expects num, found string",
+		`[1 2 3]["a"]`: "line 1 column 8: array index expects num, found string",
+		"{a:2}[2]":     "line 1 column 6: map index expects string, found num",
 
 		"{a:}": "line 1 column 4: unexpected '}'",
 		"{:a}": "line 1 column 2: expected map key, found ':'",

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -267,7 +267,11 @@ func (p *Parser) parseAssignmentTarget(scope *scope) Node {
 		return nil
 	}
 	if p.cur.TokenType() == lexer.LBRACKET { // TODO: check for whitespace
-		return p.parserIndexExpr(scope, v)
+		if v.Type() == STRING_TYPE {
+			p.appendErrorForToken("cannot index string on left side of '=', only on right", tok)
+			return nil
+		}
+		return p.parserIndexOrSliceExpr(scope, v, false)
 	}
 	if p.cur.TokenType() == lexer.DOT { // TODO: check for whitespace
 		return p.parserDotExpr(v)


### PR DESCRIPTION
Add slice parsing and evaluation for array and string. Ensure copy is made of array
elements when slicing. Dis-allow string indexing on left side of assignment:

    s := "abc"
    s[0] = "ABC" // doesn't make sense.