### PR TITLE
all: Add `on input` handler

### DIFF
--- a/frontend/index.css
+++ b/frontend/index.css
@@ -168,6 +168,18 @@ textarea:disabled {
   font-weight: bold;
 }
 
+.slider {
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid var(--primary-color-dimmer);
+}
+
+.slider input {
+  margin: 0.5rem;
+  max-width: 10rem;
+}
+
 .output {
   padding: 12px 16px;
   height: 100%;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -42,9 +42,13 @@ end
         <div class="canvas">
           <canvas id="canvas"></canvas>
         </div>
-        <div class="read">
+        <div class="read hidden">
           <label>input&gt;</label>
           <textarea id="read" rows="1"></textarea>
+        </div>
+        <div class="slider hidden">
+          <input type="range" id="sliderx" min="0" max="100" />
+          <input type="range" id="slidery" min="0" max="100" />
         </div>
         <div class="output">
           <textarea id="output" disabled></textarea>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -287,6 +287,8 @@ function registerEventHandler(ptr, len) {
     c.onpointermove = (e) => exp.onMove(logicalX(e), logicalY(e))
   } else if (s === "key") {
     document.addEventListener("keydown", keydownListener)
+  } else if (s === "input") {
+    addInputHandlers()
   } else {
     console.error("cannot register unknown event", s)
   }
@@ -308,11 +310,27 @@ function keydownListener(e) {
   wasmInst.exports.onKey(ptr, len)
 }
 
+const inputQuerySelector = "input#sliderx,input#slidery"
+
+function addInputHandlers() {
+  const exp = wasmInst.exports
+  for (const el of document.querySelectorAll(inputQuerySelector)) {
+    el.onchange = (e) => {
+      const id = stringToMem(e.target.id)
+      const val = stringToMem(e.target.value)
+      wasmInst.exports.onInput(id.ptr, id.len, val.ptr, val.len)
+    }
+  }
+}
+
 function removeEventHandlers() {
   const c = document.querySelector("#canvas")
   c.onpointerdown = null
   c.onpointerup = null
   c.onpointermove = null
+  for (const el of document.querySelectorAll(inputQuerySelector)) {
+    el.onchange = null
+  }
   document.removeEventListener("keydown", keydownListener)
 }
 

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -3,7 +3,7 @@
 let wasmModule, wasmInst
 let sourcePtr, sourceLength
 const go = newEvyGo()
-const runButton = document.getElementById("run")
+const runButton = document.querySelector("#run")
 
 // initWasm loads bytecode and initialises execution environment.
 function initWasm() {
@@ -18,7 +18,7 @@ function initWasm() {
 // writes it to the output textarea.
 function jsPrint(ptr, len) {
   const s = memToString(ptr, len)
-  const output = document.getElementById("output")
+  const output = document.querySelector("#output")
   output.textContent += s
   if (s.toLowerCase().includes("confetti")) {
     showConfetti()
@@ -30,7 +30,7 @@ function jsPrint(ptr, len) {
 // and empties the textarea. The read stream is written to shared wasm
 // memory and the address returned.
 function jsRead() {
-  const el = document.getElementById("read")
+  const el = document.querySelector("#read")
   const s = el.value
   const idx = s.indexOf("\n")
   if (idx === -1) {
@@ -43,7 +43,7 @@ function jsRead() {
 // evySource writes the evy source code into wasm memory as bytes
 // and returns pointer and length encoded into a single 64 bit number
 function evySource() {
-  const code = document.getElementById("code").value
+  const code = document.querySelector("#code").value
   return stringToMemAddr(code)
 }
 
@@ -116,7 +116,7 @@ function newEvyGo() {
 }
 
 function clearOutput() {
-  document.getElementById("output").textContent = ""
+  document.querySelector("#output").textContent = ""
   resetCanvas()
 }
 
@@ -188,7 +188,7 @@ const canvas = {
 }
 
 function initCanvas() {
-  const c = document.getElementById("canvas")
+  const c = document.querySelector("#canvas")
   const b = c.parentElement.getBoundingClientRect()
   c.width = Math.abs(scaleX(canvas.width))
   c.height = Math.abs(scaleY(canvas.height))
@@ -276,7 +276,7 @@ function circle(r) {
 
 // registerEventHandler is exported to evy go/wasm
 function registerEventHandler(ptr, len) {
-  const c = document.getElementById("canvas")
+  const c = document.querySelector("#canvas")
   const s = memToString(ptr, len)
   const exp = wasmInst.exports
   if (s === "down") {
@@ -309,7 +309,7 @@ function keydownListener(e) {
 }
 
 function removeEventHandlers() {
-  const c = document.getElementById("canvas")
+  const c = document.querySelector("#canvas")
   c.onpointerdown = null
   c.onpointerup = null
   c.onpointermove = null

--- a/frontend/samples/sliders.evy
+++ b/frontend/samples/sliders.evy
@@ -1,0 +1,17 @@
+x := 50
+y := 50
+dot x y
+
+on input id:string val:string
+  if id == "sliderx"
+    x = str2num val
+  else
+    y = str2num val
+  end
+  dot x y
+end
+
+func dot x:num y:num
+  move x y
+  circle 1
+end

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -70,12 +70,17 @@ func DefaultBuiltins(rt Runtime) Builtins {
 		{Name: "x", T: parser.NUM_TYPE},
 		{Name: "y", T: parser.NUM_TYPE},
 	}
-	stringParam := []*parser.Var{{Name: "c", T: parser.STRING_TYPE}}
+	stringParam := []*parser.Var{{Name: "s", T: parser.STRING_TYPE}}
+	inputParams := []*parser.Var{
+		{Name: "id", T: parser.STRING_TYPE},
+		{Name: "val", T: parser.STRING_TYPE},
+	}
 	eventHandlers := map[string]*parser.EventHandler{
-		"down": {Name: "down", Params: xyParams},
-		"up":   {Name: "up", Params: xyParams},
-		"move": {Name: "move", Params: xyParams},
-		"key":  {Name: "key", Params: stringParam},
+		"down":  {Name: "down", Params: xyParams},
+		"up":    {Name: "up", Params: xyParams},
+		"move":  {Name: "move", Params: xyParams},
+		"key":   {Name: "key", Params: stringParam},
+		"input": {Name: "input", Params: inputParams},
 	}
 	globals := map[string]*parser.Var{
 		"err":    {Name: "err", T: parser.BOOL_TYPE},

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -104,6 +104,13 @@ func newStringEvent(name, str string) evaluator.Event {
 	}
 }
 
+func newInputEvent(id, val string) evaluator.Event {
+	return evaluator.Event{
+		Name:   "input",
+		Params: []any{id, val},
+	}
+}
+
 // --- JS function exported to Go/WASM ---------------------------------
 
 // evySource is imported from JS. The float64 return value encodes the
@@ -231,4 +238,12 @@ func onKey(ptr *uint32, length int) {
 	str := getString(ptr, length)
 	// unsynchronized access to events - ok in WASM as single threaded.
 	events = append(events, newStringEvent("key", str))
+}
+
+//export onInput
+func onInput(idPtr *uint32, idLength int, valPtr *uint32, valLength int) {
+	id := getString(idPtr, idLength)
+	val := getString(valPtr, valLength)
+	// unsynchronized access to events - ok in WASM as single threaded.
+	events = append(events, newInputEvent(id, val))
 }


### PR DESCRIPTION
Add `on input id:string val:string` handler, so that evy can react to any
kind of input event, depending on how the frontend has wired it. By default
we have added and hidden to sliders in the index.html / DOM.

An example can be explored at
https://evy-lang--80-k6pkxs0k.web.app#show=.slider&source=samples/sliders.evy

In preparation change visibility of evy-widgets in dom via URL fragment.