### PR TITLE
parser: Update eventHandler parsing for parameters and bare return

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func (c *cmdParse) Run() error {
 	rt := evaluator.Runtime{
 		Print: func(s string) { fmt.Print(s) },
 	}
-	builtinDecls := evaluator.DefaultDecls(rt)
+	builtinDecls := evaluator.DefaulParserBuiltins(rt)
 	result := parser.Run(string(b), builtinDecls)
 	fmt.Println(result)
 	return nil

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -10,7 +10,7 @@ import (
 func NewEvaluator(builtins Builtins) *Evaluator {
 	return &Evaluator{
 		print:    builtins.Print,
-		builtins: builtins.Funcs,
+		builtins: builtins,
 		scope:    newScope(),
 	}
 }
@@ -19,13 +19,13 @@ type Evaluator struct {
 	Stopped  bool
 	Yielder  Yielder // Yield to give JavaScript/browser events a chance to run.
 	print    func(string)
-	builtins map[string]Builtin
+	builtins Builtins
 
 	scope *scope // Current top of scope stack
 }
 
 func (e *Evaluator) Run(input string) {
-	p := parser.New(input, newFuncDecls(e.builtins))
+	p := parser.New(input, newParserBuiltins(e.builtins))
 	prog := p.Parse()
 	if p.HasErrors() {
 		e.print(parser.MaxErrorsString(p.Errors(), 8))
@@ -175,7 +175,7 @@ func (e *Evaluator) evalFunctionCall(funcCall *parser.FunctionCall) Value {
 	if len(args) == 1 && isError(args[0]) {
 		return args[0]
 	}
-	builtin, ok := e.builtins[funcCall.Name]
+	builtin, ok := e.builtins.Funcs[funcCall.Name]
 	if ok {
 		return builtin.Func(args)
 	}

--- a/pkg/lexer/token.go
+++ b/pkg/lexer/token.go
@@ -189,6 +189,9 @@ func (t TokenType) FormatDetails() string {
 	if t == NL {
 		return "end of line"
 	}
+	if t == IDENT {
+		return "identifier"
+	}
 	return "'" + t.Format() + "'"
 }
 

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -126,8 +126,10 @@ type ConditionalBlock struct {
 }
 
 type EventHandler struct {
-	Name string
-	Body *BlockStatement
+	Token  *lexer.Token // The 'on' token
+	Name   string
+	Params []*Var
+	Body   *BlockStatement
 }
 
 type Var struct {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -650,6 +650,10 @@ func (p *Parser) parseForStatement(scope *scope) Node {
 		return nil
 	}
 	forNode.LoopVar = &Var{Token: p.cur, Name: p.cur.Literal, T: NONE_TYPE}
+	if !p.validateVarDecl(scope, forNode.LoopVar, p.cur) {
+		p.advancePastNL()
+		return nil
+	}
 	scope.set(forNode.LoopVar.Name, forNode.LoopVar)
 	p.advance() // advance past loopVarName
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -168,19 +168,12 @@ func (p *Parser) parseFunc(scope *scope) Node {
 
 func (p *Parser) addParamsToScope(scope *scope, fd *FuncDecl) {
 	for _, param := range fd.Params {
-		if scope.inLocalScope(param.Name) {
-			p.appendErrorForToken("redeclaration of parameter '"+param.Name+"'", param.Token)
-		}
-		if _, ok := p.funcs[param.Name]; ok {
-			p.appendErrorForToken("invalid declaration of parameter '"+param.Name+"', already used as function name", param.Token)
-		}
+		p.validateVarDecl(scope, param, param.Token)
 		scope.set(param.Name, param)
 	}
 	if fd.VariadicParam != nil {
 		param := fd.VariadicParam
-		if _, ok := p.funcs[param.Name]; ok {
-			p.appendErrorForToken("invalid declaration of parameter '"+param.Name+"', already used as function name", param.Token)
-		}
+		p.validateVarDecl(scope, param, param.Token)
 		scope.set(param.Name, param)
 	}
 }

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -602,17 +602,17 @@ end
 func x in:string in:string
    print in
 end
-`: "line 2 column 18: redeclaration of parameter 'in'",
+`: "line 2 column 18: redeclaration of 'in'",
 		`
 func x x:string
    print x
 end
-`: "line 2 column 8: invalid declaration of parameter 'x', already used as function name",
+`: "line 2 column 8: invalid declaration of 'x', already used as function name",
 		`
 func x x:string...
    print x
 end
-`: "line 2 column 8: invalid declaration of parameter 'x', already used as function name",
+`: "line 2 column 8: invalid declaration of 'x', already used as function name",
 	}
 	for input, wantErr := range inputs {
 		parser := New(input, testBuiltins())

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -204,7 +204,7 @@ func nums1:num n1:num n2:num
 	end
 	return n2
 end
-on mousedown
+on down
 	if c > 10
 	    print c
 	end
@@ -991,6 +991,53 @@ func fox
    print "fox overridden"
 end
 `: "line 6 column 1: redeclaration of function fox",
+	}
+	for input, wantErr := range inputs {
+		parser := New(input, testBuiltins())
+		_ = parser.Parse()
+		assertParseError(t, parser, input)
+		gotErr := MaxErrorsString(parser.Errors(), 1)
+		assert.Equal(t, wantErr, gotErr, "input: %s", input)
+	}
+}
+
+func TestEventHandler(t *testing.T) {
+	inputs := []string{
+		`
+on down x:num y:num
+   print "pointer down:" x y
+end`,
+		`
+on down x:num y:num
+   print "pointer down:" x y
+   if x > 100
+      return
+   end
+end`,
+	}
+	for _, input := range inputs {
+		parser := New(input, testBuiltins())
+		_ = parser.Parse()
+		assertNoParseError(t, parser, input)
+	}
+}
+
+func TestEventHandlerErr(t *testing.T) {
+	inputs := map[string]string{
+		`
+on down x:num y:num
+   print "pointer down:" x y
+`: "line 4 column 1: expected 'end', got end of input",
+		`
+on x:num y:num
+   print "pointer down:" x y
+end
+`: "line 2 column 5: expected identifier, got ':'",
+		`
+on down x:num y:num
+return "abc"
+end
+`: "line 3 column 8: expected no return value, found string",
 	}
 	for input, wantErr := range inputs {
 		parser := New(input, testBuiltins())

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -957,6 +957,14 @@ for x := range 1 true
 	print "X"
 end
 `: "line 2 column 10: range expects num type for 2nd argument, found bool",
+		`
+func x
+	print "func x"
+end
+for x := range 10
+	print "x" x
+end
+`: "line 5 column 5: invalid declaration of 'x', already used as function name",
 	}
 	for input, wantErr := range inputs {
 		parser := New(input, testBuiltins())

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -118,10 +118,10 @@ func TestFunctionCall(t *testing.T) {
 
 func TestFunctionCallError(t *testing.T) {
 	builtins := testBuiltins()
-	builtins["f0"] = &FuncDecl{Name: "f0", ReturnType: NONE_TYPE}
-	builtins["f1"] = &FuncDecl{Name: "f1", VariadicParam: &Var{Name: "a", T: NUM_TYPE}, ReturnType: NONE_TYPE}
-	builtins["f2"] = &FuncDecl{Name: "f2", Params: []*Var{{Name: "a", T: NUM_TYPE}}, ReturnType: NONE_TYPE}
-	builtins["f3"] = &FuncDecl{
+	builtins.Funcs["f0"] = &FuncDecl{Name: "f0", ReturnType: NONE_TYPE}
+	builtins.Funcs["f1"] = &FuncDecl{Name: "f1", VariadicParam: &Var{Name: "a", T: NUM_TYPE}, ReturnType: NONE_TYPE}
+	builtins.Funcs["f2"] = &FuncDecl{Name: "f2", Params: []*Var{{Name: "a", T: NUM_TYPE}}, ReturnType: NONE_TYPE}
+	builtins.Funcs["f3"] = &FuncDecl{
 		Name:       "f3",
 		Params:     []*Var{{Name: "a", T: NUM_TYPE}, {Name: "b", T: STRING_TYPE}},
 		ReturnType: NONE_TYPE,
@@ -234,7 +234,7 @@ end
 	parser := New(input, testBuiltins())
 	_ = parser.Parse()
 	assertNoParseError(t, parser, input)
-	builtinCnt := len(testBuiltins())
+	builtinCnt := len(testBuiltins().Funcs)
 	assert.Equal(t, builtinCnt+4, len(parser.funcs))
 	got := parser.funcs["nums1"]
 	assert.Equal(t, "nums1", got.Name)
@@ -1008,6 +1008,10 @@ on down x:num y:num
    print "pointer down:" x y
 end`,
 		`
+on down
+   print "down"
+end`,
+		`
 on down x:num y:num
    print "pointer down:" x y
    if x > 100
@@ -1029,15 +1033,24 @@ on down x:num y:num
    print "pointer down:" x y
 `: "line 4 column 1: expected 'end', got end of input",
 		`
-on x:num y:num
-   print "pointer down:" x y
+on down:num
+   print "down:" down
 end
-`: "line 2 column 5: expected identifier, got ':'",
+`: "line 2 column 8: expected identifier, got ':'",
 		`
 on down x:num y:num
 return "abc"
 end
 `: "line 3 column 8: expected no return value, found string",
+		`
+on down2 x:num y:num
+   print "down:" down
+end
+`: "line 2 column 4: unknown event name down2",
+		`
+on down x:num
+   print "pointer down:" x
+end`: "line 3 column 4: wrong number of parameters expected 2, got 1",
 	}
 	for input, wantErr := range inputs {
 		parser := New(input, testBuiltins())
@@ -1084,8 +1097,8 @@ func assertNoParseError(t *testing.T, parser *Parser, input string) {
 	assert.Equal(t, 0, len(parser.errors), "Unexpected parser error\n input: %s\nerrors:\n%s", input, ErrorsString(parser.Errors()))
 }
 
-func testBuiltins() map[string]*FuncDecl {
-	return map[string]*FuncDecl{
+func testBuiltins() Builtins {
+	funcs := map[string]*FuncDecl{
 		"print": {
 			Name:          "print",
 			VariadicParam: &Var{Name: "a", T: ANY_TYPE},
@@ -1097,4 +1110,15 @@ func testBuiltins() map[string]*FuncDecl {
 			ReturnType: NUM_TYPE,
 		},
 	}
+	eventHandlers := map[string]*EventHandler{
+		"down": {
+			Name: "down",
+			Params: []*Var{
+				{Name: "x", T: NUM_TYPE},
+				{Name: "y", T: NUM_TYPE},
+			},
+		},
+	}
+
+	return Builtins{Funcs: funcs, EventHandlers: eventHandlers}
 }


### PR DESCRIPTION
Update eventHandler parsing for parameters and bare return. Add builtin
eventHandler declarations for known even names and parameters.

In preparation fix for loop variable declaration validation and unify
parameter declaration validation with variable declaration validation.

This is part one of a two part PR. The second Part will add evaluation and 
wiring with frontend.