### PR TITLE
parser: Allow for multiline array and map declarations

### DIFF
--- a/frontend/samples/animate.evy
+++ b/frontend/samples/animate.evy
@@ -3,17 +3,22 @@
 s := 0.5
 radius := 5
 
-dot0 := {x:(pos 0) y:(pos 2) dx:s  dy:s  radius:radius color:0}
-dot1 := {x:(pos 1) y:(pos 3) dx:s  dy:s  radius:radius color:1}
-dot2 := {x:(pos 2) y:(pos 4) dx:s  dy:-s radius:radius color:2}
-dot3 := {x:(pos 3) y:(pos 3) dx:s  dy:-s radius:radius color:3}
-dot4 := {x:(pos 4) y:(pos 2) dx:-s dy:-s radius:radius color:4}
-dot5 := {x:(pos 3) y:(pos 1) dx:-s dy:-s radius:radius color:5}
-dot6 := {x:(pos 2) y:(pos 0) dx:-s dy:s  radius:radius color:6}
-dot7 := {x:(pos 1) y:(pos 1) dx:-s dy:s  radius:radius color:7}
-
-dots := [dot0 dot1 dot2 dot3 dot4 dot5 dot6 dot7]
 colors := ["red" "orange" "gold" "forestgreen" "blue" "indigo"  "purple" "deeppink"]
