### PR TITLE
builtin: Add join and sprint functions

### DIFF
--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -845,6 +845,29 @@ del ["a"] "a" // cannot delete from array
 	assert.Equal(t, want, got)
 }
 
+func TestJoin(t *testing.T) {
+	prog := `
+print (join [1 true "x"] ", ")
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := "1, true, x\n"
+	assert.Equal(t, want, b.String())
+}
+
+func TestSprint(t *testing.T) {
+	prog := `
+s := sprint 1 [2] "x"
+print (s)
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := "1 [2] x\n"
+	assert.Equal(t, want, b.String())
+}
+
 func TestDemo(t *testing.T) {
 	prog := `
 move 10 10


### PR DESCRIPTION
Add join and sprint functions for easier string manipulation. Sprint, Join
and Print function have similarities for so they were refactored to use the
same underlying `join(args, sep) string` function in the same commit.

Join joins the string representations of the elements of an array with the
specified separator:

	join [1 "a" true] ", " // 1, a, true

`sprint` concatenates the arguments given with a space separator, like
`print`, but returns a string rather than printing to a specified output
location. Unlike print it does not add a newline at the end as this seems
to be a more likely use case - to be seen and changed if deemed bad.