### PR TITLE
github: Fix app_token script

### DIFF
--- a/.github/scripts/app_token
+++ b/.github/scripts/app_token
@@ -40,9 +40,9 @@ make_jwt() {
 	exp=$((now + 600 - drift))
 	iss=${GITHUB_APP_ID}
 
-	header=$(printf '%s' '{"alg":"RS256"}' | b64)
-	payload=$(printf '{"iat":%s,"exp":%s,"iss":%s}' "${iat}" "${exp}" "${iss}" | b64)
-	signature=$(printf '%s.%s' "${header}" "${payload}" | openssl dgst -sha256 -sign <(printenv GITHUB_APP_PEM) | b64)
+	header=$(printf '%s' '{"alg":"RS256"}' | base64url)
+	payload=$(printf '{"iat":%s,"exp":%s,"iss":"%s"}' "${iat}" "${exp}" "${iss}" | base64url)
+	signature=$(printf '%s.%s' "${header}" "${payload}" | openssl dgst -sha256 -sign <(printenv GITHUB_APP_PEM) | base64url)
 	echo "${header}.${payload}.${signature}"
 }
 
@@ -55,10 +55,12 @@ exit_error() {
 	exit 1
 }
 
-# b64 encodes with base64 encoding then replaces `+` with `-`,
+# base64url encodes with base64 encoding then replaces `+` with `-`,
 # `/` with `_` and strips trailing `=`
-b64() {
-	base64 | sed -e 'y|+/|-_|' -e 's/=*$//'
+base64url() {
+	# Use `openssl enc -A -base64` instead of `base64` because `base64`
+	# adds linebreaks on linux but not on mac. The flag to change this doesn't work on mac.
+	openssl enc -A -base64 | sed -e 'y|+/|-_|' -e 's/=*$//'
 }
 
 validate_installation_jq='

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -27,14 +27,11 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - id: app_token
-      uses: peter-murray/workflow-application-token-action@v1
-      with:
-        application_id: ${{ secrets.BOXYGOAT_GITHUB_APP_ID }}
-        application_private_key: ${{ secrets.BOXYGOAT_GITHUB_APP_PEM }}        
     - run: ./bin/make release
       env:
-        GITHUB_TOKEN: ${{ steps.app_token.outputs.token }}
+        GITHUB_APP_ID: ${{ secrets.BOXYGOAT_GITHUB_APP_ID }}
+        GITHUB_APP_PEM: ${{ secrets.BOXYGOAT_GITHUB_APP_PEM }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: ./bin/make firebase-deploy-prod
       env:
         FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG }}

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ sh-fmt:  ## Format script files
 release: nexttag ## Tag and release binaries for different OS on GitHub release
 	git tag $(NEXTTAG)
 	git push origin $(NEXTTAG)
+	[ -z "$(CI)" ] || GITHUB_TOKEN=$$(.github/scripts/app_token) || exit 1; \
 	goreleaser release --rm-dist
 
 nexttag:


### PR DESCRIPTION
Fix `app_token` script by using `openssl enc -A -base64` instead of
`base64` because `base64` adds linebreaks on linux but not on mac. The
flag to change this doesn't work on mac.

Reinstate usage on with `make release` and remove node based third-party
app. We had only temporarily changed this to see if the rest of the
brew formula update process in repo foxygoat/homebrew-tap would work.