### PR TITLE
evalutor: Add str2num and str2bool functions

### DIFF
--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -216,7 +216,7 @@ func (e *Evaluator) evalFunctionCall(funcCall *parser.FunctionCall) Value {
 	}
 	builtin, ok := e.builtins.Funcs[funcCall.Name]
 	if ok {
-		return builtin.Func(args)
+		return builtin.Func(e.scope, args)
 	}
 	e.pushScope()
 	defer e.popScope()

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -10,10 +10,14 @@ import (
 )
 
 func NewEvaluator(builtins Builtins) *Evaluator {
+	scope := newScope()
+	for _, global := range builtins.Globals {
+		scope.set(global.Name, zero(global.Type()))
+	}
 	return &Evaluator{
 		print:    builtins.Print,
 		builtins: builtins,
-		scope:    newScope(),
+		scope:    scope,
 	}
 }
 

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -925,6 +925,57 @@ print n a m`
 	assert.Equal(t, want, got)
 }
 
+func TestStr2BoolNum(t *testing.T) {
+	prog := `
+print 1 (str2bool "1") err
+print 2 (str2bool "TRUE") err
+print 3 (str2bool "true") err
+print 4 (str2bool "False") err
+print 5 (str2num "1") err
+print 6 (str2num "-1.7") err
+`
+	out := run(prog)
+	want := []string{
+		"1 true false",
+		"2 true false",
+		"3 true false",
+		"4 false false",
+		"5 1 false",
+		"6 -1.7 false",
+		"",
+	}
+	got := strings.Split(out, "\n")
+	assert.Equal(t, len(want), len(got), out)
+	for i := range want {
+		assert.Equal(t, want[i], got[i])
+	}
+}
+
+func TestStr2BoolNumErr(t *testing.T) {
+	prog := `
+print 1 (str2bool "BAD") err
+print 2 errmsg
+str2bool "true"
+print 3 err  // check reset
+print 4 (str2num "BAD") err
+print 5 errmsg
+`
+	out := run(prog)
+	want := []string{
+		"1 false true",
+		"2 str2bool: cannot parse BAD",
+		"3 false",
+		"4 0 true",
+		"5 str2num: cannot parse BAD",
+		"",
+	}
+	got := strings.Split(out, "\n")
+	assert.Equal(t, len(want), len(got), out)
+	for i := range want {
+		assert.Equal(t, want[i], got[i])
+	}
+}
+
 func TestDemo(t *testing.T) {
 	prog := `
 move 10 10

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -100,9 +100,9 @@ func New(input string, builtins Builtins) *Parser {
 		case p.funcs[fd.Name] == nil:
 			p.funcs[fd.Name] = fd
 		case builtins.Funcs[fd.Name] == nil:
-			p.appendErrorForToken("redeclaration of function "+fd.Name, fd.Token)
+			p.appendErrorForToken("redeclaration of function '"+fd.Name+"'", fd.Token)
 		case builtins.Funcs[fd.Name] != nil:
-			p.appendErrorForToken("cannot override builtin function "+fd.Name, fd.Token)
+			p.appendErrorForToken("cannot override builtin function '"+fd.Name+"'", fd.Token)
 		}
 	}
 	return p

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -17,6 +17,7 @@ import (
 type Builtins struct {
 	Funcs         map[string]*FuncDecl
 	EventHandlers map[string]*EventHandler
+	Globals       map[string]*Var
 }
 
 func Run(input string, builtins Builtins) string {
@@ -59,7 +60,6 @@ func (e Error) String() string {
 
 func New(input string, builtins Builtins) *Parser {
 	l := lexer.New(input)
-
 	p := &Parser{
 		funcs:         map[string]*FuncDecl{},
 		EventHandlers: map[string]*EventHandler{},
@@ -96,6 +96,11 @@ func New(input string, builtins Builtins) *Parser {
 	for _, i := range funcs {
 		p.advanceTo(i)
 		fd := p.parseFuncDeclSignature()
+		if p.builtins.Globals[fd.Name] != nil {
+			// We still go on to add `fd` to the funcs map so that the
+			// function can be parsed correctly even though it has an invalid name.
+			p.appendErrorForToken("cannot override builtin variable '"+fd.Name+"'", fd.Token)
+		}
 		switch {
 		case p.funcs[fd.Name] == nil:
 			p.funcs[fd.Name] = fd
@@ -125,6 +130,10 @@ func (p *Parser) Parse() *Program {
 func (p *Parser) parseProgram() *Program {
 	program := &Program{}
 	scope := newScope(nil, program) // TODO: model scope as stack like evaluator.
+	for _, global := range p.builtins.Globals {
+		global.isUsed = true
+		scope.set(global.Name, global)
+	}
 	p.advanceTo(0)
 	for p.cur.TokenType() != lexer.EOF {
 		var stmt Node
@@ -407,6 +416,10 @@ func (p *Parser) parseTypedDecl() *Declaration {
 }
 
 func (p *Parser) validateVarDecl(scope *scope, v *Var, tok *lexer.Token) bool {
+	if _, ok := p.builtins.Globals[v.Name]; ok {
+		p.appendErrorForToken("redeclaration of builtin variable '"+v.Name+"'", tok)
+		return false
+	}
 	if scope.inLocalScope(v.Name) { // already declared in current scope
 		p.appendErrorForToken("redeclaration of '"+v.Name+"'", tok)
 		return false

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1061,6 +1061,29 @@ end`: "line 3 column 4: wrong number of parameters expected 2, got 1",
 	}
 }
 
+func TestGlobalErr(t *testing.T) {
+	inputs := map[string]string{
+		`
+err := true
+`: "line 2 column 1: redeclaration of builtin variable 'err'",
+		`
+errmsg := 5
+`: "line 2 column 1: redeclaration of builtin variable 'errmsg'",
+		`
+func errmsg
+   print "💣"
+end
+`: "line 2 column 1: cannot override builtin variable 'errmsg'",
+	}
+	for input, wantErr := range inputs {
+		parser := New(input, testBuiltins())
+		_ = parser.Parse()
+		assertParseError(t, parser, input)
+		gotErr := MaxErrorsString(parser.Errors(), 1)
+		assert.Equal(t, wantErr, gotErr)
+	}
+}
+
 func TestDemo(t *testing.T) {
 	input := `
 move 10 10
@@ -1119,6 +1142,14 @@ func testBuiltins() Builtins {
 			},
 		},
 	}
+	globals := map[string]*Var{
+		"err":    {Name: "err", T: BOOL_TYPE},
+		"errmsg": {Name: "errmsg", T: STRING_TYPE},
+	}
 
-	return Builtins{Funcs: funcs, EventHandlers: eventHandlers}
+	return Builtins{
+		Funcs:         funcs,
+		EventHandlers: eventHandlers,
+		Globals:       globals,
+	}
 }

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -981,7 +981,7 @@ func TestFuncDeclErr(t *testing.T) {
 func len s:string
    print "len:" s
 end
-`: "line 2 column 1: cannot override builtin function len",
+`: "line 2 column 1: cannot override builtin function 'len'",
 		`
 func fox
    print "fox"
@@ -990,7 +990,7 @@ end
 func fox
    print "fox overridden"
 end
-`: "line 6 column 1: redeclaration of function fox",
+`: "line 6 column 1: redeclaration of function 'fox'",
 	}
 	for input, wantErr := range inputs {
 		parser := New(input, testBuiltins())


### PR DESCRIPTION
Add builtin functions `str2num` and `str2bool` converting strings to
numbers and bools. They set the evy global variables `err` and `errmsg` in
case of an error.

Rework builtins to take scope so that they can set `err` and `errmsg`.

Disallow redeclaration of builtin globals in parser.

For good housekeeping, fix inconsistent error messages in parser