### PR TITLE
evaluator: Fix variable initialisation

### DIFF
--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -107,7 +107,7 @@ func (e *Evaluator) evalDeclaration(scope *scope, decl *parser.Declaration) Valu
 	if decl.Type() == parser.ANY_TYPE && val.Type() != ANY {
 		val = &Any{Val: val}
 	}
-	scope.set(decl.Var.Name, val)
+	scope.set(decl.Var.Name, copyOrRef(val))
 	return nil
 }
 
@@ -139,7 +139,7 @@ func (e *Evaluator) evalMapLiteral(scope *scope, m *parser.MapLiteral) Value {
 		if isError(val) {
 			return val
 		}
-		pairs[key] = val
+		pairs[key] = copyOrRef(val)
 	}
 	order := make([]string, len(m.Order))
 	copy(order, m.Order)
@@ -342,7 +342,7 @@ func (e *Evaluator) evalExprList(scope *scope, terms []parser.Node) []Value {
 		if isError(evaluated) {
 			return []Value{evaluated}
 		}
-		result[i] = evaluated
+		result[i] = copyOrRef(evaluated)
 	}
 
 	return result

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -870,16 +870,50 @@ print (s)
 
 func TestParamAssign(t *testing.T) {
 	prog := `
-f 3
+x := 1
+f x
+x = x + 1
+f x
 
 func f n:num
-	n = n + 1
-	print n
+	n = n*10
+	print n x
 end`
+
 	b := bytes.Buffer{}
 	fn := func(s string) { b.WriteString(s) }
 	Run(prog, fn)
-	want := "4\n"
+	want := "10 1\n20 2\n"
+	assert.Equal(t, want, b.String())
+}
+
+func TestAssign2(t *testing.T) {
+	prog := `
+x := 1
+n := x
+n = n * 10
+print x
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := "1\n"
+	assert.Equal(t, want, b.String())
+}
+
+func TestAssign3(t *testing.T) {
+	prog := `
+x:num
+x = 1
+n:num
+n = x
+n = n * 10
+print x
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := "1\n"
 	assert.Equal(t, want, b.String())
 }
 
@@ -891,6 +925,35 @@ print (split "a, b, c" ", ")
 	fn := func(s string) { b.WriteString(s) }
 	Run(prog, fn)
 	want := "[a b c]\n"
+	assert.Equal(t, want, b.String())
+}
+
+func TestAnyAssignment(t *testing.T) {
+	prog := `
+a := 1
+b:any
+b = a
+a = 2
+print a b
+`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := "2 1\n"
+	assert.Equal(t, want, b.String())
+}
+
+func TestCompositeAssignment(t *testing.T) {
+	prog := `
+n := 1
+a := [n n]
+m := {n: n}
+n = 2
+print n a m`
+	b := bytes.Buffer{}
+	fn := func(s string) { b.WriteString(s) }
+	Run(prog, fn)
+	want := "2 [1 1] {n:1}\n"
 	assert.Equal(t, want, b.String())
 }
 

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -179,9 +179,9 @@ func (a *Any) Equals(v Value) bool {
 
 func (a *Any) Set(v Value) {
 	if a2, ok := v.(*Any); ok {
-		a.Val = a2.Val
+		a.Val = copyOrRef(a2.Val)
 	} else {
-		a.Val = v
+		a.Val = copyOrRef(v)
 	}
 }
 


### PR DESCRIPTION
Fix variable initialisation for inferred declaration and parameter
passing from another variable. Previously we would just use the same
value as the underlying variable which resulted in values of bath
variables changing even when only one was updated.

All newly added tests accept for `TestAssign3` failed prior to this fix.