### PR TITLE
make: Fix memory corruption bug by adding -stack-size flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ go-version:
 
 # Optimise tinygo output for size, see https://www.fermyon.com/blog/optimizing-tinygo-wasm
 tiny: go-version | $(O) ## Build for tinygo / wasm
-	tinygo build -o frontend/evy.wasm -target wasm -no-debug -ldflags='$(GO_LDFLAGS)' ./pkg/wasm
+	tinygo build -o frontend/evy.wasm -target wasm -no-debug -ldflags='$(GO_LDFLAGS)' -stack-size=128kb ./pkg/wasm
 	cp -f $$(tinygo env TINYGOROOT)/targets/wasm_exec.js frontend/
 
 tidy: ## Tidy go modules with "go mod tidy"

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -17,7 +17,7 @@ func NewEvaluator(builtins Builtins) *Evaluator {
 
 type Evaluator struct {
 	Stopped  bool
-	Yield    func() // Yield to give JavaScript/browser events a chance to run.
+	Yielder  Yielder // Yield to give JavaScript/browser events a chance to run.
 	print    func(string)
 	builtins map[string]Builtin
 
@@ -35,6 +35,10 @@ func (e *Evaluator) Run(input string) {
 	if isError(val) {
 		e.print(val.String())
 	}
+}
+
+type Yielder interface {
+	Yield()
 }
 
 var ErrStopped = newError("stopped")
@@ -94,8 +98,8 @@ func (e *Evaluator) Eval(node parser.Node) Value {
 }
 
 func (e *Evaluator) yield() {
-	if e.Yield != nil {
-		e.Yield()
+	if e.Yielder != nil {
+		e.Yielder.Yield()
 	}
 }
 


### PR DESCRIPTION
Fix memory corruption bug by adding `-stack-size` flag to 
`tinygo build` to fix memory corruption issues.

Revert sleeping yielder to interface

Link: https://gophers.slack.com/archives/CDJD3SUP6/p1676264760211069

Programs for testing:

Print circles
```
func target x:num y:num
  move x y
  colors := ["yellow" "gold" "orange" "red" "maroon"]
  radius := 5

  for c := range colors
    color c
    circle radius
    radius = radius - 1
  end 
end

target 40 40
```

Stop/Start non-sleeping endless loop
```
while true
  print "🛼"
end
```

Stop/Start with sleep
```
for i := range 0 100 0.1
  clear
  dot i 50

  sleep 0.01
end

func clear
  color "white"
  move 0 0
  rect 100 100
end

func dot x:num y:num
  color "red"
  move x y
  circle 10
end
```


