### PR TITLE
wasm: Add `on animate` syntax

### DIFF
--- a/frontend/samples/animate.evy
+++ b/frontend/samples/animate.evy
@@ -1,0 +1,56 @@
+// increase `s` for highter speed
+// try 5.1 vs 5 to visualize rounding errors
+s := 0.5
+radius := 5
+
+dot0 := {x:(pos 0) y:(pos 2) dx:s  dy:s  radius:radius color:0}
+dot1 := {x:(pos 1) y:(pos 3) dx:s  dy:s  radius:radius color:1}
+dot2 := {x:(pos 2) y:(pos 4) dx:s  dy:-s radius:radius color:2}
+dot3 := {x:(pos 3) y:(pos 3) dx:s  dy:-s radius:radius color:3}
+dot4 := {x:(pos 4) y:(pos 2) dx:-s dy:-s radius:radius color:4}
+dot5 := {x:(pos 3) y:(pos 1) dx:-s dy:-s radius:radius color:5}
+dot6 := {x:(pos 2) y:(pos 0) dx:-s dy:s  radius:radius color:6}
+dot7 := {x:(pos 1) y:(pos 1) dx:-s dy:s  radius:radius color:7}
+
+dots := [dot0 dot1 dot2 dot3 dot4 dot5 dot6 dot7]
+colors := ["red" "orange" "gold" "forestgreen" "blue" "indigo"  "purple" "deeppink"]
+
+func pos:num i:num
+  l := (100 - 2*radius)/4
+  return radius + i*l
+end
+
+on animate
+  clear
+
+  for dot := range dots
+    update dot
+    draw dot colors[dot.color]
+  end
+end
+
+func update dot:{}num
+  dot.x = dot.x + dot.dx
+  dot.y = dot.y + dot.dy
+  dot.dx = delta dot.dx dot.x
+  dot.dy = delta dot.dy dot.y
+end
+
+func delta:num d:num n:num
+  if n >= radius and n < 100-radius
+    return d
+  end
+  return -d
+end
+
+func clear
+  color "white"
+  move 0 0
+  rect 100 100
+end
+
+func draw dot:{}num col:string
+  color col
+  move dot.x dot.y
+  circle dot.radius
+end

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"foxygo.at/evy/pkg/evaluator"
 	"foxygo.at/evy/pkg/lexer"
