### PR TITLE
go: Add modulo operator `%` to evy

### DIFF
--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -5,6 +5,7 @@ package evaluator
 
 import (
 	"fmt"
+	"math"
 	"math/rand"
 	"time"
 
@@ -478,6 +479,8 @@ func evalBinaryNumExpr(op parser.Operator, left, right *Num) Value {
 		return &Num{Val: left.Val - right.Val}
 	case parser.OP_ASTERISK:
 		return &Num{Val: left.Val * right.Val}
+	case parser.OP_PERCENT:
+		return &Num{Val: math.Mod(left.Val, right.Val)}
 	case parser.OP_SLASH:
 		return &Num{Val: left.Val / right.Val}
 	case parser.OP_GT:

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -281,6 +281,8 @@ end
 func TestExpr(t *testing.T) {
 	tests := map[string]string{
 		"a := 1 + 2 * 2":                    "5",
+		"a := 6 % 4":                        "2",
+		"a := 6.3 % 4.1":                    "2.2",
 		"a := (1 + 2) * 2":                  "6",
 		"a := (1 + 2) / 2":                  "1.5",
 		"a := (1 + 2) / 2 > 1":              "true",

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -68,6 +68,8 @@ func (l *Lexer) Next() *Token {
 		return tok.SetType(SLASH)
 	case '*':
 		return tok.SetType(ASTERISK)
+	case '%':
+		return tok.SetType(PERCENT)
 	case '<':
 		if l.peekRune() == '=' {
 			l.advance()

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -18,6 +18,7 @@ func TestSingleToken(t *testing.T) {
 		{in: "!", want: BANG},
 		{in: "*", want: ASTERISK},
 		{in: "/", want: SLASH},
+		{in: "%", want: PERCENT},
 		{in: "==", want: EQ},
 		{in: "!=", want: NOT_EQ},
 		{in: "<", want: LT},

--- a/pkg/lexer/token.go
+++ b/pkg/lexer/token.go
@@ -33,6 +33,7 @@ const (
 	BANG     // !
 	ASTERISK // *
 	SLASH    // /
+	PERCENT  // %
 
 	EQ     // ==
 	NOT_EQ // !=
@@ -126,6 +127,7 @@ var tokenStrings = map[TokenType]tokenString{
 	MINUS:      {string: "MINUS", format: "-"},
 	BANG:       {string: "BANG", format: "!"},
 	ASTERISK:   {string: "ASTERISK", format: "*"},
+	PERCENT:    {string: "PERCENT", format: "%"},
 	SLASH:      {string: "SLASH", format: "/"},
 	LT:         {string: "LT", format: "<"},
 	GT:         {string: "GT", format: ">"},

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -40,6 +40,7 @@ var precedences = map[lexer.TokenType]precedence{
 	lexer.OR:       OR,
 	lexer.SLASH:    PRODUCT,
 	lexer.ASTERISK: PRODUCT,
+	lexer.PERCENT:  PRODUCT,
 	lexer.AND:      AND,
 	lexer.LBRACKET: INDEX,
 	lexer.DOT:      INDEX,
@@ -262,7 +263,7 @@ func (p *Parser) parseDotExpr(left Node) Node {
 }
 
 func isBinaryOp(tt lexer.TokenType) bool {
-	return isComparisonOp(tt) || tt == lexer.PLUS || tt == lexer.MINUS || tt == lexer.SLASH || tt == lexer.ASTERISK || tt == lexer.OR || tt == lexer.AND
+	return isComparisonOp(tt) || tt == lexer.PLUS || tt == lexer.MINUS || tt == lexer.SLASH || tt == lexer.ASTERISK || tt == lexer.PERCENT || tt == lexer.OR || tt == lexer.AND
 }
 
 func isComparisonOp(tt lexer.TokenType) bool {
@@ -306,7 +307,7 @@ func (p *Parser) validateBinaryType(binaryExp *BinaryExpression) {
 		if leftType != NUM_TYPE && leftType != STRING_TYPE && leftType.Name != ARRAY {
 			p.appendErrorForToken("'+' takes num, string or array type, found "+leftType.Format(), tok)
 		}
-	case OP_MINUS, OP_SLASH, OP_ASTERISK:
+	case OP_MINUS, OP_SLASH, OP_ASTERISK, OP_PERCENT:
 		if leftType != NUM_TYPE {
 			p.appendErrorForToken("'"+op.String()+"' takes num type, found "+leftType.Format(), tok)
 		}

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -19,7 +19,7 @@ func TestParseTopLevelExpression(t *testing.T) {
 		// binary expressions, arithmetic
 		"1+1":   "(1+1)",
 		"1* n1": "(1*n1)",
-		"1*2*3": "((1*2)*3)",
+		"1*2%3": "((1*2)%3)",
 		"1*2/3": "((1*2)/3)",
 		"1+2*3": "(1+(2*3))",
 		"n1/n2": "(n1/n2)",

--- a/pkg/parser/operator.go
+++ b/pkg/parser/operator.go
@@ -10,6 +10,7 @@ const (
 	OP_MINUS
 	OP_SLASH
 	OP_ASTERISK
+	OP_PERCENT
 
 	OP_OR
 	OP_AND
@@ -32,6 +33,7 @@ var operatorStrings = map[Operator]string{
 	OP_MINUS:    "-",
 	OP_SLASH:    "/",
 	OP_ASTERISK: "*",
+	OP_PERCENT:  "%",
 	OP_OR:       "or",
 	OP_AND:      "and",
 	OP_EQ:       "==",
@@ -55,6 +57,8 @@ func op(tok *lexer.Token) Operator {
 		return OP_SLASH
 	case lexer.ASTERISK:
 		return OP_ASTERISK
+	case lexer.PERCENT:
+		return OP_PERCENT
 	case lexer.OR:
 		return OP_OR
 	case lexer.AND:


### PR DESCRIPTION
Add modulo operator to evy, which includes extending lexer, parser and
evaluator. As in other programming languages, use `%` symbol and give
the operator the same precedence as multiplication or division.