### PR TITLE
parser: Fix variadic parameter bug

### DIFF
--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -998,6 +998,48 @@ print 5 errmsg
 	}
 }
 
+func TestVariadic(t *testing.T) {
+	prog := `
+func fox nums:num...
+  for n := range nums
+    print n "🦊"
+  end
+end
+
+func fox2 strings:string...
+  for s := range strings
+    print s "🦊"
+  end
+end
+
+func fox3 anys:any...
+  for a := range anys
+    print a "🦊"
+  end
+end
+
+fox 1 2 3
+fox2 "a" "b"
+fox3 [1 2] true
+`
+	out := run(prog)
+	want := []string{
+		"1 🦊",
+		"2 🦊",
+		"3 🦊",
+		"a 🦊",
+		"b 🦊",
+		"[1 2] 🦊",
+		"true 🦊",
+		"",
+	}
+	got := strings.Split(out, "\n")
+	assert.Equal(t, len(want), len(got), out)
+	for i := range want {
+		assert.Equal(t, want[i], got[i])
+	}
+}
+
 func TestDemo(t *testing.T) {
 	prog := `
 move 10 10

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -194,9 +194,15 @@ func (p *Parser) addParamsToScope(scope *scope, fd *FuncDecl) {
 		scope.set(param.Name, param)
 	}
 	if fd.VariadicParam != nil {
-		param := fd.VariadicParam
-		p.validateVarDecl(scope, param, param.Token, true /* allowUnderscore */)
-		scope.set(param.Name, param)
+		vParam := fd.VariadicParam
+		p.validateVarDecl(scope, vParam, vParam.Token, true /* allowUnderscore */)
+
+		vParamAsArray := &Var{
+			Name:  vParam.Name,
+			Token: vParam.Token,
+			T:     &Type{Name: ARRAY, Sub: vParam.Type()},
+		}
+		scope.set(vParam.Name, vParamAsArray)
 	}
 }
 

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -255,6 +255,26 @@ end
 	assert.Equal(t, "return n2", returnStmt.String())
 }
 
+func TestVariadicFuncDecl(t *testing.T) {
+	inputs := []string{
+		`
+func fox nums:num...
+  test nums
+end
+
+func test nums:[]num
+  print nums
+end
+
+fox 1 2 3`,
+	}
+	for _, input := range inputs {
+		parser := New(input, testBuiltins())
+		_ = parser.Parse()
+		assertNoParseError(t, parser, input)
+	}
+}
+
 func TestReturnErr(t *testing.T) {
 	inputs := map[string]string{
 		`


### PR DESCRIPTION
Fix variadic parameter bug, where the variadic parameter gets added to
the scope in its original form rather than as an array of it. Before
we'd add for

    func x n:num...

x with type `num` rather than `[]num` to the function body's scope.
Fix and add tests to evaluation and parsing.