### PR TITLE
parser: Fix empty array bug

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -752,7 +752,7 @@ func (p *Parser) parseForStatement(scope *scope) Node {
 		forNode.Range = n
 	case ARRAY:
 		if forNode.LoopVar != nil {
-			forNode.LoopVar.T = t.Sub
+			forNode.LoopVar.T = t.Infer().Sub
 		}
 		forNode.Range = n
 	case NUM:

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -985,6 +985,61 @@ end
 	}
 }
 
+func TestEmptyArray(t *testing.T) {
+	inputs := []string{
+		`print []`,
+		`print [[]]`,
+		`print []+[]`,
+		`print [[]]+[[]]`,
+		`
+for i := range []
+	print i
+end`,
+
+		`
+arr := []
+for i := range arr
+	print i
+end`,
+		`
+a := []
+b := []+[]
+print a b`,
+		`
+func nums n:[]num
+	print n
+end
+
+nums []`,
+	}
+	for _, input := range inputs {
+		parser := New(input, testBuiltins())
+		_ = parser.Parse()
+		assertNoParseError(t, parser, input)
+
+		assert.Equal(t, NONE_TYPE, GENERIC_ARRAY.Sub)
+	}
+}
+
+func TestEmptyMap(t *testing.T) {
+	inputs := []string{
+		`print {}`,
+		`
+m := {}
+
+for k := range m
+   print k m[k]
+end`,
+	}
+	for _, input := range inputs {
+		parser := New(input, testBuiltins())
+		_ = parser.Parse()
+		assertNoParseError(t, parser, input)
+
+		assert.Equal(t, NONE_TYPE, GENERIC_ARRAY.Sub)
+	}
+}
+
 func TestFuncDeclErr(t *testing.T) {
 	inputs := map[string]string{
 		`

--- a/pkg/parser/type.go
+++ b/pkg/parser/type.go
@@ -128,8 +128,9 @@ func (t *Type) Infer() *Type {
 		return t
 	}
 	if t.Sub == NONE_TYPE {
-		t.Sub = ANY_TYPE
-		return t
+		t2 := *t
+		t2.Sub = ANY_TYPE
+		return &t2
 	}
 	t.Sub = t.Sub.Infer()
 	return t


### PR DESCRIPTION
Fix empty array bug mutating the GENERIC_ARRAY and GENERIC_MAP global
variable. These types are used when using the inferred declaration

    a := []

At this point it is not clear which type or array a will be, but to say
it will be of type `any` is restricting it early. When we then assign a
typed array to a, e.g. with `a = [1 2]` a becomes an array of num. The
type is updated via type.Infer(), however, the Infer method mutated
itself (the GENERIC_ARRAY). Fix this by returning a copy.

This in turn made obvious that

    for i := []
      print i
    end

caused an error, because we talk for ArrayRanging `array.Type.Sub`,
which we've now changed to `array.Type.Infer().Sub`