### PR TITLE
github: Disable app_token script and use marketplace action

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -27,11 +27,14 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - id: app_token
+      uses: peter-murray/workflow-application-token-action@v1
+      with:
+        application_id: ${{ secrets.BOXYGOAT_GITHUB_APP_ID }}
+        application_private_key: ${{ secrets.BOXYGOAT_GITHUB_APP_PEM }}        
     - run: ./bin/make release
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_APP_ID: ${{ secrets.BOXYGOAT_GITHUB_APP_ID }}
-        GITHUB_APP_PEM: ${{ secrets.BOXYGOAT_GITHUB_APP_PEM }}
+        GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
     - run: ./bin/make firebase-deploy-prod
       env:
         FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG }}

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,6 @@ sh-fmt:  ## Format script files
 release: nexttag ## Tag and release binaries for different OS on GitHub release
 	git tag $(NEXTTAG)
 	git push origin $(NEXTTAG)
-	[ -z "$(CI)" ] || GITHUB_TOKEN=$$(.github/scripts/app_token) || exit 1; \
 	goreleaser release --rm-dist
 
 nexttag:


### PR DESCRIPTION
Disable `app_token` script and use marketplace action 
`peter-murray/workflow-application-token-action@v1`
to create a temporary App `installation_token`.

This seems to work. 

Let's see if we can get brew formula update on merge to master and 
then circle back to work out the difference between this action and
our `app_token` bash script.