### PR TITLE
eval: Fix any's wrapping any's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ O = out
 COVERAGE = 80
 VERSION ?= $(shell git describe --tags --dirty  --always)
 
-all: build tiny test test-tiny check-coverage lint sh-lint frontend ## Build, test, check coverage and lint
+all: build test lint tiny test-tiny check-coverage sh-lint frontend ## Build, test, check coverage and lint
 	@if [ -e .git/rebase-merge ]; then git --no-pager log -1 --pretty='%h %s'; fi
 	@echo '$(COLOUR_GREEN)Success$(COLOUR_NORMAL)'
 

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -99,7 +99,7 @@ func (e *Evaluator) evalDeclaration(scope *scope, decl *parser.Declaration) Valu
 	if isError(val) {
 		return val
 	}
-	if decl.Type() == parser.ANY_TYPE {
+	if decl.Type() == parser.ANY_TYPE && val.Type() != ANY {
 		val = &Any{Val: val}
 	}
 	scope.set(decl.Var.Name, val)

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -155,23 +155,48 @@ print f1 f2 f3
 
 func TestAssignmentAny(t *testing.T) {
 	prog := `
-f1:any
-f2:num
-print f1 f2
-f1 = f2
-print f1 f2
-f1 = fox
-print f1 f2
-
 func fox:string
     return "🦊"
 end
 
+func lol_any:any
+    return "🍭"
+end
+
+f1:any
+f2:num
+print "1" f1 f2
+
+f1 = f2
+print "2" f1 f2
+
+f1 = fox
+print "3" f1 f2
+
+f1 = lol_any
+print "4" f1
+
+f3 := f1
+print "5" f3==f1
+
+f4:any
+f4 = f1
+print "6" f4==f1
 `
 	b := bytes.Buffer{}
 	fn := func(s string) { b.WriteString(s) }
 	Run(prog, fn)
-	want := "false 0\n0 0\n🦊 0\n"
+	wants := []string{
+		"1 false 0",
+		"2 0 0",
+		"3 🦊 0",
+		"4 🍭",
+		"5 true",
+		"6 true",
+		"",
+	}
+	want := strings.Join(wants, "\n")
+
 	assert.Equal(t, want, b.String())
 }
 

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -154,11 +154,18 @@ func (a *Any) String() string {
 }
 
 func (a *Any) Equals(v Value) bool {
-	return a.Val.Equals(v)
+	if a2, ok := v.(*Any); ok {
+		return a.Val.Equals(a2.Val)
+	}
+	return false // panic
 }
 
 func (a *Any) Set(v Value) {
-	a.Val = v
+	if a2, ok := v.(*Any); ok {
+		a.Val = a2.Val
+	} else {
+		a.Val = v
+	}
 }
 
 func (r *ReturnValue) Type() ValueType     { return RETURN_VALUE }


### PR DESCRIPTION
Fix `any`'s wrapping `any`'s so that `any` only ever contains a
non-`any` type. We have added two test cases that failed before the code fix.

Sneak in a `make ci` dependency reorder so that linter errors surface earlier.