### PR TITLE
evaluator: Add builtin sleep

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -2,6 +2,7 @@
 
 let wasmModule, wasmInst
 let sourcePtr, sourceLength
+const go = newEvyGo() // see wasm_exec.js
 
 // initWasm loads bytecode and initialises execution environment.
 function initWasm() {
@@ -34,7 +35,6 @@ function memString(ptr, len) {
 // converts it to wasm memory bytes. It then calls the evy main()
 // function running the evaluator after parsing.
 async function handleRun(event) {
-  const go = newEvyGo() // see wasm_exec.js
   wasmInst = await WebAssembly.instantiate(wasmModule, go.importObject)
   prepareSourceAccess()
   clearOutput()

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -3,6 +3,7 @@ package evaluator
 import (
 	"strconv"
 	"strings"
+	"time"
 
 	"foxygo.at/evy/pkg/parser"
 )
@@ -40,6 +41,8 @@ func DefaultBuiltins(rt Runtime) Builtins {
 		"len": {Func: BuiltinFunc(lenFunc), Decl: lenDecl},
 		"has": {Func: BuiltinFunc(hasFunc), Decl: hasDecl},
 		"del": {Func: BuiltinFunc(delFunc), Decl: delDecl},
+
+		"sleep": {Func: BuiltinFunc(sleepFunc), Decl: sleepDecl},
 
 		"move":   xyBuiltin("move", rt.Graphics.Move, rt.Print),
 		"line":   xyBuiltin("line", rt.Graphics.Line, rt.Print),
@@ -188,6 +191,19 @@ func delFunc(args []Value) Value {
 	m := args[0].(*Map)
 	keyStr := args[1].(*String)
 	m.Delete(keyStr.Val)
+	return nil
+}
+
+var sleepDecl = &parser.FuncDecl{
+	Name:       "sleep",
+	Params:     []*parser.Var{{Name: "seconds", T: parser.NUM_TYPE}},
+	ReturnType: parser.NONE_TYPE,
+}
+
+func sleepFunc(args []Value) Value {
+	secs := args[0].(*Num)
+	dur := time.Duration(secs.Val * float64(time.Second))
+	time.Sleep(dur)
 	return nil
 }
 


### PR DESCRIPTION
Add the builtin `sleep` function: `sleep 1` sleeps for one second, 
`sleep 0.001` sleeps for one milli second. Now that we have wasm
hoisted on the main() go function we can just map to Go's sleep
function which panic'ed before.

![evy](https://user-images.githubusercontent.com/1596871/216761047-e953298e-a3a9-4a44-ad4c-23e3fd978644.gif)
