### PR TITLE
evaluator: Add map builtins `has` and `del`

### DIFF
--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -34,6 +34,7 @@ func DefaultBuiltins(printFn func(string)) Builtins {
 		"move":  {Func: moveFunc(printFn), Decl: moveDecl},
 		"line":  {Func: lineFunc(printFn), Decl: lineDecl},
 		"has":   {Func: BuiltinFunc(hasFunc), Decl: hasDecl},
+		"del":   {Func: BuiltinFunc(delFunc), Decl: delDecl},
 	}
 }
 
@@ -89,6 +90,22 @@ func hasFunc(args []Value) Value {
 	key := args[1].(*String)
 	_, ok := m.Pairs[key.Val]
 	return &Bool{Val: ok}
+}
+
+var delDecl = &parser.FuncDecl{
+	Name: "del",
+	Params: []*parser.Var{
+		{Name: "m", T: parser.GENERIC_MAP},
+		{Name: "key", T: parser.STRING_TYPE},
+	},
+	ReturnType: parser.NONE_TYPE,
+}
+
+func delFunc(args []Value) Value {
+	m := args[0].(*Map)
+	keyStr := args[1].(*String)
+	m.Delete(keyStr.Val)
+	return nil
 }
 
 var moveDecl = &parser.FuncDecl{

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -33,6 +33,7 @@ func DefaultBuiltins(printFn func(string)) Builtins {
 		"len":   {Func: BuiltinFunc(lenFunc), Decl: lenDecl},
 		"move":  {Func: moveFunc(printFn), Decl: moveDecl},
 		"line":  {Func: lineFunc(printFn), Decl: lineDecl},
+		"has":   {Func: BuiltinFunc(hasFunc), Decl: hasDecl},
 	}
 }
 
@@ -72,6 +73,22 @@ func lenFunc(args []Value) Value {
 		return &Num{Val: float64(len(arg.Val))}
 	}
 	return newError("'len' takes 1 argument of type 'string', array '[]' or map '{}' not " + args[0].Type().String())
+}
+
+var hasDecl = &parser.FuncDecl{
+	Name: "has",
+	Params: []*parser.Var{
+		{Name: "m", T: parser.GENERIC_MAP},
+		{Name: "key", T: parser.STRING_TYPE},
+	},
+	ReturnType: parser.BOOL_TYPE,
+}
+
+func hasFunc(args []Value) Value {
+	m := args[0].(*Map)
+	key := args[1].(*String)
+	_, ok := m.Pairs[key.Val]
+	return &Bool{Val: ok}
 }
 
 var moveDecl = &parser.FuncDecl{

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -804,6 +804,47 @@ has ["a"] "a" // cannot run 'has' on array
 	assert.Equal(t, want, got)
 }
 
