### PR TITLE
builtin: Add printf and sprintf functions

### DIFF
--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -489,7 +489,7 @@ print "2 arr5" arr5
 		"",
 	}
 	got := strings.Split(out, "\n")
-	assert.Equal(t, len(want), len(got), got)
+	assert.Equal(t, len(want), len(got), out)
 	for i := range want {
 		assert.Equal(t, want[i], got[i])
 	}
@@ -521,7 +521,7 @@ print "6" arr arr2
 		"",
 	}
 	got := strings.Split(out, "\n")
-	assert.Equal(t, len(want), len(got), got)
+	assert.Equal(t, len(want), len(got), out)
 	for i := range want {
 		assert.Equal(t, want[i], got[i])
 	}
@@ -552,7 +552,7 @@ print "6" s s2
 		"",
 	}
 	got := strings.Split(out, "\n")
-	assert.Equal(t, len(want), len(got), got)
+	assert.Equal(t, len(want), len(got), out)
 	for i := range want {
 		assert.Equal(t, want[i], got[i])
 	}
@@ -595,7 +595,7 @@ end
 		"",
 	}
 	got := strings.Split(out, "\n")
-	assert.Equal(t, len(want), len(got), got)
+	assert.Equal(t, len(want), len(got), out)
 	for i := range want {
 		assert.Equal(t, want[i], got[i])
 	}
@@ -617,7 +617,7 @@ end
 		"",
 	}
 	got := strings.Split(out, "\n")
-	assert.Equal(t, len(want), len(got), got)
+	assert.Equal(t, len(want), len(got), out)
 	for i := range want {
 		assert.Equal(t, want[i], got[i])
 	}
@@ -640,7 +640,7 @@ end
 		"",
 	}
 	got := strings.Split(out, "\n")
-	assert.Equal(t, len(want), len(got), got)
+	assert.Equal(t, len(want), len(got), out)
 	for i := range want {
 		assert.Equal(t, want[i], got[i])
 	}
@@ -663,7 +663,7 @@ end
 		"",
 	}
 	got := strings.Split(out, "\n")
-	assert.Equal(t, len(want), len(got), got)
+	assert.Equal(t, len(want), len(got), out)
 	for i := range want {
 		assert.Equal(t, want[i], got[i])
 	}
@@ -711,7 +711,7 @@ print "6" m6
 		"",
 	}
 	got := strings.Split(out, "\n")
-	assert.Equal(t, len(want), len(got), got)
+	assert.Equal(t, len(want), len(got), out)
 	for i := range want {
 		assert.Equal(t, want[i], got[i])
 	}
@@ -741,7 +741,7 @@ print (has m "MISSING")
 		"",
 	}
 	got := strings.Split(out, "\n")
-	assert.Equal(t, len(want), len(got), got)
+	assert.Equal(t, len(want), len(got), out)
 	for i := range want {
 		assert.Equal(t, want[i], got[i])
 	}
@@ -777,7 +777,7 @@ print "4" m1 m2
 		"",
 	}
 	got := strings.Split(out, "\n")
-	assert.Equal(t, len(want), len(got), got)
+	assert.Equal(t, len(want), len(got), out)
 	for i := range want {
 		assert.Equal(t, want[i], got[i])
 	}

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -811,6 +811,43 @@ print (s)
 	assert.Equal(t, want, got)
 }
 
+func TestSprintf(t *testing.T) {
+	prog := `
+print "1:" (sprintf "-%4.1f-" 1)
+print "2:" (sprintf "%v %v %v %v %v" 42 true "🐥" [1 "b"] {name: "🦊"})
+`
+	out := run(prog)
+	want := []string{
+		"1: - 1.0-",
+		"2: 42 true 🐥 [1 b] {name:🦊}",
+		"",
+	}
+	got := strings.Split(out, "\n")
+	assert.Equal(t, len(want), len(got), out)
+	for i := range want {
+		assert.Equal(t, want[i], got[i])
+	}
+}
+
+func TestPrintf(t *testing.T) {
+	prog := `
+printf "1: -%4.1f-\n" 1
+printf "2: %v %v %v %v %v\n" 42 true "🐥" [1 "b"] {name: "🦊"}
+`
+	out := run(prog)
+
+	want := []string{
+		"1: - 1.0-",
+		"2: 42 true 🐥 [1 b] {name:🦊}",
+		"",
+	}
+	got := strings.Split(out, "\n")
+	assert.Equal(t, len(want), len(got), out)
+	for i := range want {
+		assert.Equal(t, want[i], got[i])
+	}
+}
+
 func TestParamAssign(t *testing.T) {
 	prog := `
 x := 1

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -467,3 +467,18 @@ func valueFromAny(t *parser.Type, v any) Value {
 	}
 	return newError("cannot create value for type " + t.String())
 }
+
+func unwrapBasicValue(val Value) any {
+	switch v := val.(type) {
+	case *Num:
+		return v.Val
+	case *String:
+		return v.Val
+	case *Bool:
+		return v.Val
+	case *Any:
+		return unwrapBasicValue(v.Val)
+	default:
+		return v.String()
+	}
+}

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -274,9 +274,10 @@ func TestIllegal(t *testing.T) {
 		want Token
 	}{
 		{in: ",  ", want: Token{Offset: 0, Literal: ",", Line: 1, Col: 1}},
-		{in: `"unterminated`, want: Token{Offset: 0, Literal: `"`, Line: 1, Col: 1}},
+		{in: `"unterminated`, want: Token{Offset: 0, Literal: "invalid string", Line: 1, Col: 1}},
 		{in: `"newline in the
-		middle "`, want: Token{Offset: 0, Literal: `"`, Line: 1, Col: 1}},
+		middle "`, want: Token{Offset: 0, Literal: "invalid string", Line: 1, Col: 1}},
+		{in: `"bad escape: \X"`, want: Token{Offset: 0, Literal: "invalid string", Line: 1, Col: 1}},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -298,7 +299,7 @@ func TestRun(t *testing.T) {
 		{in: "\n", want: "NL\n"},
 		{in: ` "abc"`, want: "WS\nSTRING_LIT 'abc'\n"},
 		{in: ",", want: "ILLEGAL 💥 ',' at line 1 column 1\n"},
-		{in: `"asdf `, want: "ILLEGAL 💥 '\"' at line 1 column 1\n"},
+		{in: `"asdf `, want: "ILLEGAL 💥 'invalid string' at line 1 column 1\n"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Add printf and sprintf functions using Go's fmt.Sprintf (which now that we
hoist wasm code via main works 🚀). To allow for formatted printed of
numbers and bools add and `unwrap` function to value.go, unwrapping the
value of the Value interface implementation for basic types only.

In the process of creating printf, we discovered some missing unescaping in
the lexing stage as the goal is to keep string handling consistent with Go
and print "\n" as newlines. Fix it and improve error message for invalid
strings.

While at fix evaluator test output for multiline test cases and failed
tests.