### PR TITLE
all: Implement stop

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -2,14 +2,14 @@
 
 let wasmModule, wasmInst
 let sourcePtr, sourceLength
-const go = newEvyGo() // see wasm_exec.js
+const go = newEvyGo()
+const runButton = document.getElementById("run")
 
 // initWasm loads bytecode and initialises execution environment.
 function initWasm() {
   WebAssembly.compileStreaming(fetch("evy.wasm"))
     .then((obj) => (wasmModule = obj))
     .catch((err) => console.error(err))
-  const runButton = document.getElementById("run")
   runButton.onclick = handleRun
   runButton.disabled = false
 }
@@ -35,10 +35,20 @@ function memString(ptr, len) {
 // converts it to wasm memory bytes. It then calls the evy main()
 // function running the evaluator after parsing.
 async function handleRun(event) {
+  if (runButton.innerText === "Stop") {
+    wasmInst.exports.stop()
+    onExit()
+    return
+  }
   wasmInst = await WebAssembly.instantiate(wasmModule, go.importObject)
   prepareSourceAccess()
   clearOutput()
+  runButton.innerText = "Stop"
   go.run(wasmInst)
+}
+
+function onExit() {
+  runButton.innerText = "Run"
 }
 
 function newEvyGo() {
@@ -50,6 +60,7 @@ function newEvyGo() {
     circle,
     rect,
     color,
+    onExit,
     sourcePtr: () => sourcePtr,
     sourceLength: () => sourceLength,
   }

--- a/main.go
+++ b/main.go
@@ -46,7 +46,8 @@ func (c *cmdRun) Run() error {
 	printFn := func(s string) { fmt.Print(s) }
 	rt := evaluator.Runtime{Print: printFn}
 	builtins := evaluator.DefaultBuiltins(rt)
-	evaluator.Run(string(b), builtins)
+	eval := evaluator.NewEvaluator(builtins)
+	eval.Run(string(b))
 	return nil
 }
 
@@ -65,10 +66,11 @@ func (c *cmdParse) Run() error {
 	if err != nil {
 		return err
 	}
-	printFunc := func(s string) { fmt.Print(s) }
-	rt := evaluator.Runtime{Print: printFunc}
-	builtins := evaluator.DefaultBuiltins(rt).Decls()
-	result := parser.Run(string(b), builtins)
+	rt := evaluator.Runtime{
+		Print: func(s string) { fmt.Print(s) },
+	}
+	builtinDecls := evaluator.DefaultDecls(rt)
+	result := parser.Run(string(b), builtinDecls)
 	fmt.Println(result)
 	return nil
 }

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -18,9 +18,9 @@ type Builtins struct {
 	Print func(s string)
 }
 
-func (b Builtins) Decls() map[string]*parser.FuncDecl {
-	decls := make(map[string]*parser.FuncDecl, len(b.Funcs))
-	for name, builtin := range b.Funcs {
+func newFuncDecls(funcs map[string]Builtin) map[string]*parser.FuncDecl {
+	decls := make(map[string]*parser.FuncDecl, len(funcs))
+	for name, builtin := range funcs {
 		decls[name] = builtin.Decl
 	}
 	return decls
@@ -53,6 +53,11 @@ func DefaultBuiltins(rt Runtime) Builtins {
 		"colour": stringBuiltin("colour", rt.Graphics.Color, rt.Print),
 	}
 	return Builtins{Funcs: funcs, Print: rt.Print}
+}
+
+func DefaultDecls(rt Runtime) map[string]*parser.FuncDecl {
+	db := DefaultBuiltins(rt)
+	return newFuncDecls(db.Funcs)
 }
 
 type Runtime struct {

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -12,7 +12,8 @@ func run(input string) string {
 	b := bytes.Buffer{}
 	printFn := func(s string) { b.WriteString(s) }
 	rt := Runtime{Print: printFn}
-	Run(input, DefaultBuiltins(rt))
+	eval := NewEvaluator(DefaultBuiltins(rt))
+	eval.Run(input)
 	return b.String()
 }
 

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -195,8 +195,13 @@ func (r *Break) String() string      { return "" }
 func (r *Break) Equals(_ Value) bool { return false }
 func (r *Break) Set(_ Value)         {}
 
-func (e *Error) Type() ValueType     { return ERROR }
-func (e *Error) String() string      { return "ERROR: " + e.Message }
+func (e *Error) Type() ValueType { return ERROR }
+func (e *Error) String() string {
+	if e == ErrStopped {
+		return "Stopped"
+	}
+	return "ERROR: " + e.Message
+}
 func (e *Error) Equals(_ Value) bool { return false }
 func (e *Error) Set(_ Value)         {}
 

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -10,24 +10,27 @@ import (
 )
 
 var version string
+var eval *evaluator.Evaluator
 
 func main() {
 	builtins := evaluator.DefaultBuiltins(jsRuntime)
-	source := getSource()
-	evaluator.Run(source, builtins)
+	eval = evaluator.NewEvaluator(builtins)
+	eval.Run(getSource())
 }
-
-//export sourcePtr
-func sourcePtr() *uint32
-
-//export sourceLength
-func sourceLength() int
 
 func getSource() string {
 	ptr := sourcePtr()
 	length := sourceLength()
 	return getString(ptr, length)
 }
+
+// --- JS function exported to Go/WASM ---------------------------------
+
+//export sourcePtr
+func sourcePtr() *uint32
+
+//export sourceLength
+func sourceLength() int
 
 // jsPrint is imported from JS
 //export jsPrint
@@ -71,6 +74,8 @@ var jsRuntime evaluator.Runtime = evaluator.Runtime{
 		Color:  func(s string) { color(s) },
 	},
 }
+
+// --- Go function exported to JS/WASM runtime -------------------------
 
 // alloc pre-allocates memory used in string parameter passing.
 //


### PR DESCRIPTION
Implement stop in frontend by turning the Run button into a Stop button
during execution. For this we also need an onExit callback into JS from
go when execution finishes so that the button label gets reset.

Additionally we need to occasionally yield to JS event processing via a
`time.Sleep` in the evaluator code. This operation is abstracted via
the Yielder interface.

Execution is stopped in Eval if the Stopped flag is set, which gets set
on click via the exported Go function stop(). The access to the stop
flag is not synchronised, but as JS is single threaded so we don't need
to worry about it.

In a preparatory commit refactor evaluator and builtins so that there is 
a separate `NewEvaluator` function and `e.Run` method. This allows for
`wasm/main.go` to hold an evaluator as global variable on which we set the 
`evaluator.Stopped` flag. 

Evy program for testing.
```
while true 
   rect 10 10
end
```
another one with sleep:
```
for i := range 0 100 0.1
  clear
  dot i 50

  sleep 0.01
end

func clear
  color "white"
  move 0 0 
  rect 100 100
end

func dot x:num y:num
  color "red"
  move x y
  circle 10
end
```