### PR TITLE
evaluator: Add test ensuring func params can be reassigned

### DIFF
--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -868,6 +868,22 @@ print (s)
 	assert.Equal(t, want, b.String())
 }
 
+func TestParamAssign(t *testing.T) {
+	prog := `
+f 3
+
+func f n:num
+	n = n + 1
+	print n
+end
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := "4\n"
+	assert.Equal(t, want, b.String())
+}
+
 func TestDemo(t *testing.T) {
 	prog := `
 move 10 10


### PR DESCRIPTION
Add test ensuring func params can be reassigned - as I thought this was
a bug, but it turns out it was not.