### PR TITLE
builtin: Add `rand` and strings functions

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -31,6 +31,7 @@ function jsPrint(ptr, len) {
 // memory and the address returned.
 function jsRead() {
   const el = document.querySelector("#read")
+  el.focus()
   const s = el.value
   const idx = s.indexOf("\n")
   if (idx === -1) {

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -396,6 +396,9 @@ async function fetchSource() {
   }
   try {
     const response = await fetch(opts.source)
+    if (response.status < 200 || response.status > 299) {
+      throw new Error("invalid reponse status", response.status)
+    }
     const source = await response.text()
     document.querySelector("#code").value = source
   } catch (err) {

--- a/frontend/samples/rand.evy
+++ b/frontend/samples/rand.evy
@@ -1,0 +1,37 @@
+while true
+  print "╔════════════════════════╗"
+  print "║ Guess my number (1-10) ║"
+  print "╚════════════════════════╝"
+
+  n := 1 + (rand 10)
+  guess := readn
+
+  while guess != n
+    if guess > 10
+      print guess "Guess lower (1-10)."
+    else if guess < 1
+      print guess " Guess higher (1-10)."
+    else if guess < n
+       print guess "Guess higher."
+    else
+       print  guess "Guess lower."
+    end
+    guess = readn
+  end
+  print guess "You got it 🥳."
+  print
+end
+
+// readn reads a number.
+// If you enter a string that is not number
+func readn:num
+  while true
+    str := read
+    n := str2num str
+    if !err
+      return n
+    end
+    print "💣 '"+str+"'is not a number. Try again."
+  end
+  return -1
+end

--- a/frontend/samples/strings.evy
+++ b/frontend/samples/strings.evy
@@ -1,0 +1,11 @@
+s := "Hello World!"
+
+print "upper" (upper s)
+print "lower" (lower s)
+print "index" (index s "e")
+print "startswith" (startswith s "Hello")
+print "startswith2" (startswith s "hello")
+print "endswith" (endswith s "World!")
+print "endswith2" (endswith s "World")
+print "replace" (replace s "l" "L")
+print "trim" (trim s "H!")

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -45,10 +45,17 @@ func DefaultBuiltins(rt *Runtime) Builtins {
 		"print":  {Func: printFunc(rt.Print), Decl: printDecl},
 		"printf": {Func: printfFunc(rt.Print), Decl: printDecl},
 
-		"sprint":  {Func: sprintFunc, Decl: sprintDecl},
-		"sprintf": {Func: sprintfFunc, Decl: sprintDecl},
-		"join":    {Func: joinFunc, Decl: joinDecl},
-		"split":   {Func: splitFunc, Decl: splitDecl},
+		"sprint":     {Func: sprintFunc, Decl: sprintDecl},
+		"sprintf":    {Func: sprintfFunc, Decl: sprintDecl},
+		"join":       {Func: joinFunc, Decl: joinDecl},
+		"split":      {Func: splitFunc, Decl: splitDecl},
+		"upper":      {Func: upperFunc, Decl: upperDecl},
+		"lower":      {Func: lowerFunc, Decl: lowerDecl},
+		"index":      {Func: indexFunc, Decl: indexDecl},
+		"startswith": {Func: startswithFunc, Decl: startswithDecl},
+		"endswith":   {Func: endswithFunc, Decl: endswithDecl},
+		"trim":       {Func: trimFunc, Decl: trimDecl},
+		"replace":    {Func: replaceFunc, Decl: replaceDecl},
 
 		"str2num":  {Func: BuiltinFunc(str2numFunc), Decl: str2numDecl},
 		"str2bool": {Func: BuiltinFunc(str2boolFunc), Decl: str2boolDecl},
@@ -237,6 +244,109 @@ func splitFunc(_ *scope, args []Value) Value {
 		elements[i] = &String{Val: s}
 	}
 	return &Array{Elements: &elements}
+}
+
+var upperDecl = &parser.FuncDecl{
+	Name: "upper",
+	Params: []*parser.Var{
+		{Name: "s", T: parser.STRING_TYPE},
+	},
+	ReturnType: parser.STRING_TYPE,
+}
+
+func upperFunc(_ *scope, args []Value) Value {
+	s := args[0].(*String).Val
+	return &String{Val: strings.ToUpper(s)}
+}
+
+var lowerDecl = &parser.FuncDecl{
+	Name: "lower",
+	Params: []*parser.Var{
+		{Name: "s", T: parser.STRING_TYPE},
+	},
+	ReturnType: parser.STRING_TYPE,
+}
+
+func lowerFunc(_ *scope, args []Value) Value {
+	s := args[0].(*String).Val
+	return &String{Val: strings.ToLower(s)}
+}
+
+var indexDecl = &parser.FuncDecl{
+	Name: "index",
+	Params: []*parser.Var{
+		{Name: "s", T: parser.STRING_TYPE},
+		{Name: "substr", T: parser.STRING_TYPE},
+	},
+	ReturnType: parser.NUM_TYPE,
+}
+
+func indexFunc(_ *scope, args []Value) Value {
+	s := args[0].(*String).Val
+	substr := args[1].(*String).Val
+	return &Num{Val: float64(strings.Index(s, substr))}
+}
+
+var startswithDecl = &parser.FuncDecl{
+	Name: "startswith",
+	Params: []*parser.Var{
+		{Name: "s", T: parser.STRING_TYPE},
+		{Name: "startstr", T: parser.STRING_TYPE},
+	},
+	ReturnType: parser.BOOL_TYPE,
+}
+
+func startswithFunc(_ *scope, args []Value) Value {
+	s := args[0].(*String).Val
+	prefix := args[1].(*String).Val
+	return &Bool{Val: strings.HasPrefix(s, prefix)}
+}
+
+var endswithDecl = &parser.FuncDecl{
+	Name: "endswith",
+	Params: []*parser.Var{
+		{Name: "s", T: parser.STRING_TYPE},
+		{Name: "endstr", T: parser.STRING_TYPE},
+	},
+	ReturnType: parser.BOOL_TYPE,
+}
+
+func endswithFunc(_ *scope, args []Value) Value {
+	s := args[0].(*String).Val
+	suffix := args[1].(*String).Val
+	return &Bool{Val: strings.HasSuffix(s, suffix)}
+}
+
+var trimDecl = &parser.FuncDecl{
+	Name: "trim",
+	Params: []*parser.Var{
+		{Name: "s", T: parser.STRING_TYPE},
+		{Name: "cutset", T: parser.STRING_TYPE},
+	},
+	ReturnType: parser.STRING_TYPE,
+}
+
+func trimFunc(_ *scope, args []Value) Value {
+	s := args[0].(*String).Val
+	cutset := args[1].(*String).Val
+	return &String{Val: strings.Trim(s, cutset)}
+}
+
+var replaceDecl = &parser.FuncDecl{
+	Name: "replace",
+	Params: []*parser.Var{
+		{Name: "s", T: parser.STRING_TYPE},
+		{Name: "old", T: parser.STRING_TYPE},
+		{Name: "new", T: parser.STRING_TYPE},
+	},
+	ReturnType: parser.STRING_TYPE,
+}
+
+func replaceFunc(_ *scope, args []Value) Value {
+	s := args[0].(*String).Val
+	oldStr := args[1].(*String).Val
+	newStr := args[2].(*String).Val
+	return &String{Val: strings.ReplaceAll(s, oldStr, newStr)}
 }
 
 var str2numDecl = &parser.FuncDecl{

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -2,6 +2,7 @@ package evaluator
 
 import (
 	"fmt"
+	"math/rand"
 	"strconv"
 	"strings"
 	"time"
@@ -57,6 +58,9 @@ func DefaultBuiltins(rt *Runtime) Builtins {
 		"del": {Func: BuiltinFunc(delFunc), Decl: delDecl},
 
 		"sleep": {Func: sleepFunc(rt.Sleep), Decl: sleepDecl},
+
+		"rand":  {Func: BuiltinFunc(randFunc), Decl: randDecl},
+		"rand1": {Func: BuiltinFunc(rand1Func), Decl: rand1Decl},
 
 		"move":   xyBuiltin("move", rt.Graphics.Move, rt.Print),
 		"line":   xyBuiltin("line", rt.Graphics.Line, rt.Print),
@@ -351,6 +355,27 @@ func sleepFunc(sleepFn func(time.Duration)) BuiltinFunc {
 		sleepFn(dur)
 		return nil
 	}
+}
+
+var randDecl = &parser.FuncDecl{
+	Name:       "rand",
+	Params:     []*parser.Var{{Name: "upper", T: parser.NUM_TYPE}},
+	ReturnType: parser.NUM_TYPE,
+}
+
+func randFunc(_ *scope, args []Value) Value {
+	upper := int32(args[0].(*Num).Val)
+	return &Num{Val: float64(rand.Int31n(upper))} //nolint: gosec
+}
+
+var rand1Decl = &parser.FuncDecl{
+	Name:       "rand",
+	Params:     []*parser.Var{},
+	ReturnType: parser.NUM_TYPE,
+}
+
+func rand1Func(_ *scope, args []Value) Value {
+	return &Num{Val: rand.Float64()} //nolint: gosec
 }
 
 func xyDecl(name string) *parser.FuncDecl {

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -5,11 +5,14 @@ package evaluator
 
 import (
 	"fmt"
+	"math/rand"
+	"time"
 
 	"foxygo.at/evy/pkg/parser"
 )
 
 func NewEvaluator(builtins Builtins) *Evaluator {
+	rand.Seed(time.Now().UnixNano()) //nolint: staticcheck //still required in tinygo
 	scope := newScope()
 	for _, global := range builtins.Globals {
 		scope.set(global.Name, zero(global.Type()))


### PR DESCRIPTION
Add random number generation functions:

* `rand n` returns an integer in the half open interval [0,n)
* `rand1` returns an float64 in the half open interval [0,1)

Add string functions `upper`, `lower`, `index`, `trim`,
`startswith`, `endswith`, `replace`.

This functions are mapped to Go's math/rand package. It seems that
tinygo still requires seeding (tested).

Add a demos for clarity.

Minor bug fix for non 2xx source response: don't load random HTLM,
write error to console instead.

https://evy-lang--82-r0m72zv4.web.app/#source=samples/rand.evy&show=.read
https://evy-lang--82-r0m72zv4.web.app/#strings