### PR TITLE
go: Allow `for` statement without var declaration

### DIFF
--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -565,6 +565,9 @@ func TestForStepRange(t *testing.T) {
 for i := range 2
 	print "🎈" i
 end
+for range 2
+	print "🦈"
+end
 for i := range -1 1
 	print "🐣" i
 end
@@ -588,6 +591,8 @@ end
 	want := []string{
 		"🎈 0",
 		"🎈 1",
+		"🦈",
+		"🦈",
 		"🐣 -1",
 		"🐣 0",
 		"🍭 2",
@@ -608,6 +613,9 @@ func TestForArray(t *testing.T) {
 for x := range [0 1]
 	print "🎈" x
 end
+for range [0 1]
+	print "🦊"
+end
 for i := range []
 	print "💣" i
 end
@@ -616,6 +624,8 @@ end
 	want := []string{
 		"🎈 0",
 		"🎈 1",
+		"🦊",
+		"🦊",
 		"",
 	}
 	got := strings.Split(out, "\n")
@@ -630,6 +640,9 @@ func TestForString(t *testing.T) {
 for x := range "abc"
 	print "🎈" x
 end
+for range "ab"
+	print "🦊"
+end
 for i := range ""
 	print "💣" i
 end
@@ -639,6 +652,8 @@ end
 		"🎈 a",
 		"🎈 b",
 		"🎈 c",
+		"🦊",
+		"🦊",
 		"",
 	}
 	got := strings.Split(out, "\n")
@@ -654,6 +669,9 @@ m := {a:1 b:2}
 for x := range m
 	print "🎈" x  m[x]
 end
+for range m
+	print "🦊"
+end
 for i := range {}
 	print "💣" i
 end
@@ -662,6 +680,8 @@ end
 	want := []string{
 		"🎈 a 1",
 		"🎈 b 2",
+		"🦊",
+		"🦊",
 		"",
 	}
 	got := strings.Split(out, "\n")

--- a/pkg/evaluator/ranger.go
+++ b/pkg/evaluator/ranger.go
@@ -38,7 +38,9 @@ func (s *stepRange) next() bool {
 	if s.step < 0 && s.cur <= s.stop {
 		return false
 	}
-	s.loopVar.Val = s.cur
+	if s.loopVar != nil {
+		s.loopVar.Val = s.cur
+	}
 	s.cur += s.step
 	return true
 }
@@ -48,7 +50,10 @@ func (a *arrayRange) next() bool {
 	if a.cur >= len(elements) {
 		return false
 	}
-	a.loopVar.Set(elements[a.cur])
+	if a.loopVar != nil {
+		a.loopVar.Set(elements[a.cur])
+	}
+
 	a.cur++
 	return true
 }
@@ -58,7 +63,9 @@ func (m *mapRange) next() bool {
 		key := m.order[m.cur]
 		m.cur++
 		if _, ok := m.mapVal.Pairs[key]; ok { // ensure value hasn't been deleted
-			m.loopVar.(*String).Val = key
+			if m.loopVar != nil {
+				m.loopVar.(*String).Val = key
+			}
 			return true
 		}
 	}
@@ -72,7 +79,9 @@ func (s *stringRange) next() bool {
 	if s.cur >= len(s.runes) {
 		return false
 	}
-	s.loopVar.Val = string(s.runes[s.cur])
+	if s.loopVar != nil {
+		s.loopVar.Val = string(s.runes[s.cur])
+	}
 	s.cur++
 	return true
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -699,21 +699,18 @@ func (p *Parser) parseForStatement(scope *scope) Node {
 	scope = newScope(scope, forNode)
 	p.advance() // advance past FOR token
 
-	if p.cur.TokenType() != lexer.IDENT {
-		p.appendError("expected variable, found " + p.cur.FormatDetails())
-		p.advancePastNL()
-		return nil
-	}
-	forNode.LoopVar = &Var{Token: p.cur, Name: p.cur.Literal, T: NONE_TYPE}
-	if !p.validateVarDecl(scope, forNode.LoopVar, p.cur) {
-		p.advancePastNL()
-		return nil
-	}
-	scope.set(forNode.LoopVar.Name, forNode.LoopVar)
-	p.advance() // advance past loopVarName
+	if p.cur.TokenType() == lexer.IDENT {
+		forNode.LoopVar = &Var{Token: p.cur, Name: p.cur.Literal, T: NONE_TYPE}
+		if !p.validateVarDecl(scope, forNode.LoopVar, p.cur) {
+			p.advancePastNL()
+			return nil
+		}
+		scope.set(forNode.LoopVar.Name, forNode.LoopVar)
+		p.advance() // advance past loopVarName
 
-	p.assertToken(lexer.DECLARE)
-	p.advance() // advance past :=
+		p.assertToken(lexer.DECLARE)
+		p.advance() // advance past :=
+	}
 	if !p.assertToken(lexer.RANGE) {
 		p.advancePastNL()
 		return nil
@@ -734,13 +731,19 @@ func (p *Parser) parseForStatement(scope *scope) Node {
 	p.assertEOL()
 	switch t.Name {
 	case STRING, MAP:
-		forNode.LoopVar.T = STRING_TYPE
+		if forNode.LoopVar != nil {
+			forNode.LoopVar.T = STRING_TYPE
+		}
 		forNode.Range = n
 	case ARRAY:
-		forNode.LoopVar.T = t.Sub
+		if forNode.LoopVar != nil {
+			forNode.LoopVar.T = t.Sub
+		}
 		forNode.Range = n
 	case NUM:
-		forNode.LoopVar.T = NUM_TYPE
+		if forNode.LoopVar != nil {
+			forNode.LoopVar.T = NUM_TYPE
+		}
 		forNode.Range = p.parseStepRange(nodes, tok)
 	default:
 		p.appendError("expected num, string, array or map after range, found " + t.Format())

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -930,12 +930,12 @@ func TestForErr(t *testing.T) {
 for
 	print "X"
 end
-`: "line 2 column 4: expected variable, found end of line",
+`: "line 2 column 4: expected 'range', got end of line",
 		`
 for true
 	print "X"
 end
-`: "line 2 column 5: expected variable, found 'true'",
+`: "line 2 column 5: expected 'range', got 'true'",
 		`
 x := 0
 for x = range 5


### PR DESCRIPTION
Allow for statement without var declaration, e.g.:

	for range 2
       print "Hello"  // executed twice
	end

This fell in place quite easily, however, the nesting might be deeper
than ideal - looking forward to feedback.