### PR TITLE
all: Rework evy-evaluation to be hoisted on main

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,9 +12,7 @@
   <body class="play">
     <header>
       <div>
-        <button id="evaluate" disabled>Run</button>
-        <button id="tokenize" disabled class="hidden">Tokenize</button>
-        <button id="parse" disabled class="hidden">Parse</button>
+        <button id="run" disabled>Run</button>
       </div>
       <img src="logo.svg" alt="evy logo" height="100%" />
     </header>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -6,13 +6,13 @@ var wasm
 function initWasm() {
   const go = new Go() // see wasm_exec.js
   const evyEnv = {
-    jsPrint: jsPrint,
-    move: move,
-    line: line,
-    width: width,
-    circle: circle,
-    rect: rect,
-    color: color,
+    jsPrint,
+    move,
+    line,
+    width,
+    circle,
+    rect,
+    color,
   }
   go.importObject.env = Object.assign(go.importObject.env, evyEnv)
   WebAssembly.instantiateStreaming(fetch("evy.wasm"), go.importObject)

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -23,11 +23,9 @@ function initWasm() {
     .catch((err) => {
       console.error(err)
     })
-  document.querySelectorAll("header button").forEach((button) => {
-    button.onclick = handleRun
-    button.disabled = false
-    window.location.hash.includes("debug") && button.classList.remove("hidden")
-  })
+  const button = document.getElementById("run")
+  button.onclick = handleRun
+  button.disabled = false
 }
 
 // jsPrint converts wasm memory bytes from ptr to ptr+len to string and
@@ -58,8 +56,7 @@ function handleRun(event) {
   mem.set(new Uint8Array(bytes))
   document.getElementById("output").textContent = ""
   resetCanvas()
-  const fn = wasm.exports[event.target.id] // evaluate, tokenize or parse
-  fn(ptr, bytes.length)
+  wasm.exports.evaluate(ptr, bytes.length)
 }
 
 // --------------------------------------------------

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -23,15 +23,6 @@ function initWasm() {
     .catch((err) => {
       console.error(err)
     })
-  go.importObject.env = {
-    jsPrint: jsPrint,
-    move: move,
-    line: line,
-    width: width,
-    circle: circle,
-    rect: rect,
-    color: color,
-  }
   document.querySelectorAll("header button").forEach((button) => {
     button.onclick = handleRun
     button.disabled = false

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,34 +1,19 @@
 "use strict"
 
-var wasm
+let wasmModule, wasmInst
+let sourcePtr, sourceLength
 
 // initWasm loads bytecode and initialises execution environment.
 function initWasm() {
-  const go = new Go() // see wasm_exec.js
-  const evyEnv = {
-    jsPrint,
-    move,
-    line,
-    width,
-    circle,
-    rect,
-    color,
-  }
-  go.importObject.env = Object.assign(go.importObject.env, evyEnv)
-  WebAssembly.instantiateStreaming(fetch("evy.wasm"), go.importObject)
-    .then(function (obj) {
-      wasm = obj.instance
-      go.run(wasm)
-    })
-    .catch((err) => {
-      console.error(err)
-    })
-  const button = document.getElementById("run")
-  button.onclick = handleRun
-  button.disabled = false
+  WebAssembly.compileStreaming(fetch("evy.wasm"))
+    .then((obj) => (wasmModule = obj))
+    .catch((err) => console.error(err))
+  const runButton = document.getElementById("run")
+  runButton.onclick = handleRun
+  runButton.disabled = false
 }
 
-// jsPrint converts wasm memory bytes from ptr to ptr+len to string and
+// jsPrint converts wasmInst memory bytes from ptr to ptr+len to string and
 // writes it to the output textarea.
 function jsPrint(ptr, len) {
   const s = memString(ptr, len)
@@ -40,23 +25,53 @@ function jsPrint(ptr, len) {
 }
 
 function memString(ptr, len) {
-  const buf = new Uint8Array(wasm.exports.memory.buffer, ptr, len)
+  const buf = new Uint8Array(wasmInst.exports.memory.buffer, ptr, len)
   const s = new TextDecoder("utf8").decode(buf)
   return s
 }
 
 // handleRun retrieves the input string from the code pane and
-// converts it to wasm memory bytes. It then calls the evy evaluate
-// function.
-function handleRun(event) {
+// converts it to wasm memory bytes. It then calls the evy main()
+// function running the evaluator after parsing.
+async function handleRun(event) {
+  const go = newEvyGo() // see wasm_exec.js
+  wasmInst = await WebAssembly.instantiate(wasmModule, go.importObject)
+  prepareSourceAccess()
+  clearOutput()
+  go.run(wasmInst)
+}
+
+function newEvyGo() {
+  const evyEnv = {
+    jsPrint,
+    move,
+    line,
+    width,
+    circle,
+    rect,
+    color,
+    sourcePtr: () => sourcePtr,
+    sourceLength: () => sourceLength,
+  }
+  const go = new Go() // see wasm_exec.js
+  go.importObject.env = Object.assign(go.importObject.env, evyEnv)
+  return go
+}
+
+function prepareSourceAccess() {
   const code = document.getElementById("code").value
   const bytes = new TextEncoder("utf8").encode(code)
-  const ptr = wasm.exports.alloc(bytes.length)
-  const mem = new Uint8Array(wasm.exports.memory.buffer, ptr, bytes.length)
+  const e = wasmInst.exports
+  const ptr = e.alloc(bytes.length)
+  const mem = new Uint8Array(e.memory.buffer, ptr, bytes.length)
   mem.set(new Uint8Array(bytes))
+  sourcePtr = ptr
+  sourceLength = bytes.length
+}
+
+function clearOutput() {
   document.getElementById("output").textContent = ""
   resetCanvas()
-  wasm.exports.evaluate(ptr, bytes.length)
 }
 
 // --------------------------------------------------
@@ -114,7 +129,6 @@ function showConfetti() {
 }
 
 // graphics
-
 const canvas = {
   x: 0,
   y: 0,

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -7,8 +7,6 @@ import (
 	"unsafe"
 
 	"foxygo.at/evy/pkg/evaluator"
-	"foxygo.at/evy/pkg/lexer"
-	"foxygo.at/evy/pkg/parser"
 )
 
 var version string
@@ -71,19 +69,6 @@ func jsEvaluate(ptr *uint32, length int) {
 	s := getString(ptr, length)
 	builtins := evaluator.DefaultBuiltins(jsRuntime)
 	evaluator.Run(s, builtins)
-}
-
-//export tokenize
-func jsTokenize(ptr *uint32, length int) {
-	s := getString(ptr, length)
-	jsPrint(lexer.Run(s))
-}
-
-//export parse
-func jsParse(ptr *uint32, length int) {
-	s := getString(ptr, length)
-	builtins := evaluator.DefaultBuiltins(jsRuntime).Decls()
-	jsPrint(parser.Run(s, builtins))
 }
 
 // alloc pre-allocates memory used in string parameter passing.

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -12,6 +12,21 @@ import (
 var version string
 
 func main() {
+	builtins := evaluator.DefaultBuiltins(jsRuntime)
+	source := getSource()
+	evaluator.Run(source, builtins)
+}
+
+//export sourcePtr
+func sourcePtr() *uint32
+
+//export sourceLength
+func sourceLength() int
+
+func getSource() string {
+	ptr := sourcePtr()
+	length := sourceLength()
+	return getString(ptr, length)
 }
 
 // jsPrint is imported from JS
@@ -57,20 +72,6 @@ var jsRuntime evaluator.Runtime = evaluator.Runtime{
 	},
 }
 
-// evaluate evaluates an evy program, after tokenizing and parsing. It
-// is exported to wasm and JS. Strings cannot be passed to wasm
-// directly so we need to use linear memory arithmetic as workaround.
-// See:
-// * https://www.wasm.builders/k33g_org/an-essay-on-the-bi-directional-exchange-of-strings-between-the-wasm-module-with-tinygo-and-nodejs-with-wasi-support-3i9h
-// * https://www.alcarney.me/blog/2020/passing-strings-between-tinygo-wasm/
-//
-//export evaluate
-func jsEvaluate(ptr *uint32, length int) {
-	s := getString(ptr, length)
-	builtins := evaluator.DefaultBuiltins(jsRuntime)
-	evaluator.Run(s, builtins)
-}
-
 // alloc pre-allocates memory used in string parameter passing.
 //
 //export alloc
@@ -79,8 +80,12 @@ func alloc(size uint32) *byte {
 	return &buf[0]
 }
 
-// getString turns pointers in linear memory into string, see comments
-// for evaluate.
+// getString turns pointer and length in linear memory into string
+// Strings cannot be passed to or returned from wasm directly so we
+// need to use linear memory arithmetic as workaround.
+// See:
+// * https://www.wasm.builders/k33g_org/an-essay-on-the-bi-directional-exchange-of-strings-between-the-wasm-module-with-tinygo-and-nodejs-with-wasi-support-3i9h
+// * https://www.alcarney.me/blog/2020/passing-strings-between-tinygo-wasm
 func getString(ptr *uint32, length int) string {
 	var builder strings.Builder
 	uptr := uintptr(unsafe.Pointer(ptr))


### PR DESCRIPTION
Rework evy-evaluation to be hoisted on main rather than the separately
exported `evaluate` function. Some things, such as time.Sleep and
fmt.Sprintf only get properly initialised if the main*() function is
the entry point to the wasm code.

Additional, we had to solve to problem of having a JS function
returning a string in memory - we've done this in a hacky way by
returning Ptr and Length in separate function calls.

In preparation remove Lex and Parse button and wasm bindings.