### PR TITLE
all: Wire eventHandler to frontend

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -244,5 +244,43 @@ function circle(r) {
   ctx.fill()
 }
 
+async function initUI() {
+  document.addEventListener("keydown", ctrlEnterListener)
+  document.addEventListener("hashchange", fetchSource)
+  fetchSource()
+}
+
+function ctrlEnterListener(e) {
+  if ((e.metaKey || e.ctrlKey) && event.key === "Enter") {
+    handleRun()
+  }
+}
+
+async function fetchSource() {
+  // parse url fragment into object
+  // e.g. https://example.com#a=1&b=2 into {a: "1", b: "2"}
+  // then fetch source from URL and write it to code input.
+  const strs = window.location.hash.substring(1).split("&") //  ["a=1", "b=2"]
+  const entries = strs.map((s) => s.split("=")) // [["a", "1"], ["b", "2"]]
+  let sourceURL
+  if (entries.length === 1 && entries[0].length === 1 && entries[0][0]) {
+    // shortcut for example.com#draw loading example.com/samples/draw.evy
+    sourceURL = `samples/${entries[0][0]}.evy`
+  } else {
+    sourceURL = Object.fromEntries(entries).source
+  }
+  if (!sourceURL) {
+    return
+  }
+  try {
+    const response = await fetch(sourceURL)
+    const source = await response.text()
+    document.getElementById("code").value = source
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+initUI()
 initWasm()
 initCanvas()

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -150,7 +150,8 @@ const canvas = {
   x: 0,
   y: 0,
   ctx: null,
-  scale: { x: 10, y: -10 },
+  factor: 10,
+  scale: { x: 1, y: -1 },
   width: 100,
   height: 100,
 
@@ -178,11 +179,11 @@ function resetCanvas() {
 }
 
 function scaleX(x) {
-  return canvas.scale.x * x
+  return canvas.scale.x * canvas.factor * x
 }
 
 function scaleY(y) {
-  return canvas.scale.y * y
+  return canvas.scale.y * canvas.factor * y
 }
 
 function transformX(x) {

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -47,7 +47,6 @@ function stringToMem(s) {
 async function handleRun(event) {
   if (runButton.innerText === "Stop") {
     wasmInst.exports.stop()
-    onExit()
     return
   }
   wasmInst = await WebAssembly.instantiate(wasmModule, go.importObject)
@@ -57,7 +56,8 @@ async function handleRun(event) {
   go.run(wasmInst)
 }
 
-function onExit() {
+// onStopped is exported to evy go/wasm and called when execution finishes
+function onStopped() {
   runButton.innerText = "Run"
 }
 
@@ -70,7 +70,7 @@ function newEvyGo() {
     circle,
     rect,
     color,
-    onExit,
+    onStopped,
     sourcePtr: () => sourcePtr,
     sourceLength: () => sourceLength,
   }
@@ -193,6 +193,7 @@ function transformY(y) {
   return scaleY(y + canvas.offset.y)
 }
 
+// move is exported to evy go/wasm
 function move(x, y) {
   movePhysical(transformX(x), transformY(y))
 }
@@ -202,6 +203,7 @@ function movePhysical(px, py) {
   canvas.y = py
 }
 
+// line is exported to evy go/wasm
 function line(x2, y2) {
   const { ctx, x, y } = canvas
   const px2 = transformX(x2)
@@ -213,16 +215,19 @@ function line(x2, y2) {
   movePhysical(px2, py2)
 }
 
+// color is exported to evy go/wasm
 function color(ptr, len) {
   const s = memToString(ptr, len)
   canvas.ctx.fillStyle = s
   canvas.ctx.strokeStyle = s
 }
 
+// width is exported to evy go/wasm
 function width(n) {
   canvas.ctx.lineWidth = scaleX(n)
 }
 
+// rect is exported to evy go/wasm
 function rect(dx, dy) {
   const { ctx, x, y } = canvas
   const sDX = scaleX(dx)
@@ -231,6 +236,7 @@ function rect(dx, dy) {
   movePhysical(x + sDX, y + sDY)
 }
 
+// circle is exported to evy go/wasm
 function circle(r) {
   const { x, y, ctx } = canvas
   ctx.beginPath()

--- a/frontend/samples/dot.evy
+++ b/frontend/samples/dot.evy
@@ -1,0 +1,18 @@
+for i := range 0 100 0.1
+  clear
+  dot i 50
+
+  sleep 0.01
+end
+
+func clear
+  color "white"
+  move 0 0
+  rect 100 100
+end
+
+func dot x:num y:num
+  color "red"
+  move x y
+  circle 10
+end

--- a/frontend/samples/draw.evy
+++ b/frontend/samples/draw.evy
@@ -1,0 +1,17 @@
+down := false
+width 1
+
+on down x:num y:num
+  down = true
+  move x y
+end
+
+on up
+  down = false
+end
+
+on move x:num y:num
+  if down
+    line x y
+  end
+end

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -4,6 +4,8 @@
 package evaluator
 
 import (
+	"fmt"
+
 	"foxygo.at/evy/pkg/parser"
 )
 
@@ -16,12 +18,18 @@ func NewEvaluator(builtins Builtins) *Evaluator {
 }
 
 type Evaluator struct {
-	Stopped  bool
-	Yielder  Yielder // Yield to give JavaScript/browser events a chance to run.
-	print    func(string)
-	builtins Builtins
+	Stopped       bool
+	Yielder       Yielder // Yield to give JavaScript/browser events a chance to run.
+	print         func(string)
+	builtins      Builtins
+	eventHandlers map[string]*parser.EventHandler
 
 	scope *scope // Current top of scope stack
+}
+
+type Event struct {
+	Name   string
+	Params []any
 }
 
 func (e *Evaluator) Run(input string) {
@@ -31,6 +39,7 @@ func (e *Evaluator) Run(input string) {
 		e.print(parser.MaxErrorsString(p.Errors(), 8))
 		return
 	}
+	e.eventHandlers = p.EventHandlers
 	val := e.Eval(prog)
 	if isError(val) {
 		e.print(val.String())
@@ -91,10 +100,40 @@ func (e *Evaluator) Eval(node parser.Node) Value {
 		return e.evalSliceExpr(node)
 	case *parser.DotExpression:
 		return e.evalDotExpr(node, false /* forAssign */)
-	case *parser.FuncDecl:
+	case *parser.FuncDecl, *parser.EventHandler:
 		return nil
 	}
-	return newError("internal error: unknown node type")
+	return newError(fmt.Sprintf("internal error: unknown node type %v", node))
+}
+
+func (e *Evaluator) EventHandlerNames() []string {
+	names := make([]string, 0, len(e.eventHandlers))
+	for name := range e.eventHandlers {
+		names = append(names, name)
+	}
+	return names
+}
+
+func (e *Evaluator) HandleEvent(ev Event) {
+	eh := e.eventHandlers[ev.Name]
+	if eh == nil {
+		panic("no event handler for " + ev.Name)
+	}
+	e.pushScope()
+	defer e.popScope()
+	args := ev.Params
+	if len(args) < len(eh.Params) {
+		panic("not enough arguments for " + ev.Name)
+	}
+	for i, param := range eh.Params {
+		arg := valueFromAny(param.Type(), args[i])
+		e.scope.set(param.Name, arg)
+	}
+	result := e.Eval(eh.Body)
+
+	if isError(result) {
+		e.print(result.String())
+	}
 }
 
 func (e *Evaluator) yield() {

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -1,6 +1,7 @@
 package evaluator
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -441,4 +442,28 @@ func zero(t *parser.Type) Value {
 		return &Map{Pairs: map[string]Value{}, Order: &order}
 	}
 	return newError("cannot create zero value for type " + t.String())
+}
+
+func valueFromAny(t *parser.Type, v any) Value {
+	switch {
+	case t == parser.NUM_TYPE:
+		val, ok := v.(float64)
+		if !ok {
+			return newError(fmt.Sprintf("expected number, found %v", val))
+		}
+		return &Num{Val: val}
+	case t == parser.STRING_TYPE:
+		val, ok := v.(string)
+		if !ok {
+			return newError(fmt.Sprintf("expected string, found %v", val))
+		}
+		return &String{Val: val}
+	case t == parser.BOOL_TYPE:
+		val, ok := v.(bool)
+		if !ok {
+			return newError(fmt.Sprintf("expected bool, found %v", val))
+		}
+		return &Bool{Val: val}
+	}
+	return newError("cannot create value for type " + t.String())
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -42,7 +42,7 @@ type Parser struct {
 	tokens        []*lexer.Token
 	builtins      Builtins
 	funcs         map[string]*FuncDecl     // all function declarations by name
-	eventHandlers map[string]*EventHandler // all event handler declarations by name
+	EventHandlers map[string]*EventHandler // all event handler declarations by name
 
 	wssStack []bool
 }
@@ -62,7 +62,7 @@ func New(input string, builtins Builtins) *Parser {
 
 	p := &Parser{
 		funcs:         map[string]*FuncDecl{},
-		eventHandlers: map[string]*EventHandler{},
+		EventHandlers: map[string]*EventHandler{},
 		wssStack:      []bool{false},
 		builtins:      builtins,
 	}
@@ -201,12 +201,12 @@ func (p *Parser) parseEventHandler(scope *scope) Node {
 
 	e.Name = p.cur.Literal
 	switch {
-	case p.eventHandlers[e.Name] != nil:
+	case p.EventHandlers[e.Name] != nil:
 		p.appendError("redeclaration of on " + e.Name)
 	case p.builtins.EventHandlers[e.Name] == nil:
 		p.appendError("unknown event name " + e.Name)
 	default:
-		p.eventHandlers[e.Name] = e
+		p.EventHandlers[e.Name] = e
 	}
 	p.advance() // advance past event name IDENT
 	for !p.isAtEOL() {

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -18,7 +18,7 @@ func main() {
 	eval = evaluator.NewEvaluator(builtins)
 	eval.Yielder = newSleepingYielder()
 	eval.Run(getSource())
-	onExit()
+	onStopped()
 }
 
 func getSource() string {
@@ -62,9 +62,9 @@ func sourceLength() int
 //export jsPrint
 func jsPrint(string)
 
-// onExit is imported from JS
-//export onExit
-func onExit()
+// onStopped is imported from JS
+//export onStopped
+func onStopped()
 
 // move is imported from JS
 //export move

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -12,12 +12,16 @@ import (
 
 var version string
 var eval *evaluator.Evaluator
+var events []evaluator.Event
+
+const minSleepDur = time.Millisecond
 
 func main() {
 	builtins := evaluator.DefaultBuiltins(jsRuntime)
 	eval = evaluator.NewEvaluator(builtins)
 	eval.Yielder = newSleepingYielder()
 	eval.Run(getSource())
+	handleEvents()
 	onStopped()
 }
 
@@ -44,9 +48,45 @@ type sleepingYielder struct {
 func (y *sleepingYielder) Yield() {
 	y.count++
 	if y.count > 1000 && time.Since(y.start) > 100*time.Millisecond {
-		time.Sleep(time.Millisecond)
+		time.Sleep(minSleepDur)
 		y.start = time.Now()
 		y.count = 0
+	}
+}
+
+func handleEvents() {
+	if eval == nil || len(eval.EventHandlerNames()) == 0 {
+		return
+	}
+	for _, name := range eval.EventHandlerNames() {
+		registerEventHandler(name)
+	}
+	for {
+		if eval.Stopped {
+			return
+		}
+		// unsynchronized access to events - ok in WASM as single threaded.
+		if len(events) > 0 {
+			event := events[0]
+			events = events[1:]
+			eval.HandleEvent(event)
+		} else {
+			time.Sleep(minSleepDur)
+		}
+	}
+}
+
+func newXYEvent(name string, x, y float64) evaluator.Event {
+	return evaluator.Event{
+		Name:   name,
+		Params: []any{x, y},
+	}
+}
+
+func newStringEvent(name, str string) evaluator.Event {
+	return evaluator.Event{
+		Name:   name,
+		Params: []any{str},
 	}
 }
 
@@ -105,6 +145,9 @@ var jsRuntime evaluator.Runtime = evaluator.Runtime{
 	},
 }
 
+//export registerEventHandler
+func registerEventHandler(eventName string)
+
 // --- Go function exported to JS/WASM runtime -------------------------
 
 // alloc pre-allocates memory used in string parameter passing.
@@ -137,4 +180,29 @@ func stop() {
 	if eval != nil {
 		eval.Stopped = true
 	}
+}
+
+//export onUp
+func onUp(x, y float64) {
+	// unsynchronized access to events - ok in WASM as single threaded.
+	events = append(events, newXYEvent("up", x, y))
+}
+
+//export onDown
+func onDown(x, y float64) {
+	// unsynchronized access to events - ok in WASM as single threaded.
+	events = append(events, newXYEvent("down", x, y))
+}
+
+//export onMove
+func onMove(x, y float64) {
+	// unsynchronized access to events - ok in WASM as single threaded.
+	events = append(events, newXYEvent("move", x, y))
+}
+
+//export onKey
+func onKey(ptr *uint32, length int) {
+	str := getString(ptr, length)
+	// unsynchronized access to events - ok in WASM as single threaded.
+	events = append(events, newStringEvent("key", str))
 }


### PR DESCRIPTION
Wire eventHandler to frontend so that when `on <event>` block appears in
evy code the corresponding frontend event triggers the execution of
that block. Currently implemented events: `down`, `up`, `move`, `key`.

Only `frontend:` and `all:` commits are relevant, the `parser:` commits are 
covered in #70 

Sample code
https://evy-lang--73-51oq7tbx.web.app#draw

```
on down x:num y:num
  print "down" x y
end

on up
  print "up"
end

on key c:string
   print "key" c
end
```

simple drawing tool

```
d := false
width 1

on down x:num y:num
  d = true
  move x y
end

on up
  d = false
end

on move x:num y:num
  if d
    line x y
  end
end
```

