### PR TITLE
docs: Fix off-by-one error in example

### DIFF
--- a/docs/syntax_grammar.md
+++ b/docs/syntax_grammar.md
@@ -374,7 +374,7 @@ In order to distinguish between array literals and array indices, there
 cannot be any whitespace between array variable and index.
 
     arr := ["a" "b"]
-    print arr[1]  // index:   a
+    print arr[1]  // index: b
     print arr [1] // literal: [a b] [1]
     arr[0] = "A"
     arr [1] = "B" // invalid


### PR DESCRIPTION
Fix off-by-one error in example and while at it remove extra whitespace.
This has been reported by christof.kaser@gmail.com

Thanks @chkas