@@ -44,12 +45,7 @@ func (c *cmdRun) Run() error {
 	if err != nil {
 		return err
 	}
-	reader := bufio.NewReader(os.Stdin)
-	rt := evaluator.Runtime{
-		Print: func(s string) { fmt.Print(s) },
-		Read:  func() string { s, _ := reader.ReadString('\n'); return s },
-	}
-	builtins := evaluator.DefaultBuiltins(rt)
+	builtins := evaluator.DefaultBuiltins(newRuntime())
 	eval := evaluator.NewEvaluator(builtins)
 	eval.Run(string(b))
 	return nil
@@ -70,10 +66,7 @@ func (c *cmdParse) Run() error {
 	if err != nil {
 		return err
 	}
-	rt := evaluator.Runtime{
-		Print: func(s string) { fmt.Print(s) },
-	}
-	builtinDecls := evaluator.DefaulParserBuiltins(rt)
+	builtinDecls := evaluator.DefaulParserBuiltins(newRuntime())
 	result := parser.Run(string(b), builtinDecls)
 	fmt.Println(result)
 	return nil
@@ -92,4 +85,13 @@ func fileBytes(filename string) ([]byte, error) {
 		return io.ReadAll(os.Stdin)
 	}
 	return os.ReadFile(filename)
+}
+
+func newRuntime() *evaluator.Runtime {
+	reader := bufio.NewReader(os.Stdin)
+	return &evaluator.Runtime{
+		Print: func(s string) { fmt.Print(s) },
+		Read:  func() string { s, _ := reader.ReadString('\n'); return s },
+		Sleep: time.Sleep,
+	}
 }

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -38,7 +38,7 @@ type BuiltinFunc func(scope *scope, args []Value) Value
 func (b BuiltinFunc) Type() ValueType { return BUILTIN }
 func (b BuiltinFunc) String() string  { return "builtin function" }
 
-func DefaultBuiltins(rt Runtime) Builtins {
+func DefaultBuiltins(rt *Runtime) Builtins {
 	funcs := map[string]Builtin{
 		"read":   {Func: readFunc(rt.Read), Decl: readDecl},
 		"print":  {Func: printFunc(rt.Print), Decl: printDecl},
@@ -56,7 +56,7 @@ func DefaultBuiltins(rt Runtime) Builtins {
 		"has": {Func: BuiltinFunc(hasFunc), Decl: hasDecl},
 		"del": {Func: BuiltinFunc(delFunc), Decl: delDecl},
 
-		"sleep": {Func: BuiltinFunc(sleepFunc), Decl: sleepDecl},
+		"sleep": {Func: sleepFunc(rt.Sleep), Decl: sleepDecl},
 
 		"move":   xyBuiltin("move", rt.Graphics.Move, rt.Print),
 		"line":   xyBuiltin("line", rt.Graphics.Line, rt.Print),
@@ -96,7 +96,7 @@ func DefaultBuiltins(rt Runtime) Builtins {
 	}
 }
 
-func DefaulParserBuiltins(rt Runtime) parser.Builtins {
+func DefaulParserBuiltins(rt *Runtime) parser.Builtins {
 	builtins := DefaultBuiltins(rt)
 	return newParserBuiltins(builtins)
 }
@@ -104,6 +104,7 @@ func DefaulParserBuiltins(rt Runtime) parser.Builtins {
 type Runtime struct {
 	Print    func(string)
 	Read     func() string
+	Sleep    func(dur time.Duration)
 	Graphics GraphicsRuntime
 }
 
@@ -343,11 +344,13 @@ var sleepDecl = &parser.FuncDecl{
 	ReturnType: parser.NONE_TYPE,
 }
 
-func sleepFunc(_ *scope, args []Value) Value {
-	secs := args[0].(*Num)
-	dur := time.Duration(secs.Val * float64(time.Second))
-	time.Sleep(dur)
-	return nil
+func sleepFunc(sleepFn func(time.Duration)) BuiltinFunc {
+	return func(_ *scope, args []Value) Value {
+		secs := args[0].(*Num)
+		dur := time.Duration(secs.Val * float64(time.Second))
+		sleepFn(dur)
+		return nil
+	}
 }
 
 func xyDecl(name string) *parser.FuncDecl {

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -71,16 +71,18 @@ func DefaultBuiltins(rt Runtime) Builtins {
 		{Name: "y", T: parser.NUM_TYPE},
 	}
 	stringParam := []*parser.Var{{Name: "s", T: parser.STRING_TYPE}}
+	numParam := []*parser.Var{{Name: "n", T: parser.NUM_TYPE}}
 	inputParams := []*parser.Var{
 		{Name: "id", T: parser.STRING_TYPE},
 		{Name: "val", T: parser.STRING_TYPE},
 	}
 	eventHandlers := map[string]*parser.EventHandler{
-		"down":  {Name: "down", Params: xyParams},
-		"up":    {Name: "up", Params: xyParams},
-		"move":  {Name: "move", Params: xyParams},
-		"key":   {Name: "key", Params: stringParam},
-		"input": {Name: "input", Params: inputParams},
+		"down":    {Name: "down", Params: xyParams},
+		"up":      {Name: "up", Params: xyParams},
+		"move":    {Name: "move", Params: xyParams},
+		"key":     {Name: "key", Params: stringParam},
+		"input":   {Name: "input", Params: inputParams},
+		"animate": {Name: "animate", Params: numParam},
 	}
 	globals := map[string]*parser.Var{
 		"err":    {Name: "err", T: parser.BOOL_TYPE},

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -11,7 +11,7 @@ import (
 func run(input string) string {
 	b := bytes.Buffer{}
 	printFn := func(s string) { b.WriteString(s) }
-	rt := Runtime{Print: printFn}
+	rt := &Runtime{Print: printFn}
 	eval := NewEvaluator(DefaultBuiltins(rt))
 	eval.Run(input)
 	return b.String()

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -17,11 +17,13 @@ var events []evaluator.Event
 const minSleepDur = time.Millisecond
 
 func main() {
-	builtins := evaluator.DefaultBuiltins(jsRuntime)
+	yielder := newSleepingYielder()
+	rt := newJSRuntime(yielder)
+	builtins := evaluator.DefaultBuiltins(rt)
 	eval = evaluator.NewEvaluator(builtins)
-	eval.Yielder = newSleepingYielder()
+	eval.Yielder = yielder
 	eval.Run(getEvySource())
-	handleEvents()
+	handleEvents(yielder)
 	onStopped()
 }
 
@@ -29,20 +31,6 @@ func getEvySource() string {
 	addr := evySource()
 	ptr, length := decodePtrLen(uint64(addr))
 	return getString(ptr, length)
-}
-
-func read() string {
-	for {
-		if eval.Stopped {
-			return ""
-		}
-		addr := jsRead()
-		if addr != 0 {
-			ptr, length := decodePtrLen(uint64(addr))
-			return getString(ptr, length)
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
 }
 
 // newSleepingYielder yields the CPU so that JavaScript/browser events
@@ -63,12 +51,35 @@ func (y *sleepingYielder) Yield() {
 	y.count++
 	if y.count > 1000 && time.Since(y.start) > 100*time.Millisecond {
 		time.Sleep(minSleepDur)
-		y.start = time.Now()
-		y.count = 0
+		y.Reset()
 	}
 }
 
-func handleEvents() {
+func (y *sleepingYielder) Sleep(dur time.Duration) {
+	time.Sleep(dur)
+	y.Reset()
+}
+
+func (y *sleepingYielder) Read() string {
+	for {
+		if eval.Stopped {
+			return ""
+		}
+		addr := jsRead()
+		if addr != 0 {
+			ptr, length := decodePtrLen(uint64(addr))
+			return getString(ptr, length)
+		}
+		y.Sleep(50 * time.Millisecond)
+	}
+}
+
+func (y *sleepingYielder) Reset() {
+	y.start = time.Now()
+	y.count = 0
+}
+
+func handleEvents(yielder *sleepingYielder) {
 	if eval == nil || len(eval.EventHandlerNames()) == 0 {
 		return
 	}
@@ -83,9 +94,10 @@ func handleEvents() {
 		if len(events) > 0 {
 			event := events[0]
 			events = events[1:]
+			yielder.Reset()
 			eval.HandleEvent(event)
 		} else {
-			time.Sleep(minSleepDur)
+			yielder.Sleep(minSleepDur)
 		}
 	}
 }
@@ -166,17 +178,20 @@ func color(s string)
 // We cannot take the address of external/exported functions
 // (https://golang.org/cmd/cgo/#hdr-Passing_pointers) so we must wrap them in a
 // Go function first to put them in this Runtime struct.
-var jsRuntime evaluator.Runtime = evaluator.Runtime{
-	Print: func(s string) { jsPrint(s) },
-	Read:  read,
-	Graphics: evaluator.GraphicsRuntime{
-		Move:   func(x, y float64) { move(x, y) },
-		Line:   func(x, y float64) { line(x, y) },
-		Rect:   func(dx, dy float64) { rect(dx, dy) },
-		Circle: func(r float64) { circle(r) },
-		Width:  func(w float64) { width(w) },
-		Color:  func(s string) { color(s) },
-	},
+func newJSRuntime(yielder *sleepingYielder) *evaluator.Runtime {
+	return &evaluator.Runtime{
+		Print: func(s string) { jsPrint(s) },
+		Read:  yielder.Read,
+		Sleep: yielder.Sleep,
+		Graphics: evaluator.GraphicsRuntime{
+			Move:   func(x, y float64) { move(x, y) },
+			Line:   func(x, y float64) { line(x, y) },
+			Rect:   func(dx, dy float64) { rect(dx, dy) },
+			Circle: func(r float64) { circle(r) },
+			Width:  func(w float64) { width(w) },
+			Color:  func(s string) { color(s) },
+		},
+	}
 }
 
 //export registerEventHandler

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -97,10 +97,10 @@ func newXYEvent(name string, x, y float64) evaluator.Event {
 	}
 }
 
-func newStringEvent(name, str string) evaluator.Event {
+func newKeyEvent(key string) evaluator.Event {
 	return evaluator.Event{
-		Name:   name,
-		Params: []any{str},
+		Name:   "key",
+		Params: []any{key},
 	}
 }
 
@@ -237,7 +237,7 @@ func onMove(x, y float64) {
 func onKey(ptr *uint32, length int) {
 	str := getString(ptr, length)
 	// unsynchronized access to events - ok in WASM as single threaded.
-	events = append(events, newStringEvent("key", str))
+	events = append(events, newKeyEvent(str))
 }
 
 //export onInput

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -111,6 +111,13 @@ func newInputEvent(id, val string) evaluator.Event {
 	}
 }
 
+func newAnimateEvent(elapsed float64) evaluator.Event {
+	return evaluator.Event{
+		Name:   "animate",
+		Params: []any{elapsed},
+	}
+}
+
 // --- JS function exported to Go/WASM ---------------------------------
 
 // evySource is imported from JS. The float64 return value encodes the
@@ -238,6 +245,12 @@ func onKey(ptr *uint32, length int) {
 	str := getString(ptr, length)
 	// unsynchronized access to events - ok in WASM as single threaded.
 	events = append(events, newKeyEvent(str))
+}
+
+//export onAnimate
+func onAnimate(elapsed float64) {
+	// unsynchronized access to events - ok in WASM as single threaded.
+	events = append(events, newAnimateEvent(elapsed))
 }
 
 //export onInput


### PR DESCRIPTION
Add `on animate elapsedms:num` based on JS' window.requestAnimationFrame.
The parameter passed is the number of elapsed Milliseconds since the
animation started.

Rework yielding and make Sleep part of the runtime to fix flickering of
the animation.

https://evy-lang--81-9qbk365r.web.app/#animate

Aside: the initial sleep / dot animation is now flicker free too

https://evy-lang--81-9qbk365r.web.app/#dot