### PR TITLE
frontend: Fix styles for iPad

### DIFF
--- a/frontend/index.css
+++ b/frontend/index.css
@@ -130,7 +130,7 @@ main {
   display: flex;
   flex-direction: column;
 }
-textarea {
+textarea, textarea[disabled] {
   font-family: var(--font-family-code);
   color: var(--code-color);
   line-height: 1.4;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,7 +20,7 @@
     </header>
     <main>
       <div class="code">
-        <textarea id="code" spellcheck="false" autocapitalize="none">
+        <textarea id="code" spellcheck="false" autocorrect="off" autocapitalize="none">
 move 10 20
 line 50 50
 rect 25 25


### PR DESCRIPTION
Fix styles for iPad, the output was dim grey on the right. Also, turn
off change `i` being spell-corrected to `I`.