### PR TITLE
parser: Fix double index in assignment

### DIFF
--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -375,6 +375,24 @@ func TestIndex(t *testing.T) {
 	}
 }
 
+func TestDoubleIndex(t *testing.T) {
+	tests := map[string]string{
+		`
+		x := [ [1 2 3] ([4 5 6]) ]
+		x[0][1] = 99
+		print x
+		`: "[[1 99 3] [4 5 6]]",
+	}
+	for in, want := range tests {
+		t.Run(in, func(t *testing.T) {
+			b := bytes.Buffer{}
+			fn := func(s string) { b.WriteString(s) }
+			Run(in, fn)
+			assert.Equal(t, want+"\n", b.String())
+		})
+	}
+}
+
 func TestIndexErr(t *testing.T) {
 	tests := map[string]string{
 		// x := ["a","b","c"]; x = "abc"

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -266,17 +266,22 @@ func (p *Parser) parseAssignmentTarget(scope *scope) Node {
 		p.appendErrorForToken("unknown variable name '"+name+"'", tok)
 		return nil
 	}
-	if p.cur.TokenType() == lexer.LBRACKET { // TODO: check for whitespace
-		if v.Type() == STRING_TYPE {
-			p.appendErrorForToken("cannot index string on left side of '=', only on right", tok)
-			return nil
+	tt := p.cur.TokenType()
+	var n Node = v
+	for tt == lexer.LBRACKET || tt == lexer.DOT {
+		if p.cur.TokenType() == lexer.LBRACKET { // TODO: check for whitespace
+			if n.Type() == STRING_TYPE {
+				p.appendErrorForToken("cannot index string on left side of '=', only on right", tok)
+				return nil
+			}
+			n = p.parserIndexOrSliceExpr(scope, n, false)
 		}
-		return p.parserIndexOrSliceExpr(scope, v, false)
+		if p.cur.TokenType() == lexer.DOT { // TODO: check for whitespace
+			n = p.parserDotExpr(n)
+		}
+		tt = p.cur.TokenType()
 	}
-	if p.cur.TokenType() == lexer.DOT { // TODO: check for whitespace
-		return p.parserDotExpr(v)
-	}
-	return v
+	return n
 }
 
 func (p *Parser) parseFuncDeclSignature() *FuncDecl {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -266,6 +266,7 @@ func (p *Parser) parseAssignmentTarget(scope *scope) Node {
 		p.appendErrorForToken("unknown variable name '"+name+"'", tok)
 		return nil
 	}
+	v.isUsed = true
 	tt := p.cur.TokenType()
 	var n Node = v
 	for tt == lexer.LBRACKET || tt == lexer.DOT {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -434,6 +434,11 @@ if true
 	print x
 end
 print x
+`, `
+a := [ ([1 2 3]) ([4 5 6]) ]
+b := a[0]
+b[1] = 7
+print a
 `,
 	}
 	for _, input := range inputs {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -345,6 +345,10 @@ a := [0 2 3]
 a[0] = 1
 print a
 `, `
+a :=  [ [0 2 3] ([4 5]) ]
+a[0][1] = 1
+print a
+`, `
 a := {name: "mali"}
 a.sport = "climbing"
 print a


### PR DESCRIPTION
Fix double index in target of assignment statements:

     a := [[1 2] ([3])]
     a[0][0] = 1

Fix by looping until next token is not a `[` or `.` any longer.

Also add test to evaluator ensuring we are evaluating correctly.

Fix missing isUsed flagging for indexed array