### PR TITLE
github: Commit brew formula on release

### DIFF
--- a/.github/scripts/app_token
+++ b/.github/scripts/app_token
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Generate temporary installation token for GitHub App
+#
+# The following environment variables are required
+# 1. GITHUB_APP_ID:  number
+# 2. GITHUB_APP_PEM: contents of the App's private key.
+main() {
+	set -euo pipefail
+	on_ci && set -x
+	validate_env
+
+	jwt=$(make_jwt)
+	resp=$(curl -s -H "Authorization: Bearer ${jwt}" -H "Accept: application/vnd.github+json" https://api.github.com/app/installations)
+	installation_id=$(jq "${validate_installation_jq}" <<<"${resp}")
+
+	resp=$(curl -s -X POST -H "Authorization: Bearer ${jwt}" -H "Accept: application/vnd.github+json" "https://api.github.com/app/installations/${installation_id}/access_tokens")
+	jq -r "${validate_token_jq}" <<<"${resp}"
+}
+
+validate_env() {
+	if [[ -z ${GITHUB_APP_ID:-} ]]; then
+		exit_error "GITHUB_APP_ID is not set"
+	fi
+	if ! [[ ${GITHUB_APP_ID:-} =~ ^[0-9]+$ ]]; then
+		exit_error "GITHUB_APP_ID is not a number"
+	fi
+	if [[ -z ${GITHUB_APP_PEM:-} ]]; then
+		exit_error "GITHUB_APP_PEM is not set"
+	fi
+}
+
+make_jwt() {
+	local now drift iat exp iss header payload signature
+	now=$(date +%s)
+	drift=10
+	# iat is the "issued at time".
+	iat=$((now - drift))
+	# exp is the JWT expiration time (max 10m).
+	exp=$((now + 600 - drift))
+	iss=${GITHUB_APP_ID}
+
+	header=$(printf '%s' '{"alg":"RS256"}' | b64)
+	payload=$(printf '{"iat":%s,"exp":%s,"iss":%s}' "${iat}" "${exp}" "${iss}" | b64)
+	signature=$(printf '%s.%s' "${header}" "${payload}" | openssl dgst -sha256 -sign <(printenv GITHUB_APP_PEM) | b64)
+	echo "${header}.${payload}.${signature}"
+}
+
+on_ci() {
+	[[ -n "${CI:-}" ]]
+}
+
+exit_error() {
+	echo "$1" >&2
+	exit 1
+}
+
+# b64 encodes with base64 encoding then replaces `+` with `-`,
+# `/` with `_` and strips trailing `=`
+b64() {
+	base64 | sed -e 'y|+/|-_|' -e 's/=*$//'
+}
+
+validate_installation_jq='
+if type != "array" then
+	"installations response is not array.\n" | halt_error
+elif length != 1 then
+	"expected exactly 1 installation\n" | halt_error
+elif .[0].id | type != "number" then
+	"installation id is not a number\n" | halt_error
+else
+	.[0].id
+end'
+
+validate_token_jq='
+if .token | type != "string" then
+	"token is not a string.\n" | halt_error
+else
+	.token
+end'
+
+# Only run main if executed as a script and not sourced.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then main "$@"; fi

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -30,6 +30,8 @@ jobs:
     - run: ./bin/make release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_APP_ID: ${{ secrets.BOXYGOAT_GITHUB_APP_ID }}
+        GITHUB_APP_PEM: ${{ secrets.BOXYGOAT_GITHUB_APP_PEM }}
     - run: ./bin/make firebase-deploy-prod
       env:
         FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,14 @@
+brews:
+  - tap:
+      owner: foxygoat
+      name: homebrew-tap
+      branch: master
+
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+
+    commit_msg_template: "Update brew formula for {{ .ProjectName }} version {{ .Tag }}"
+    homepage: "https://evy.dev"
+    description: "Evy is a simple programming language."
+    license: "Apache-2.0"

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ firebase-public: frontend
 .PHONY: firebase-deploy firebase-deploy-prod firebase-emulate firebase-public
 
 # --- scripts ------------------------------------------------------------------
-SCRIPTS = firebase/deploy
+SCRIPTS = firebase/deploy .github/scripts/app_token
 
 sh-lint: ## Lint script files with shellcheck and shfmt
 	shellcheck $(SCRIPTS)
@@ -117,6 +117,7 @@ sh-fmt:  ## Format script files
 release: nexttag ## Tag and release binaries for different OS on GitHub release
 	git tag $(NEXTTAG)
 	git push origin $(NEXTTAG)
+	[ -z "$(CI)" ] || GITHUB_TOKEN=$$(.github/scripts/app_token) || exit 1; \
 	goreleaser release --rm-dist
 
 nexttag:


### PR DESCRIPTION
github: Commit brew formula on release

Automatically commit homebrew formula to
https://github.com/foxygoat/homebrew-tap when we create an `evy`
release. This allows mac users to install `evy` with

    brew tap foxygoat/tap
    brew install evy

`goreleaser` does the heavy lifting of creating the brew formula and
committing it, all configured in .goreleaser.yaml. However, creating a
GitHub token that has the privileges to push to another foxygoat repo
is tricky. Encapsulate the logic for creating a temporary, elevated
privileges GITHUB_TOKEN in script .github/scripts/app_token.

In the background we have created a new GitHub App to work as a "Service
Account" for cross-repo automation. It is only used on the foxygoat
GitHub org and it is called boxygoat (foxygoat bot). We have created
org wide secrets containing boxygoat's ID and PEM called
`BOXYGOAT_GITHUB_APP_ID` and `BOXYGOAT_GITHUB_APP_PEM`. These secrets
are set to the environment variables `GITHUB_APP_ID` and
`GITHUB_APP_PEM` by the GitHub workflow
in .github/workflows/cicd.yaml.

Use `GITHUB_APP_ID` and `GITHUB_APP_PEM` environment variables in
`app_token` script to create a boxygoat JWT. Use JWT to retrieve the
`installation_id` for the boxygoat App. The app could be installed
several times, on several orgs. Ensure that it has been installed only
once in our use case. Call GitHub API with JWT and the installation_id
to create a short-lived (<10m) installation_token. Use the
installation_token as elevated privileges GITHUB_TOKEN to push commits
to other foxygoat repos, in specific foxygoat/homebrew-tap.


Link: https://github.com/organizations/foxygoat/settings/apps/boxygoat/
Link: https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#authenticating-as-an-installation
Link: https://docs.brew.sh/Formula-Cookbook
Link: https://goreleaser.com/customization/homebrew/