### PR TITLE
Add for ... range loop parsing and evaluation

### DIFF
--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -571,6 +571,125 @@ print "6" s s2
 	}
 }
 
+func TestForStepRange(t *testing.T) {
+	prog := `
+for i := range 2
+	print "🎈" i
+end
+for i := range -1 1
+	print "🐣" i
+end
+for i := range 2 6 2
+	print "🍭" i
+end
+for i := range 5 3 (-1) // TODO: should work 5 3 -1 !
+	print "🦊" i
+end
+for i := range 3 5 (-1)
+	print "1💣" i
+end
+for i := range 3 (-1) 1
+	print "2💣" i
+end
+for i := range 3 (-1)
+	print "3💣" i
+end
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := []string{
+		"🎈 0",
+		"🎈 1",
+		"🐣 -1",
+		"🐣 0",
+		"🍭 2",
+		"🍭 4",
+		"🦊 5",
+		"🦊 4",
+		"",
+	}
+	got := strings.Split(b.String(), "\n")
+	assert.Equal(t, len(want), len(got), b.String())
+	for i := range want {
+		assert.Equal(t, want[i], got[i])
+	}
+}
+
+func TestForArray(t *testing.T) {
+	prog := `
+for x := range [0 1]
+	print "🎈" x
+end
+for i := range []
+	print "💣" i
+end
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := []string{
+		"🎈 0",
+		"🎈 1",
+		"",
+	}
+	got := strings.Split(b.String(), "\n")
+	assert.Equal(t, len(want), len(got), b.String())
+	for i := range want {
+		assert.Equal(t, want[i], got[i])
+	}
+}
+
+func TestForString(t *testing.T) {
+	prog := `
+for x := range "abc"
+	print "🎈" x
+end
+for i := range ""
+	print "💣" i
+end
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := []string{
+		"🎈 a",
+		"🎈 b",
+		"🎈 c",
+		"",
+	}
+	got := strings.Split(b.String(), "\n")
+	assert.Equal(t, len(want), len(got), b.String())
+	for i := range want {
+		assert.Equal(t, want[i], got[i])
+	}
+}
+
+func TestForMap(t *testing.T) {
+	prog := `
+m := {a:1 b:2}
+for x := range m
+	print "🎈" x  m[x]
+end
+for i := range {}
+	print "💣" i
+end
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := []string{
+		"🎈 a 1",
+		"🎈 b 2",
+		"",
+	}
+	got := strings.Split(b.String(), "\n")
+	assert.Equal(t, len(want), len(got), b.String())
+	for i := range want {
+		assert.Equal(t, want[i], got[i])
+	}
+}
+
 func TestDemo(t *testing.T) {
 	prog := `
 move 10 10

--- a/pkg/evaluator/ranger.go
+++ b/pkg/evaluator/ranger.go
@@ -1,0 +1,78 @@
+package evaluator
+
+type ranger interface {
+	next() bool
+}
+
+type stepRange struct {
+	loopVar *Num
+	cur     float64
+	stop    float64
+	step    float64
+}
+
+type arrayRange struct {
+	loopVar Value
+	cur     int
+	array   *Array
+}
+
+type mapRange struct {
+	loopVar Value
+	cur     int // index of Map.Order slice of keys
+	mapVal  *Map
+	order   []string // copy of order in case map entry gets deleted during iteration
+}
+
+type stringRange struct {
+	loopVar *String
+	cur     int
+	str     *String
+	runes   []rune
+}
+
+func (s *stepRange) next() bool {
+	if s.step > 0 && s.cur >= s.stop {
+		return false
+	}
+	if s.step < 0 && s.cur <= s.stop {
+		return false
+	}
+	s.loopVar.Val = s.cur
+	s.cur += s.step
+	return true
+}
+
+func (a *arrayRange) next() bool {
+	elements := *a.array.Elements
+	if a.cur >= len(elements) {
+		return false
+	}
+	a.loopVar.Set(elements[a.cur])
+	a.cur++
+	return true
+}
+
+func (m *mapRange) next() bool {
+	for m.cur < len(m.order) {
+		key := m.order[m.cur]
+		m.cur++
+		if _, ok := m.mapVal.Pairs[key]; ok { // ensure value hasn't been deleted
+			m.loopVar.(*String).Val = key
+			return true
+		}
+	}
+	return false
+}
+
+func (s *stringRange) next() bool {
+	if s.runes == nil {
+		s.runes = s.str.runes()
+	}
+	if s.cur >= len(s.runes) {
+		return false
+	}
+	s.loopVar.Val = string(s.runes[s.cur])
+	s.cur++
+	return true
+}

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -102,6 +102,23 @@ type While struct {
 	ConditionalBlock
 }
 
+type For struct {
+	Token *lexer.Token
+
+	LoopVar *Var
+	Range   Node // StepRange or array/map/string expression
+
+	Block *BlockStatement
+}
+
+type StepRange struct {
+	Token *lexer.Token
+
+	Start Node // num expression or nil
+	Stop  Node // num expression
+	Step  Node // num expression or nil
+}
+
 type ConditionalBlock struct {
 	Token     *lexer.Token
 	Condition Node // must be of type bool
@@ -370,6 +387,36 @@ func (w *While) Type() *Type {
 }
 
 func (*While) AlwaysTerminates() bool {
+	return false
+}
+
+func (f *For) String() string {
+	header := "for " + f.LoopVar.Name + " := " + f.Range.String()
+	return header + " {\n" + f.Block.String() + "}"
+}
+
+func (f *For) Type() *Type {
+	return f.Block.Type()
+}
+
+func (s *StepRange) String() string {
+	start := "0"
+	if s.Start != nil {
+		start = s.Start.String()
+	}
+	stop := s.Stop.String()
+	step := "1"
+	if s.Step != nil {
+		step = s.Step.String()
+	}
+	return start + " " + stop + " " + step
+}
+
+func (s *StepRange) Type() *Type {
+	return NUM_TYPE
+}
+
+func (*For) AlwaysTerminates() bool {
 	return false
 }
 


### PR DESCRIPTION
Add `for` statement parsing according to grammar.

    for_stmt   = "for" ident := "range" expr [ expr [expr]]
                    statements
                 "end" NL .


Range Expression can be an expression evaluating to a string, a map or
an array or it can consist of 1 to 3 numbers forming a StepRange.

Add 2 new AST nodes: `For` and `StepRange`. Fix up previous for loop tests
that now fail because of unused variable errors in parser package.

Add `for ... range` loop evaluation using the new AST nodes `for` and `stepRange`.
In order to properly capture the loopVariable, e.g. `x` in `for
x := range [1 2 3]` introduce the creation of a zeroValue from
a *parser.Type in evaluator.