### PR TITLE
parser: Prepare for `evy format`

### DIFF
--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -12,18 +12,18 @@ import (
 
 type Builtin struct {
 	Func BuiltinFunc
-	Decl *parser.FuncDecl
+	Decl *parser.FuncDeclStmt
 }
 
 type Builtins struct {
 	Funcs         map[string]Builtin
 	Print         func(s string)
-	EventHandlers map[string]*parser.EventHandler
+	EventHandlers map[string]*parser.EventHandlerStmt
 	Globals       map[string]*parser.Var
 }
 
 func newParserBuiltins(builtins Builtins) parser.Builtins {
-	funcs := make(map[string]*parser.FuncDecl, len(builtins.Funcs))
+	funcs := make(map[string]*parser.FuncDeclStmt, len(builtins.Funcs))
 	for name, builtin := range builtins.Funcs {
 		funcs[name] = builtin.Decl
 	}
@@ -87,7 +87,7 @@ func DefaultBuiltins(rt *Runtime) Builtins {
 		{Name: "id", T: parser.STRING_TYPE},
 		{Name: "val", T: parser.STRING_TYPE},
 	}
-	eventHandlers := map[string]*parser.EventHandler{
+	eventHandlers := map[string]*parser.EventHandlerStmt{
 		"down":    {Name: "down", Params: xyParams},
 		"up":      {Name: "up", Params: xyParams},
 		"move":    {Name: "move", Params: xyParams},
@@ -128,7 +128,7 @@ type GraphicsRuntime struct {
 	Color  func(s string)
 }
 
-var readDecl = &parser.FuncDecl{
+var readDecl = &parser.FuncDeclStmt{
 	Name:       "read",
 	ReturnType: parser.STRING_TYPE,
 }
@@ -140,7 +140,7 @@ func readFunc(readFn func() string) BuiltinFunc {
 	}
 }
 
-var printDecl = &parser.FuncDecl{
+var printDecl = &parser.FuncDeclStmt{
 	Name:          "print",
 	VariadicParam: &parser.Var{Name: "a", T: parser.ANY_TYPE},
 	ReturnType:    parser.NONE_TYPE,
@@ -168,7 +168,7 @@ func printfFunc(printFn func(string)) BuiltinFunc {
 	}
 }
 
-var sprintDecl = &parser.FuncDecl{
+var sprintDecl = &parser.FuncDeclStmt{
 	Name:          "sprint",
 	VariadicParam: &parser.Var{Name: "a", T: parser.ANY_TYPE},
 	ReturnType:    parser.STRING_TYPE,
@@ -197,7 +197,7 @@ func sprintf(s string, vals []Value) string {
 	return fmt.Sprintf(s, args...)
 }
 
-var joinDecl = &parser.FuncDecl{
+var joinDecl = &parser.FuncDeclStmt{
 	Name: "join",
 	Params: []*parser.Var{
 		{Name: "arr", T: parser.GENERIC_ARRAY},
@@ -226,7 +226,7 @@ var stringArrayType *parser.Type = &parser.Type{
 	Sub:  parser.STRING_TYPE,
 }
 
-var splitDecl = &parser.FuncDecl{
+var splitDecl = &parser.FuncDeclStmt{
 	Name: "split",
 	Params: []*parser.Var{
 		{Name: "s", T: parser.STRING_TYPE},
@@ -246,7 +246,7 @@ func splitFunc(_ *scope, args []Value) Value {
 	return &Array{Elements: &elements}
 }
 
-var upperDecl = &parser.FuncDecl{
+var upperDecl = &parser.FuncDeclStmt{
 	Name: "upper",
 	Params: []*parser.Var{
 		{Name: "s", T: parser.STRING_TYPE},
@@ -259,7 +259,7 @@ func upperFunc(_ *scope, args []Value) Value {
 	return &String{Val: strings.ToUpper(s)}
 }
 
-var lowerDecl = &parser.FuncDecl{
+var lowerDecl = &parser.FuncDeclStmt{
 	Name: "lower",
 	Params: []*parser.Var{
 		{Name: "s", T: parser.STRING_TYPE},
@@ -272,7 +272,7 @@ func lowerFunc(_ *scope, args []Value) Value {
 	return &String{Val: strings.ToLower(s)}
 }
 
-var indexDecl = &parser.FuncDecl{
+var indexDecl = &parser.FuncDeclStmt{
 	Name: "index",
 	Params: []*parser.Var{
 		{Name: "s", T: parser.STRING_TYPE},
@@ -287,7 +287,7 @@ func indexFunc(_ *scope, args []Value) Value {
 	return &Num{Val: float64(strings.Index(s, substr))}
 }
 
-var startswithDecl = &parser.FuncDecl{
+var startswithDecl = &parser.FuncDeclStmt{
 	Name: "startswith",
 	Params: []*parser.Var{
 		{Name: "s", T: parser.STRING_TYPE},
@@ -302,7 +302,7 @@ func startswithFunc(_ *scope, args []Value) Value {
 	return &Bool{Val: strings.HasPrefix(s, prefix)}
 }
 
-var endswithDecl = &parser.FuncDecl{
+var endswithDecl = &parser.FuncDeclStmt{
 	Name: "endswith",
 	Params: []*parser.Var{
 		{Name: "s", T: parser.STRING_TYPE},
@@ -317,7 +317,7 @@ func endswithFunc(_ *scope, args []Value) Value {
 	return &Bool{Val: strings.HasSuffix(s, suffix)}
 }
 
-var trimDecl = &parser.FuncDecl{
+var trimDecl = &parser.FuncDeclStmt{
 	Name: "trim",
 	Params: []*parser.Var{
 		{Name: "s", T: parser.STRING_TYPE},
@@ -332,7 +332,7 @@ func trimFunc(_ *scope, args []Value) Value {
 	return &String{Val: strings.Trim(s, cutset)}
 }
 
-var replaceDecl = &parser.FuncDecl{
+var replaceDecl = &parser.FuncDeclStmt{
 	Name: "replace",
 	Params: []*parser.Var{
 		{Name: "s", T: parser.STRING_TYPE},
@@ -349,7 +349,7 @@ func replaceFunc(_ *scope, args []Value) Value {
 	return &String{Val: strings.ReplaceAll(s, oldStr, newStr)}
 }
 
-var str2numDecl = &parser.FuncDecl{
+var str2numDecl = &parser.FuncDeclStmt{
 	Name:       "str2num",
 	Params:     []*parser.Var{{Name: "s", T: parser.STRING_TYPE}},
 	ReturnType: parser.NUM_TYPE,
@@ -365,7 +365,7 @@ func str2numFunc(scope *scope, args []Value) Value {
 	return &Num{Val: n}
 }
 
-var str2boolDecl = &parser.FuncDecl{
+var str2boolDecl = &parser.FuncDeclStmt{
 	Name:       "str2bool",
 	Params:     []*parser.Var{{Name: "s", T: parser.STRING_TYPE}},
 	ReturnType: parser.BOOL_TYPE,
@@ -402,7 +402,7 @@ func globalErr(scope *scope, isErr bool, msg string) {
 	val.Set(&String{Val: msg})
 }
 
-var lenDecl = &parser.FuncDecl{
+var lenDecl = &parser.FuncDeclStmt{
 	Name:       "len",
 	Params:     []*parser.Var{{Name: "a", T: parser.ANY_TYPE}},
 	ReturnType: parser.NUM_TYPE,
@@ -420,7 +420,7 @@ func lenFunc(_ *scope, args []Value) Value {
 	return newError("'len' takes 1 argument of type 'string', array '[]' or map '{}' not " + args[0].Type().String())
 }
 
-var hasDecl = &parser.FuncDecl{
+var hasDecl = &parser.FuncDeclStmt{
 	Name: "has",
 	Params: []*parser.Var{
 		{Name: "m", T: parser.GENERIC_MAP},
@@ -436,7 +436,7 @@ func hasFunc(_ *scope, args []Value) Value {
 	return &Bool{Val: ok}
 }
 
-var delDecl = &parser.FuncDecl{
+var delDecl = &parser.FuncDeclStmt{
 	Name: "del",
 	Params: []*parser.Var{
 		{Name: "m", T: parser.GENERIC_MAP},
@@ -452,7 +452,7 @@ func delFunc(_ *scope, args []Value) Value {
 	return nil
 }
 
-var sleepDecl = &parser.FuncDecl{
+var sleepDecl = &parser.FuncDeclStmt{
 	Name:       "sleep",
 	Params:     []*parser.Var{{Name: "seconds", T: parser.NUM_TYPE}},
 	ReturnType: parser.NONE_TYPE,
@@ -467,7 +467,7 @@ func sleepFunc(sleepFn func(time.Duration)) BuiltinFunc {
 	}
 }
 
-var randDecl = &parser.FuncDecl{
+var randDecl = &parser.FuncDeclStmt{
 	Name:       "rand",
 	Params:     []*parser.Var{{Name: "upper", T: parser.NUM_TYPE}},
 	ReturnType: parser.NUM_TYPE,
@@ -478,7 +478,7 @@ func randFunc(_ *scope, args []Value) Value {
 	return &Num{Val: float64(rand.Int31n(upper))} //nolint: gosec
 }
 
-var rand1Decl = &parser.FuncDecl{
+var rand1Decl = &parser.FuncDeclStmt{
 	Name:       "rand",
 	Params:     []*parser.Var{},
 	ReturnType: parser.NUM_TYPE,
@@ -488,8 +488,8 @@ func rand1Func(_ *scope, args []Value) Value {
 	return &Num{Val: rand.Float64()} //nolint: gosec
 }
 
-func xyDecl(name string) *parser.FuncDecl {
-	return &parser.FuncDecl{
+func xyDecl(name string) *parser.FuncDeclStmt {
+	return &parser.FuncDeclStmt{
 		Name: name,
 		Params: []*parser.Var{
 			{Name: "x", T: parser.NUM_TYPE},
@@ -514,8 +514,8 @@ func xyBuiltin(name string, fn func(x, y float64), printFn func(string)) Builtin
 	return result
 }
 
-func numDecl(name string) *parser.FuncDecl {
-	return &parser.FuncDecl{
+func numDecl(name string) *parser.FuncDeclStmt {
+	return &parser.FuncDeclStmt{
 		Name: name,
 		Params: []*parser.Var{
 			{Name: "n", T: parser.NUM_TYPE},
@@ -538,8 +538,8 @@ func numBuiltin(name string, fn func(n float64), printFn func(string)) Builtin {
 	return result
 }
 
-func stringDecl(name string) *parser.FuncDecl {
-	return &parser.FuncDecl{
+func stringDecl(name string) *parser.FuncDeclStmt {
+	return &parser.FuncDeclStmt{
 		Name: name,
 		Params: []*parser.Var{
 			{Name: "str", T: parser.STRING_TYPE},

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -70,6 +70,10 @@ func (e *Evaluator) Eval(node parser.Node) Value {
 		return e.evalProgram(node)
 	case *parser.Decl:
 		return e.evalDecl(node)
+	case *parser.TypedDeclStmt:
+		return e.evalDecl(node.Decl)
+	case *parser.InferredDeclStmt:
+		return e.evalDecl(node.Decl)
 	case *parser.AssignmentStmt:
 		return e.evalAssignment(node)
 	case *parser.Var:

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -68,8 +68,8 @@ func (e *Evaluator) Eval(node parser.Node) Value {
 	switch node := node.(type) {
 	case *parser.Program:
 		return e.evalProgram(node)
-	case *parser.Declaration:
-		return e.evalDeclaration(node)
+	case *parser.Decl:
+		return e.evalDecl(node)
 	case *parser.AssignmentStmt:
 		return e.evalAssignment(node)
 	case *parser.Var:
@@ -170,7 +170,7 @@ func (e *Evaluator) evalBool(b *parser.Bool) Value {
 	return &Bool{Val: b.Value}
 }
 
-func (e *Evaluator) evalDeclaration(decl *parser.Declaration) Value {
+func (e *Evaluator) evalDecl(decl *parser.Decl) Value {
 	val := e.Eval(decl.Value)
 	if isError(val) {
 		return val

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -85,7 +85,9 @@ func (e *Evaluator) Eval(node parser.Node) Value {
 	case *parser.MapLiteral:
 		return e.evalMapLiteral(node)
 	case *parser.FuncCall:
-		return e.evalFunctionCall(node)
+		return e.evalFunccall(node)
+	case *parser.FuncCallStmt:
+		return e.evalFunccall(node.FuncCall)
 	case *parser.ReturnStmt:
 		return e.evalReturn(node)
 	case *parser.BreakStmt:
@@ -217,7 +219,7 @@ func (e *Evaluator) evalMapLiteral(m *parser.MapLiteral) Value {
 	return &Map{Pairs: pairs, Order: &order}
 }
 
-func (e *Evaluator) evalFunctionCall(funcCall *parser.FuncCall) Value {
+func (e *Evaluator) evalFunccall(funcCall *parser.FuncCall) Value {
 	args := e.evalExprList(funcCall.Arguments)
 	if len(args) == 1 && isError(args[0]) {
 		return args[0]

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -84,7 +84,7 @@ func (e *Evaluator) Eval(node parser.Node) Value {
 		return e.evalArrayLiteral(node)
 	case *parser.MapLiteral:
 		return e.evalMapLiteral(node)
-	case *parser.FunctionCall:
+	case *parser.FuncCall:
 		return e.evalFunctionCall(node)
 	case *parser.ReturnStmt:
 		return e.evalReturn(node)
@@ -217,7 +217,7 @@ func (e *Evaluator) evalMapLiteral(m *parser.MapLiteral) Value {
 	return &Map{Pairs: pairs, Order: &order}
 }
 
-func (e *Evaluator) evalFunctionCall(funcCall *parser.FunctionCall) Value {
+func (e *Evaluator) evalFunctionCall(funcCall *parser.FuncCall) Value {
 	args := e.evalExprList(funcCall.Arguments)
 	if len(args) == 1 && isError(args[0]) {
 		return args[0]

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -114,6 +114,8 @@ func (e *Evaluator) Eval(node parser.Node) Value {
 		return e.evalSliceExpr(node)
 	case *parser.DotExpression:
 		return e.evalDotExpr(node, false /* forAssign */)
+	case *parser.GroupExpression:
+		return e.Eval(node.Expr)
 	case *parser.FuncDeclStmt, *parser.EventHandlerStmt:
 		return nil
 	}

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -773,7 +773,7 @@ func TestHasErr(t *testing.T) {
 	prog := `
 has ["a"] "a" // cannot run 'has' on array
 `
-	want := "line 2 column 15: 'has' takes 1st argument of type '{}', found 'string[]'"
+	want := "line 2 column 15: 'has' takes 1st argument of type '{}', found '[]string'"
 	got := run(prog)
 	assert.Equal(t, want, got)
 }
@@ -809,7 +809,7 @@ func TestDelErr(t *testing.T) {
 	prog := `
 del ["a"] "a" // cannot delete from array
 `
-	want := "line 2 column 15: 'del' takes 1st argument of type '{}', found 'string[]'"
+	want := "line 2 column 15: 'del' takes 1st argument of type '{}', found '[]string'"
 	got := run(prog)
 	assert.Equal(t, want, got)
 }

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -24,7 +24,7 @@ func TestBasicEval(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
-func TestParseDeclaration(t *testing.T) {
+func TestParseDecl(t *testing.T) {
 	tests := map[string]string{
 		"a:=1":          "1",
 		`a:="abc"`:      "abc",

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -71,6 +71,16 @@ type Decl struct {
 	Value Node // literal, expression, assignable, ...
 }
 
+type TypedDeclStmt struct {
+	Token *lexer.Token
+	Decl  *Decl
+}
+
+type InferredDeclStmt struct {
+	Token *lexer.Token
+	Decl  *Decl
+}
+
 type AssignmentStmt struct {
 	Token  *lexer.Token
 	Target Node // Variable, index or field expression
@@ -271,6 +281,22 @@ func (d *Decl) String() string {
 
 func (d *Decl) Type() *Type {
 	return d.Var.T
+}
+
+func (d *TypedDeclStmt) String() string {
+	return d.Decl.String()
+}
+
+func (d *TypedDeclStmt) Type() *Type {
+	return d.Decl.Var.T
+}
+
+func (d *InferredDeclStmt) String() string {
+	return d.Decl.String()
+}
+
+func (d *InferredDeclStmt) Type() *Type {
+	return d.Decl.Var.T
 }
 
 func (r *ReturnStmt) String() string {

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -21,7 +21,7 @@ type FunctionCall struct {
 	Token     *lexer.Token // The IDENT of the function
 	Name      string
 	Arguments []Node
-	FuncDecl  *FuncDecl
+	FuncDecl  *FuncDeclStmt
 }
 
 type UnaryExpression struct {
@@ -66,23 +66,23 @@ type Declaration struct {
 	Value Node // literal, expression, assignable, ...
 }
 
-type Assignment struct {
+type AssignmentStmt struct {
 	Token  *lexer.Token
 	Target Node // Variable, index or field expression
 	Value  Node // literal, expression, assignable, ...
 }
 
-type Return struct {
+type ReturnStmt struct {
 	Token *lexer.Token
 	Value Node // literal, expression, assignable, ...
 	T     *Type
 }
 
-type Break struct {
+type BreakStmt struct {
 	Token *lexer.Token
 }
 
-type FuncDecl struct {
+type FuncDeclStmt struct {
 	Token         *lexer.Token // The 'func' token
 	Name          string
 	Params        []*Var
@@ -91,18 +91,18 @@ type FuncDecl struct {
 	Body          *BlockStatement
 }
 
-type If struct {
+type IfStmt struct {
 	Token        *lexer.Token
 	IfBlock      *ConditionalBlock
 	ElseIfBlocks []*ConditionalBlock
 	Else         *BlockStatement
 }
 
-type While struct {
+type WhileStmt struct {
 	ConditionalBlock
 }
 
-type For struct {
+type ForStmt struct {
 	Token *lexer.Token
 
 	LoopVar *Var
@@ -125,7 +125,7 @@ type ConditionalBlock struct {
 	Block     *BlockStatement
 }
 
-type EventHandler struct {
+type EventHandlerStmt struct {
 	Token  *lexer.Token // The 'on' token
 	Name   string
 	Params []*Var
@@ -260,42 +260,42 @@ func (d *Declaration) Type() *Type {
 	return d.Var.T
 }
 
-func (r *Return) String() string {
+func (r *ReturnStmt) String() string {
 	if r.Value == nil {
 		return "return"
 	}
 	return "return " + r.Value.String()
 }
 
-func (r *Return) Type() *Type {
+func (r *ReturnStmt) Type() *Type {
 	return r.T
 }
 
-func (*Return) AlwaysTerminates() bool {
+func (*ReturnStmt) AlwaysTerminates() bool {
 	return true
 }
 
-func (*Break) String() string {
+func (*BreakStmt) String() string {
 	return "break"
 }
 
-func (*Break) Type() *Type {
+func (*BreakStmt) Type() *Type {
 	return NONE_TYPE
 }
 
-func (b *Break) AlwaysTerminates() bool {
+func (b *BreakStmt) AlwaysTerminates() bool {
 	return true
 }
 
-func (a *Assignment) String() string {
+func (a *AssignmentStmt) String() string {
 	return a.Target.String() + " = " + a.Value.String()
 }
 
-func (a *Assignment) Type() *Type {
+func (a *AssignmentStmt) Type() *Type {
 	return a.Target.Type()
 }
 
-func (f *FuncDecl) String() string {
+func (f *FuncDeclStmt) String() string {
 	s := make([]string, len(f.Params))
 	for i, param := range f.Params {
 		s[i] = param.String()
@@ -312,11 +312,11 @@ func (f *FuncDecl) String() string {
 	return signature + "{\n" + body + "}\n"
 }
 
-func (f *FuncDecl) Type() *Type {
+func (f *FuncDeclStmt) Type() *Type {
 	return f.ReturnType
 }
 
-func (i *If) String() string {
+func (i *IfStmt) String() string {
 	result := "if " + i.IfBlock.String()
 	for _, elseif := range i.ElseIfBlocks {
 		result += "else if" + elseif.String()
@@ -327,11 +327,11 @@ func (i *If) String() string {
 	return result
 }
 
-func (i *If) Type() *Type {
+func (i *IfStmt) Type() *Type {
 	return NONE_TYPE
 }
 
-func (i *If) AlwaysTerminates() bool {
+func (i *IfStmt) AlwaysTerminates() bool {
 	if i.Else == nil || !i.Else.AlwaysTerminates() {
 		return false
 	}
@@ -346,12 +346,12 @@ func (i *If) AlwaysTerminates() bool {
 	return true
 }
 
-func (e *EventHandler) String() string {
+func (e *EventHandlerStmt) String() string {
 	body := e.Body.String()
 	return "on " + e.Name + " {\n" + body + "}\n"
 }
 
-func (e *EventHandler) Type() *Type {
+func (e *EventHandlerStmt) Type() *Type {
 	return NONE_TYPE
 }
 
@@ -380,24 +380,24 @@ func alwaysTerminates(n Node) bool {
 	return ok && r.AlwaysTerminates()
 }
 
-func (w *While) String() string {
+func (w *WhileStmt) String() string {
 	return "while " + w.ConditionalBlock.String()
 }
 
-func (w *While) Type() *Type {
+func (w *WhileStmt) Type() *Type {
 	return w.ConditionalBlock.Type()
 }
 
-func (*While) AlwaysTerminates() bool {
+func (*WhileStmt) AlwaysTerminates() bool {
 	return false
 }
 
-func (f *For) String() string {
+func (f *ForStmt) String() string {
 	header := "for " + f.LoopVar.Name + " := " + f.Range.String()
 	return header + " {\n" + f.Block.String() + "}"
 }
 
-func (f *For) Type() *Type {
+func (f *ForStmt) Type() *Type {
 	return f.Block.Type()
 }
 
@@ -418,7 +418,7 @@ func (s *StepRange) Type() *Type {
 	return NUM_TYPE
 }
 
-func (*For) AlwaysTerminates() bool {
+func (*ForStmt) AlwaysTerminates() bool {
 	return false
 }
 

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -60,7 +60,7 @@ type DotExpression struct {
 	Key   string // m := { age: 42}; m.age => key: "age"
 }
 
-type Declaration struct {
+type Decl struct {
 	Token *lexer.Token
 	Var   *Var
 	Value Node // literal, expression, assignable, ...
@@ -249,14 +249,14 @@ func (d *DotExpression) Type() *Type {
 	return d.T
 }
 
-func (d *Declaration) String() string {
+func (d *Decl) String() string {
 	if d.Value == nil {
 		return d.Var.String()
 	}
 	return d.Var.String() + "=" + d.Value.String()
 }
 
-func (d *Declaration) Type() *Type {
+func (d *Decl) Type() *Type {
 	return d.Var.T
 }
 

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -17,6 +17,11 @@ type Program struct {
 	alwaysTerminates bool
 }
 
+type FuncCallStmt struct {
+	Token    *lexer.Token // The IDENT of the function
+	FuncCall *FuncCall
+}
+
 type FuncCall struct {
 	Token     *lexer.Token // The IDENT of the function
 	Name      string
@@ -196,6 +201,14 @@ func (f *FuncCall) String() string {
 
 func (f *FuncCall) Type() *Type {
 	return f.FuncDecl.ReturnType
+}
+
+func (f *FuncCallStmt) String() string {
+	return f.FuncCall.String()
+}
+
+func (f *FuncCallStmt) Type() *Type {
+	return f.FuncCall.FuncDecl.ReturnType
 }
 
 func (u *UnaryExpression) String() string {

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -17,7 +17,7 @@ type Program struct {
 	alwaysTerminates bool
 }
 
-type FunctionCall struct {
+type FuncCall struct {
 	Token     *lexer.Token // The IDENT of the function
 	Name      string
 	Arguments []Node
@@ -185,7 +185,7 @@ func (p *Program) AlwaysTerminates() bool {
 	return p.alwaysTerminates
 }
 
-func (f *FunctionCall) String() string {
+func (f *FuncCall) String() string {
 	s := make([]string, len(f.Arguments))
 	for i, arg := range f.Arguments {
 		s[i] = arg.String()
@@ -194,7 +194,7 @@ func (f *FunctionCall) String() string {
 	return f.Name + "(" + args + ")"
 }
 
-func (f *FunctionCall) Type() *Type {
+func (f *FuncCall) Type() *Type {
 	return f.FuncDecl.ReturnType
 }
 

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -65,6 +65,11 @@ type DotExpression struct {
 	Key   string // m := { age: 42}; m.age => key: "age"
 }
 
+type GroupExpression struct {
+	Token *lexer.Token
+	Expr  Node
+}
+
 type Decl struct {
 	Token *lexer.Token
 	Var   *Var
@@ -270,6 +275,14 @@ func (d *DotExpression) String() string {
 
 func (d *DotExpression) Type() *Type {
 	return d.T
+}
+
+func (d *GroupExpression) String() string {
+	return d.Expr.String()
+}
+
+func (d *GroupExpression) Type() *Type {
+	return d.Expr.Type()
 }
 
 func (d *Decl) String() string {

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -173,7 +173,7 @@ func (p *Parser) parseIndexOrSliceExpr(scope *scope, left Node, allowSlice bool)
 	p.advance() // advance past [
 	leftType := left.Type().Name
 	if leftType != ARRAY && leftType != MAP && leftType != STRING {
-		p.appendErrorForToken("only array, string and map type can be indexed found "+left.Type().Format(), tok)
+		p.appendErrorForToken("only array, string and map type can be indexed found "+left.Type().String(), tok)
 		return nil
 	}
 	if p.cur.TokenType() == lexer.COLON && allowSlice { // e.g. a[:2]
@@ -205,11 +205,11 @@ func (p *Parser) validateIndex(tok *lexer.Token, leftType TypeName, indexType *T
 		return false
 	}
 	if (leftType == ARRAY || leftType == STRING) && indexType != NUM_TYPE {
-		p.appendErrorForToken(leftType.String()+" index expects num, found "+indexType.Format(), tok)
+		p.appendErrorForToken(leftType.Name()+" index expects num, found "+indexType.String(), tok)
 		return false
 	}
 	if leftType == MAP && indexType != STRING_TYPE {
-		p.appendErrorForToken("map index expects string, found "+indexType.Format(), tok)
+		p.appendErrorForToken("map index expects string, found "+indexType.String(), tok)
 		return false
 	}
 	return true
@@ -218,7 +218,7 @@ func (p *Parser) validateIndex(tok *lexer.Token, leftType TypeName, indexType *T
 func (p *Parser) parseSlice(scope *scope, tok *lexer.Token, left, start Node) Node {
 	leftType := left.Type().Name
 	if leftType != ARRAY && leftType != STRING {
-		p.appendErrorForToken("only array and string be indexed sliced"+left.Type().Format(), tok)
+		p.appendErrorForToken("only array and string be indexed sliced"+left.Type().String(), tok)
 		return nil
 	}
 
@@ -251,11 +251,11 @@ func (p *Parser) parseDotExpr(left Node) Node {
 	p.advance() // advance past .
 	leftType := left.Type().Name
 	if leftType != MAP {
-		p.appendErrorForToken("field access with '.' expects map type, found "+left.Type().Format(), tok)
+		p.appendErrorForToken("field access with '.' expects map type, found "+left.Type().String(), tok)
 		return nil
 	}
 	if p.cur.TokenType() != lexer.IDENT {
-		p.appendErrorForToken("expected map key, found "+p.cur.TokenType().Format(), tok)
+		p.appendErrorForToken("expected map key, found "+p.cur.TokenType().String(), tok)
 		return nil
 	}
 	expr := &DotExpression{Token: tok, Left: left, T: left.Type().Sub, Key: p.cur.Literal}
@@ -299,26 +299,26 @@ func (p *Parser) validateBinaryType(binaryExp *BinaryExpression) {
 	leftType := binaryExp.Left.Type()
 	rightType := binaryExp.Right.Type()
 	if !leftType.Matches(rightType) {
-		p.appendErrorForToken("mismatched type for "+op.String()+": "+leftType.Format()+", "+rightType.Format(), tok)
+		p.appendErrorForToken("mismatched type for "+op.String()+": "+leftType.String()+", "+rightType.String(), tok)
 		return
 	}
 
 	switch op {
 	case OP_PLUS:
 		if leftType != NUM_TYPE && leftType != STRING_TYPE && leftType.Name != ARRAY {
-			p.appendErrorForToken("'+' takes num, string or array type, found "+leftType.Format(), tok)
+			p.appendErrorForToken("'+' takes num, string or array type, found "+leftType.String(), tok)
 		}
 	case OP_MINUS, OP_SLASH, OP_ASTERISK, OP_PERCENT:
 		if leftType != NUM_TYPE {
-			p.appendErrorForToken("'"+op.String()+"' takes num type, found "+leftType.Format(), tok)
+			p.appendErrorForToken("'"+op.String()+"' takes num type, found "+leftType.String(), tok)
 		}
 	case OP_LT, OP_GT, OP_LTEQ, OP_GTEQ:
 		if leftType != NUM_TYPE && leftType != STRING_TYPE {
-			p.appendErrorForToken("'"+op.String()+"' takes num or string type, found "+leftType.Format(), tok)
+			p.appendErrorForToken("'"+op.String()+"' takes num or string type, found "+leftType.String(), tok)
 		}
 	case OP_AND, OP_OR:
 		if leftType != BOOL_TYPE {
-			p.appendErrorForToken("'"+op.String()+"' takes bool type, found "+leftType.Format(), tok)
+			p.appendErrorForToken("'"+op.String()+"' takes bool type, found "+leftType.String(), tok)
 		}
 	}
 }

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -55,7 +55,7 @@ func (p *Parser) parseTopLevelExpr(scope *scope) Node {
 }
 
 func (p *Parser) parseFuncCall(scope *scope) Node {
-	fc := &FunctionCall{Token: p.cur, Name: p.cur.Literal}
+	fc := &FuncCall{Token: p.cur, Name: p.cur.Literal}
 	p.advance() // advance past function name IDENT
 	fc.FuncDecl = p.funcs[fc.Name]
 	fc.Arguments = p.parseExprList(scope)

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -152,13 +152,14 @@ func (p *Parser) parseBinaryExpr(scope *scope, left Node) Node {
 func (p *Parser) parseGroupedExpr(scope *scope) Node {
 	p.pushWSS(false)
 	defer p.popWSS()
+	tok := p.cur
 	p.advance() // advance past (
 	exp := p.parseTopLevelExpr(scope)
-	if !p.assertToken(lexer.RPAREN) {
+	if !p.assertToken(lexer.RPAREN) || exp == nil {
 		return nil
 	}
 	p.advance() // advance past )
-	return exp
+	return &GroupExpression{Token: tok, Expr: exp}
 }
 
 func (p *Parser) parseIndexOrSliceExpr(scope *scope, left Node, allowSlice bool) Node {

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -230,7 +230,7 @@ func TestParseTopLevelExpressionErr(t *testing.T) {
 		"{a:}": "line 1 column 4: unexpected '}'",
 		"{:a}": "line 1 column 2: expected map key, found ':'",
 
-		"[1] + [false]": "line 1 column 5: mismatched type for +: num[], bool[]",
+		"[1] + [false]": "line 1 column 5: mismatched type for +: []num, []bool",
 
 		"a. b":        "line 1 column 2: unexpected whitespace after '.'",
 		"a .b":        "line 1 column 3: unexpected whitespace before '.'",

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -320,7 +320,7 @@ func (p *Parser) parseAssignmentStatement(scope *scope) Node {
 		return nil
 	}
 	if !target.Type().Accepts(value.Type()) {
-		msg := "'" + target.String() + "' accepts values of type " + target.Type().Format() + ", found " + value.Type().Format()
+		msg := "'" + target.String() + "' accepts values of type " + target.Type().String() + ", found " + value.Type().String()
 		p.appendErrorForToken(msg, tok)
 	}
 	p.assertEOL()
@@ -495,7 +495,7 @@ func (p *Parser) assertArgTypes(decl *FuncDeclStmt, args []Node) {
 		for _, arg := range args {
 			argType := arg.Type()
 			if !paramType.Accepts(argType) && !paramType.Matches(argType) {
-				p.appendError("'" + funcName + "' takes variadic arguments of type '" + paramType.Format() + "', found '" + argType.Format() + "'")
+				p.appendError("'" + funcName + "' takes variadic arguments of type '" + paramType.String() + "', found '" + argType.String() + "'")
 			}
 		}
 		return
@@ -508,7 +508,7 @@ func (p *Parser) assertArgTypes(decl *FuncDeclStmt, args []Node) {
 		paramType := decl.Params[i].Type()
 		argType := args[i].Type()
 		if !paramType.Accepts(argType) && !paramType.Matches(argType) {
-			p.appendError("'" + funcName + "' takes " + ordinalize(i+1) + " argument of type '" + paramType.Format() + "', found '" + argType.Format() + "'")
+			p.appendError("'" + funcName + "' takes " + ordinalize(i+1) + " argument of type '" + paramType.String() + "', found '" + argType.String() + "'")
 		}
 	}
 }
@@ -695,9 +695,9 @@ func (p *Parser) parseReturnStatement(scope *scope) Node {
 		}
 	}
 	if !scope.returnType.Accepts(ret.T) {
-		msg := "expected return value of type " + scope.returnType.Format() + ", found " + ret.T.Format()
+		msg := "expected return value of type " + scope.returnType.String() + ", found " + ret.T.String()
 		if scope.returnType == NONE_TYPE && ret.T != NONE_TYPE {
-			msg = "expected no return value, found " + ret.T.Format()
+			msg = "expected no return value, found " + ret.T.String()
 		}
 		p.appendErrorForToken(msg, retValueToken)
 	}
@@ -767,7 +767,7 @@ func (p *Parser) parseForStatement(scope *scope) Node {
 		}
 		forNode.Range = p.parseStepRange(nodes, tok)
 	default:
-		p.appendError("expected num, string, array or map after range, found " + t.Format())
+		p.appendError("expected num, string, array or map after range, found " + t.String())
 	}
 	p.advancePastNL()
 	forNode.Block = p.parseBlock(scope)
@@ -862,7 +862,7 @@ func (p *Parser) parseCondition(scope *scope) Node {
 	if condition != nil {
 		p.assertEOL()
 		if condition.Type() != BOOL_TYPE {
-			p.appendErrorForToken("expected condition of type bool, found "+condition.Type().Format(), tok)
+			p.appendErrorForToken("expected condition of type bool, found "+condition.Type().String(), tok)
 		}
 	}
 	return condition

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -407,10 +407,10 @@ func (p *Parser) parseTypedDeclStatement(scope *scope) Node {
 
 // parseTypedDecl parses declarations like
 // `x:num` or `y:any[]{}`.
-func (p *Parser) parseTypedDecl() *Declaration {
+func (p *Parser) parseTypedDecl() *Decl {
 	p.assertToken(lexer.IDENT)
 	varName := p.cur.Literal
-	decl := &Declaration{
+	decl := &Decl{
 		Token: p.cur,
 		Var:   &Var{Token: p.cur, Name: varName},
 	}
@@ -448,7 +448,7 @@ func (p *Parser) validateVarDecl(scope *scope, v *Var, tok *lexer.Token, allowUn
 func (p *Parser) parseInferredDeclStatement(scope *scope) Node {
 	p.assertToken(lexer.IDENT)
 	varName := p.cur.Literal
-	decl := &Declaration{
+	decl := &Decl{
 		Token: p.cur,
 		Var:   &Var{Token: p.cur, Name: varName},
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -482,10 +482,10 @@ func (p *Parser) isFuncCall(tok *lexer.Token) bool {
 }
 
 func (p *Parser) parseFunCallStatement(scope *scope) Node {
-	fc := p.parseFuncCall(scope)
+	fc := p.parseFuncCall(scope).(*FuncCall)
 	p.assertEOL()
 	p.advancePastNL()
-	return fc
+	return &FuncCallStmt{Token: fc.Token, FuncCall: fc}
 }
 
 func (p *Parser) assertArgTypes(decl *FuncDeclStmt, args []Node) {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -402,7 +402,7 @@ func (p *Parser) parseTypedDeclStatement(scope *scope) Node {
 		p.assertEOL()
 	}
 	p.advancePastNL()
-	return decl
+	return &TypedDeclStmt{Token: decl.Token, Decl: decl}
 }
 
 // parseTypedDecl parses declarations like
@@ -472,7 +472,7 @@ func (p *Parser) parseInferredDeclStatement(scope *scope) Node {
 	decl.Value = val
 	scope.set(varName, decl.Var)
 	p.assertEOL()
-	return decl
+	return &InferredDeclStmt{Token: decl.Token, Decl: decl}
 }
 
 func (p *Parser) isFuncCall(tok *lexer.Token) bool {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -7,7 +7,7 @@ import (
 	"foxygo.at/evy/pkg/assert"
 )
 
-func TestParseDeclaration(t *testing.T) {
+func TestParseDecl(t *testing.T) {
 	tests := map[string][]string{
 		"a := 1":     {"a=1"},
 		"a:bool":     {"a=false"},
@@ -62,7 +62,7 @@ func TestEmptyProgram(t *testing.T) {
 	}
 }
 
-func TestParseDeclarationError(t *testing.T) {
+func TestParseDeclError(t *testing.T) {
 	tests := map[string]string{
 		"a :invalid":    "line 1 column 1: invalid type declaration for 'a'",
 		"a :":           "line 1 column 1: invalid type declaration for 'a'",

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -95,7 +95,7 @@ print m[s]`: "line 3 column 6: unknown variable name 'name'",
 	}
 }
 
-func TestFunctionCall(t *testing.T) {
+func TestFunccall(t *testing.T) {
 	tests := map[string][]string{
 		"print":                          {"print()"},
 		"print 123":                      {"print(123)"},
@@ -118,7 +118,7 @@ func TestFunctionCall(t *testing.T) {
 	}
 }
 
-func TestFunctionCallError(t *testing.T) {
+func TestFunccallError(t *testing.T) {
 	builtins := testBuiltins()
 	builtins.Funcs["f0"] = &FuncDeclStmt{Name: "f0", ReturnType: NONE_TYPE}
 	builtins.Funcs["f1"] = &FuncDeclStmt{Name: "f1", VariadicParam: &Var{Name: "a", T: NUM_TYPE}, ReturnType: NONE_TYPE}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -120,10 +120,10 @@ func TestFunctionCall(t *testing.T) {
 
 func TestFunctionCallError(t *testing.T) {
 	builtins := testBuiltins()
-	builtins.Funcs["f0"] = &FuncDecl{Name: "f0", ReturnType: NONE_TYPE}
-	builtins.Funcs["f1"] = &FuncDecl{Name: "f1", VariadicParam: &Var{Name: "a", T: NUM_TYPE}, ReturnType: NONE_TYPE}
-	builtins.Funcs["f2"] = &FuncDecl{Name: "f2", Params: []*Var{{Name: "a", T: NUM_TYPE}}, ReturnType: NONE_TYPE}
-	builtins.Funcs["f3"] = &FuncDecl{
+	builtins.Funcs["f0"] = &FuncDeclStmt{Name: "f0", ReturnType: NONE_TYPE}
+	builtins.Funcs["f1"] = &FuncDeclStmt{Name: "f1", VariadicParam: &Var{Name: "a", T: NUM_TYPE}, ReturnType: NONE_TYPE}
+	builtins.Funcs["f2"] = &FuncDeclStmt{Name: "f2", Params: []*Var{{Name: "a", T: NUM_TYPE}}, ReturnType: NONE_TYPE}
+	builtins.Funcs["f3"] = &FuncDeclStmt{
 		Name:       "f3",
 		Params:     []*Var{{Name: "a", T: NUM_TYPE}, {Name: "b", T: STRING_TYPE}},
 		ReturnType: NONE_TYPE,
@@ -1215,7 +1215,7 @@ func assertNoParseError(t *testing.T, parser *Parser, input string) {
 }
 
 func testBuiltins() Builtins {
-	funcs := map[string]*FuncDecl{
+	funcs := map[string]*FuncDeclStmt{
 		"print": {
 			Name:          "print",
 			VariadicParam: &Var{Name: "a", T: ANY_TYPE},
@@ -1227,7 +1227,7 @@ func testBuiltins() Builtins {
 			ReturnType: NUM_TYPE,
 		},
 	}
-	eventHandlers := map[string]*EventHandler{
+	eventHandlers := map[string]*EventHandlerStmt{
 		"down": {
 			Name: "down",
 			Params: []*Var{

--- a/pkg/parser/type.go
+++ b/pkg/parser/type.go
@@ -39,33 +39,27 @@ func compositeTypeName(t lexer.TokenType) TypeName {
 }
 
 type typeNameString struct {
-	string string
+	name   string
 	format string
 }
 
 var typeNameStrings = map[TypeName]typeNameString{
-	ILLEGAL: {string: "ILLEGAL", format: "ILLEGAL"},
-	NUM:     {string: "num", format: "num"},
-	STRING:  {string: "string", format: "string"},
-	BOOL:    {string: "bool", format: "bool"},
-	ANY:     {string: "any", format: "any"},
-	ARRAY:   {string: "array", format: "[]"},
-	MAP:     {string: "map", format: "{}"},
-	NONE:    {string: "none", format: "none"},
+	ILLEGAL: {name: "ILLEGAL", format: "ILLEGAL"},
+	NUM:     {name: "num", format: "num"},
+	STRING:  {name: "string", format: "string"},
+	BOOL:    {name: "bool", format: "bool"},
+	ANY:     {name: "any", format: "any"},
+	ARRAY:   {name: "array", format: "[]"},
+	MAP:     {name: "map", format: "{}"},
+	NONE:    {name: "none", format: "none"},
 }
 
 func (t TypeName) String() string {
-	if s, ok := typeNameStrings[t]; ok {
-		return s.string
-	}
-	return "UNKNOWN"
+	return typeNameStrings[t].format
 }
 
-func (t TypeName) Format() string {
-	if s, ok := typeNameStrings[t]; ok {
-		return s.format
-	}
-	return "<unknown>"
+func (t TypeName) Name() string {
+	return typeNameStrings[t].name
 }
 
 func (t TypeName) GoString() string {
@@ -81,14 +75,7 @@ func (t *Type) String() string {
 	if t.Sub == nil || t == GENERIC_ARRAY || t == GENERIC_MAP {
 		return t.Name.String()
 	}
-	return t.Name.String() + " " + t.Sub.String()
-}
-
-func (t *Type) Format() string {
-	if t.Sub == nil || t == GENERIC_ARRAY || t == GENERIC_MAP {
-		return t.Name.Format()
-	}
-	return t.Sub.Format() + t.Name.Format()
+	return t.Name.String() + t.Sub.String()
 }
 
 func (t *Type) Accepts(t2 *Type) bool {


### PR DESCRIPTION
Prepare for `evy format` to print parse-error free source code 
in canonical way.

We will attach comments to the Stmt nodes in a follow up PR
when adding formatting, for this reason we introduce distinct
node for `FunCallStmt`, `InferredDeclStmt`, `TypedDeclStmt` and
`GroupedExpression` (expressions with `()`).

Remove the `Format` method from parser.Type to free up the Format
name purely for formatting and clean up its usage a little.
