### PR TITLE
Parser: Add variable validation in for statements

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -650,6 +650,10 @@ func (p *Parser) parseForStatement(scope *scope) Node {
 		return nil
 	}
 	forNode.LoopVar = &Var{Token: p.cur, Name: p.cur.Literal, T: NONE_TYPE}
+	if !p.validateVarDecl(scope, forNode.LoopVar, p.cur) {
+		p.advancePastNL()
+		return nil
+	}
 	scope.set(forNode.LoopVar.Name, forNode.LoopVar)
 	p.advance() // advance past loopVarName
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -957,6 +957,14 @@ for x := range 1 true
 	print "X"
 end
 `: "line 2 column 10: range expects num type for 2nd argument, found bool",
+		`
+func x
+   print "func x"
+end
+for x := range 10
+	print "x" x
+end
+`: "line 5 column 5: invalid declaration of 'x', already used as function name",
 	}
 	for input, wantErr := range inputs {
 		parser := New(input, testBuiltins())


### PR DESCRIPTION
Add variable validation in for statements. In specific, variable
declared in the as `for VAR :=  range ...` should follow the same
validation rules as other variable declarations. It's been an
oversight.