### PR TITLE
parser: Error on function redeclaration

### DIFF
--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -967,6 +967,32 @@ end
 	}
 }
 
+func TestFuncDeclErr(t *testing.T) {
+	inputs := map[string]string{
+		`
+func len s:string
+   print "len:" s
+end
+`: "line 2 column 1: cannot override builtin function len",
+		`
+func fox
+   print "fox"
+end
+
+func fox
+   print "fox overridden"
+end
+`: "line 6 column 1: redeclaration of function fox",
+	}
+	for input, wantErr := range inputs {
+		parser := New(input, testBuiltins())
+		_ = parser.Parse()
+		assertParseError(t, parser, input)
+		gotErr := MaxErrorsString(parser.Errors(), 1)
+		assert.Equal(t, wantErr, gotErr, "input: %s", input)
+	}
+}
+
 func TestDemo(t *testing.T) {
 	input := `
 move 10 10


### PR DESCRIPTION
Error on function redeclaration, including builtin functions. Before we
would just let new functions override existing functions which is
pretty confusing, err early err often.