### PR TITLE
all: Investigate potential memory corruption bug

### DIFF
--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -3,9 +3,8 @@
 package main
 
 import (
-	"strings"
+	"fmt"
 	"time"
-	"unsafe"
 
 	"foxygo.at/evy/pkg/evaluator"
 )
@@ -13,18 +12,24 @@ import (
 var version string
 var eval *evaluator.Evaluator
 
+var source = `func target x:num y:num
+  colors := ["yellow" "gold" "orange" "red" "maroon"]
+  radius := 5
+
+  for c := range colors
+    radius = radius - 1
+    print "x" x "y" y "color" c "radius" radius
+  end
+end
+
+target 40 40
+`
+
 func main() {
 	builtins := evaluator.DefaultBuiltins(jsRuntime)
 	eval = evaluator.NewEvaluator(builtins)
 	eval.Yield = newSleepingYielder()
-	eval.Run(getSource())
-	onExit()
-}
-
-func getSource() string {
-	ptr := sourcePtr()
-	length := sourceLength()
-	return getString(ptr, length)
+	eval.Run(source)
 }
 
 type sleepingYielder struct {
@@ -60,89 +65,11 @@ func newSleepingYielder() func() {
 
 // --- JS function exported to Go/WASM ---------------------------------
 
-//export sourcePtr
-func sourcePtr() *uint32
-
-//export sourceLength
-func sourceLength() int
-
-// jsPrint is imported from JS
-//export jsPrint
-func jsPrint(string)
-
-// onExit is imported from JS
-//export onExit
-func onExit()
-
-// move is imported from JS
-//export move
-func move(x, y float64)
-
-// line is imported from JS
-//export line
-func line(x, y float64)
-
-// rect is imported from JS
-//export rect
-func rect(dx, dy float64)
-
-// circle is imported from JS
-//export circle
-func circle(r float64)
-
-// width is imported from JS, setting the lineWidth
-//export width
-func width(w float64)
-
-// color is imported from JS
-//export color
-func color(s string)
-
 // We cannot take the address of external/exported functions
 // (https://golang.org/cmd/cgo/#hdr-Passing_pointers) so we must wrap them in a
 // Go function first to put them in this Runtime struct.
 var jsRuntime evaluator.Runtime = evaluator.Runtime{
-	Print: func(s string) { jsPrint(s) },
-	Graphics: evaluator.GraphicsRuntime{
-		Move:   func(x, y float64) { move(x, y) },
-		Line:   func(x, y float64) { line(x, y) },
-		Rect:   func(dx, dy float64) { rect(dx, dy) },
-		Circle: func(r float64) { circle(r) },
-		Width:  func(w float64) { width(w) },
-		Color:  func(s string) { color(s) },
-	},
+	Print: func(s string) { fmt.Print(s) },
 }
 
 // --- Go function exported to JS/WASM runtime -------------------------
-
-// alloc pre-allocates memory used in string parameter passing.
-//
-//export alloc
-func alloc(size uint32) *byte {
-	buf := make([]byte, size)
-	return &buf[0]
-}
-
-// getString turns pointer and length in linear memory into string
-// Strings cannot be passed to or returned from wasm directly so we
-// need to use linear memory arithmetic as workaround.
-// See:
-// * https://www.wasm.builders/k33g_org/an-essay-on-the-bi-directional-exchange-of-strings-between-the-wasm-module-with-tinygo-and-nodejs-with-wasi-support-3i9h
-// * https://www.alcarney.me/blog/2020/passing-strings-between-tinygo-wasm
-func getString(ptr *uint32, length int) string {
-	var builder strings.Builder
-	uptr := uintptr(unsafe.Pointer(ptr))
-	for i := 0; i < length; i++ {
-		s := *(*int32)(unsafe.Pointer(uptr + uintptr(i)))
-		builder.WriteByte(byte(s))
-	}
-	return builder.String()
-}
-
-//export stop
-func stop() {
-	// unsynchronized access to eval.Stopped - ok in WASM as single threaded.
-	if eval != nil {
-		eval.Stopped = true
-	}
-}


### PR DESCRIPTION
Investigate potential memory corruption bug by removing all
communication between JS and Go/Wasm via
WebAssembly.Memory.prototype.buffer.

Hard-code evy sample program in main.go and demonstrate recurring error:
```
panic: runtime error: stack overflow
evy.wasm:0x54cf Uncaught (in promise) RuntimeError: unreachable
    at runtime.runtimePanic (evy.wasm:0x54cf)
    at internal/task.Pause (evy.wasm:0x57f5)
    at runtime.deadlock (evy.wasm:0x152d7)
    at runtime.run$1$gowrapper (evy.wasm:0x15a71)
    at tinygo_launch (evy.wasm:0x4d5db)
    at (*internal/task.Task).Resume (evy.wasm:0x534c)
    at runtime.scheduler (evy.wasm:0x15c60)
    at _start (evy.wasm:0x159bf)
    at _start.command_export (evy.wasm:0x4d90d)
    at global.Go.run (wasm_exec.js:486:24)
$runtime.runtimePanic @ evy.wasm:0x54cf
$internal/task.Pause @ evy.wasm:0x57f5
$runtime.deadlock @ evy.wasm:0x152d7
$runtime.run$1$gowrapper @ evy.wasm:0x15a71
$tinygo_launch @ evy.wasm:0x4d5db
$(*internal/task.Task).Resume @ evy.wasm:0x534c
$runtime.scheduler @ evy.wasm:0x15c60
$_start @ evy.wasm:0x159bf
$_start.command_export @ evy.wasm:0x4d90d
run @ wasm_exec.js:486
handleRun @ index.js:29
```

This program runs fine executed with `go run ./pkg/wasm/main.go`