+func TestDel(t *testing.T) {
+	prog := `
+m1 := {a:1 b:2}
+m2 := m1
+print "1" m1 m2
+del m1 "a"
+print "2" m1 m2
+del m1 "MISSING"
+print "3" m1 m2
+del m2 "b"
+print "4" m1 m2
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := []string{
+		"1 {a:1 b:2} {a:1 b:2}",
+		"2 {b:2} {b:2}",
+		"3 {b:2} {b:2}",
+		"4 {} {}",
+		"",
+	}
+	got := strings.Split(b.String(), "\n")
+	assert.Equal(t, len(want), len(got), b.String())
+	for i := range want {
+		assert.Equal(t, want[i], got[i])
+	}
+}
+
+func TestDelErr(t *testing.T) {
+	prog := `
+del ["a"] "a" // cannot delete from array
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := "line 2 column 15: 'del' takes 1st argument of type '{}', found 'string[]'"
+	got := b.String()
+	assert.Equal(t, want, got)
+}
+
 func TestDemo(t *testing.T) {
 	prog := `
 move 10 10

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -771,6 +771,39 @@ m.b.c = 2
 	assert.Equal(t, want, b.String())
 }
 
+func TestHas(t *testing.T) {
+	prog := `
+m := {a:1 b:2}
+print (has m "a")
+print (has m "MISSING")
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := []string{
+		"true",
+		"false",
+		"",
+	}
+	got := strings.Split(b.String(), "\n")
+	assert.Equal(t, len(want), len(got), b.String())
+	for i := range want {
+		assert.Equal(t, want[i], got[i])
+	}
+}
+
+func TestHasErr(t *testing.T) {
+	prog := `
+has ["a"] "a" // cannot run 'has' on array
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := "line 2 column 15: 'has' takes 1st argument of type '{}', found 'string[]'"
+	got := b.String()
+	assert.Equal(t, want, got)
+}
+
 func TestDemo(t *testing.T) {
 	prog := `
 move 10 10

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -331,6 +331,19 @@ func (m *Map) InsertKey(key string, t *parser.Type) {
 	m.Pairs[key] = zero(t)
 }
 
+func (m *Map) Delete(key string) {
+	if _, ok := m.Pairs[key]; !ok {
+		return
+	}
+	delete(m.Pairs, key)
+	for i, k := range *m.Order {
+		if k == key {
+			*m.Order = append((*m.Order)[:i], (*m.Order)[i+1:]...)
+			break
+		}
+	}
+}
+
 func isError(val Value) bool { // TODO: replace with panic flow
 	return val != nil && val.Type() == ERROR
 }

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -24,16 +24,16 @@ const (
 )
 
 var valueTypeStrings = map[ValueType]string{
-	ERROR:        "ERROR",
-	NUM:          "NUM",
-	BOOL:         "BOOL",
-	STRING:       "STRING",
-	ANY:          "ANY",
-	ARRAY:        "ARRAY",
-	MAP:          "MAP",
-	RETURN_VALUE: "RETURN_VALUE",
-	FUNCTION:     "FUNCTION",
-	BUILTIN:      "BUILTIN",
+	ERROR:        "error",
+	NUM:          "num",
+	BOOL:         "bool",
+	STRING:       "string",
+	ANY:          "any",
+	ARRAY:        "array",
+	MAP:          "map",
+	RETURN_VALUE: "return_value",
+	FUNCTION:     "function",
+	BUILTIN:      "builtin",
 }
 
 func (t ValueType) String() string {

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -320,7 +320,7 @@ func (p *Parser) parseArrayLiteral(scope *scope) Node {
 	}
 	p.advance() // advance past ]
 	if len(elements) == 0 {
-		return &ArrayLiteral{Token: tok, T: EMPTY_ARRAY}
+		return &ArrayLiteral{Token: tok, T: GENERIC_ARRAY}
 	}
 	types := make([]*Type, len(elements))
 	for i, e := range elements {
@@ -371,7 +371,7 @@ func (p *Parser) parseMapLiteral(scope *scope) Node {
 	}
 	p.advance() // advance past }
 	if len(pairs) == 0 {
-		return &MapLiteral{Token: tok, T: EMPTY_MAP}
+		return &MapLiteral{Token: tok, T: GENERIC_MAP}
 	}
 	types := make([]*Type, 0, len(pairs))
 	for _, n := range pairs {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -410,8 +410,9 @@ func (p *Parser) assertArgTypes(decl *FuncDecl, args []Node) {
 	if decl.VariadicParam != nil {
 		paramType := decl.VariadicParam.Type()
 		for _, arg := range args {
-			if !paramType.Accepts(arg.Type()) {
-				p.appendError("'" + funcName + "' takes variadic arguments of type '" + paramType.Format() + "', found '" + arg.Type().Format() + "'")
+			argType := arg.Type()
+			if !paramType.Accepts(argType) && !paramType.Matches(argType) {
+				p.appendError("'" + funcName + "' takes variadic arguments of type '" + paramType.Format() + "', found '" + argType.Format() + "'")
 			}
 		}
 		return
@@ -423,7 +424,7 @@ func (p *Parser) assertArgTypes(decl *FuncDecl, args []Node) {
 	for i := range args {
 		paramType := decl.Params[i].Type()
 		argType := args[i].Type()
-		if !paramType.Accepts(argType) {
+		if !paramType.Accepts(argType) && !paramType.Matches(argType) {
 			p.appendError("'" + funcName + "' takes " + ordinalize(i+1) + " argument of type '" + paramType.Format() + "', found '" + argType.Format() + "'")
 		}
 	}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -378,7 +378,7 @@ b = a
 		`
 a:= 1
 a = []
-`: "line 3 column 1: 'a' accepts values of type num, found any[]",
+`: "line 3 column 1: 'a' accepts values of type num, found []",
 		`
 a:num
 b:any


### PR DESCRIPTION
Add builtin function `del` for entry removal from map:

    del {a: 1} "a" // {}

Add builtin function `has` for entry existence check in map:

    has {a: 1} "a" // true
    