+dots := [
+  { x:(pos 0) y:(pos 2) dx:s  dy:s  }
+  { x:(pos 1) y:(pos 3) dx:s  dy:s  }
+  { x:(pos 2) y:(pos 4) dx:s  dy:-s }
+  { x:(pos 3) y:(pos 3) dx:s  dy:-s }
+  { x:(pos 4) y:(pos 2) dx:-s dy:-s }
+  { x:(pos 3) y:(pos 1) dx:-s dy:-s }
+  { x:(pos 2) y:(pos 0) dx:-s dy:s  }
+  { x:(pos 1) y:(pos 1) dx:-s dy:s  }
+]
+
+for i := range (len dots)
+  dots[i].radius = radius
+  dots[i].color = i
+end
 
 func pos:num i:num
   l := (100 - 2*radius)/4

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -350,12 +350,18 @@ func (p *Parser) parseLiteral(scope *scope) Node {
 
 func (p *Parser) parseArrayLiteral(scope *scope) Node {
 	tok := p.cur
-	p.advance()     // advance past [
-	p.advanceIfWS() // allow whitespace after `[`, eg [ 1 2 3 ]
-	elements := p.parseExprList(scope)
-
-	if elements == nil {
-		return nil // previous error
+	p.advance()        // advance past [
+	p.advanceIfWSEOL() // allow whitespace after `[`, eg [ 1 2 3 ]
+	elements := []Node{}
+	tt := p.cur.TokenType()
+	for tt != lexer.RBRACKET && tt != lexer.EOF {
+		n := p.parseExprWSS(scope)
+		if n == nil {
+			return nil // previous error
+		}
+		elements = append(elements, n)
+		p.advanceIfWSEOL()
+		tt = p.cur.TokenType()
 	}
 	if !p.assertToken(lexer.RBRACKET) {
 		return nil
@@ -375,8 +381,8 @@ func (p *Parser) parseArrayLiteral(scope *scope) Node {
 func (p *Parser) parseExprList(scope *scope) []Node {
 	list := []Node{}
 	tt := p.cur.TokenType()
-	for !p.isAtEOL() && tt != lexer.RPAREN && tt != lexer.RBRACKET {
-		n := p.parseExprWSS(scope, LOWEST)
+	for tt != lexer.RPAREN && tt != lexer.RBRACKET && tt != lexer.EOF && !p.isAtEOL() {
+		n := p.parseExprWSS(scope)
 		if n == nil {
 			return nil // previous error
 		}
@@ -387,10 +393,10 @@ func (p *Parser) parseExprList(scope *scope) []Node {
 	return list
 }
 
-func (p *Parser) parseExprWSS(scope *scope, prec precedence) Node {
+func (p *Parser) parseExprWSS(scope *scope) Node {
 	p.pushWSS(true)
 	defer p.popWSS()
-	return p.parseExpr(scope, prec)
+	return p.parseExpr(scope, LOWEST)
 }
 
 func (p *Parser) combineTypes(types []*Type) *Type {
@@ -450,7 +456,7 @@ func (p *Parser) parseMapPairs(scope *scope) (map[string]Node, []string) {
 		p.assertToken(lexer.COLON)
 		p.advance() // advance past COLON
 
-		n := p.parseExprWSS(scope, LOWEST)
+		n := p.parseExprWSS(scope)
 		if n == nil {
 			return nil, nil // previous error
 		}

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -441,9 +441,10 @@ func (p *Parser) parseMapLiteral(scope *scope) Node {
 func (p *Parser) parseMapPairs(scope *scope) (map[string]Node, []string) {
 	pairs := map[string]Node{}
 	var order []string
+	p.advanceIfWSEOL()
 	tt := p.cur.TokenType()
 
-	for !p.isAtEOL() && tt != lexer.RCURLY {
+	for tt != lexer.RCURLY && tt != lexer.EOF {
 		if tt != lexer.IDENT {
 			p.appendError("expected map key, found " + p.cur.FormatDetails())
 		}
@@ -462,6 +463,7 @@ func (p *Parser) parseMapPairs(scope *scope) (map[string]Node, []string) {
 		}
 		pairs[key] = n
 		order = append(order, key)
+		p.advanceIfWSEOL()
 		tt = p.cur.TokenType()
 	}
 	return pairs, order

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -146,6 +146,19 @@ func TestParseTopLevelExpression(t *testing.T) {
 		"arr[1:]":  "(arr[1:])",
 		"arr[:2]":  "(arr[:2])",
 		"arr[:]":   "(arr[:])",
+
+		// Multiline declarations
+		`[ 1
+		   2 ]`: "[1, 2]",
+		"[  " + `
+		   1
+
+		   2
+		 ]`: "[1, 2]",
+		`[
+		   1
+		   2
+		 ]`: "[1, 2]",
 	}
 	for input, want := range tests {
 		parser := New(input, testBuiltins())
@@ -221,6 +234,11 @@ func TestParseTopLevelExpressionErr(t *testing.T) {
 		"{a: _}":   "line 1 column 5: anonymous variable '_' cannot be read",
 		"[_]":      "line 1 column 2: anonymous variable '_' cannot be read",
 		"{a:1}[_]": "line 1 column 7: anonymous variable '_' cannot be read",
+
+		"[1":    "line 1 column 3: expected ']', got end of input",
+		"[1)":   "line 1 column 3: unexpected ')'",
+		"[1(]":  "line 1 column 4: unexpected ']'",
+		"[1()]": "line 1 column 4: unexpected ')'",
 	}
 	for input, wantErr := range tests {
 		parser := New(input, testBuiltins())

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -126,6 +126,7 @@ func TestParseTopLevelExpression(t *testing.T) {
 		// Map literals
 		"{}":                     "{}",
 		"{a: 1}":                 "{a:1}",
+		"{ a: 1 }":               "{a:1}",
 		"{a: 1 b:2}":             "{a:1, b:2}",
 		"{a: [1] b:2}":           "{a:[1], b:2}",
 		"{a: [1] b:2 c: 1+2}":    "{a:[1], b:2, c:(1+2)}",
@@ -159,6 +160,18 @@ func TestParseTopLevelExpression(t *testing.T) {
 		   1
 		   2
 		 ]`: "[1, 2]",
+		`{ a:1
+		   b:2 }`: "{a:1, b:2}",
+		`{
+		   a:1
+		   b:2
+		}`: "{a:1, b:2}",
+		"{  " + `
+		   a:1
+
+		   b:2   ` + `
+
+		}`: "{a:1, b:2}",
 	}
 	for input, want := range tests {
 		parser := New(input, testBuiltins())

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -612,6 +612,14 @@ func (p *Parser) advanceIfWS() {
 	}
 }
 
+func (p *Parser) advanceIfWSEOL() {
+	tt := p.cur.Type
+	for tt == lexer.NL || tt == lexer.COMMENT || tt == lexer.WS {
+		p.advanceWSS()
+		tt = p.cur.Type
+	}
+}
+
 func (p *Parser) isWSS() bool {
 	return p.wssStack[len(p.wssStack)-1]
 }


### PR DESCRIPTION
Allow for multiline array and map declarations so that it is easier to
declare large blocks of data. We want to get this in before we look
into `evy format` or syntax colouring as this might impact things.