### PR TITLE
all: Keep UX and go code tidy

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -46,7 +46,7 @@ end
           <label>input&gt;</label>
           <textarea id="read" rows="1"></textarea>
         </div>
-        <div class="slider hidden">
+        <div class="input slider hidden">
           <input type="range" id="sliderx" min="0" max="100" />
           <input type="range" id="slidery" min="0" max="100" />
         </div>

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -327,6 +327,7 @@ function keydownListener(e) {
 const inputQuerySelector = "input#sliderx,input#slidery"
 
 function addInputHandlers() {
+  getElements(".input").map((el) => el.classList.remove("hidden"))
   const exp = wasmInst.exports
   for (const el of document.querySelectorAll(inputQuerySelector)) {
     el.onchange = (e) => {

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -33,9 +33,9 @@ let jsReadInitialised = false
 function jsRead() {
   const el = document.querySelector("#read")
   if (!jsReadInitialised) {
-    el.focus()
     getElements(".read").map((el) => el.classList.remove("hidden"))
-    readInitialised = true
+    el.focus()
+    jsReadInitialised = true
   }
   const s = el.value
   const idx = s.indexOf("\n")

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -86,8 +86,7 @@ let stopped = true
 // function running the evaluator after parsing.
 async function handleRun(event) {
   if (runButton.innerText === "Stop") {
-    stopped = true
-    wasmInst.exports.stop()
+    stop()
     return
   }
   wasmInst = await WebAssembly.instantiate(wasmModule, go.importObject)
@@ -97,6 +96,11 @@ async function handleRun(event) {
   go.run(wasmInst)
 }
 
+function stop() {
+  stopped = true
+  wasmInst ? wasmInst.exports.stop() : onStopped()
+}
+
 // onStopped is exported to evy go/wasm and called when execution finishes
 function onStopped() {
   removeEventHandlers()
@@ -104,6 +108,7 @@ function onStopped() {
   animationStart = undefined
   jsReadInitialised = false
   runButton.innerText = "Run"
+  wasmInst = undefined
 }
 
 function newEvyGo() {
@@ -409,6 +414,8 @@ async function fetchSource() {
     }
     const source = await response.text()
     document.querySelector("#code").value = source
+    stop()
+    clearOutput()
   } catch (err) {
     console.error(err)
   }

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -445,7 +445,11 @@ func (*WhileStmt) AlwaysTerminates() bool {
 }
 
 func (f *ForStmt) String() string {
-	header := "for " + f.LoopVar.Name + " := " + f.Range.String()
+	header := "for "
+	if f.LoopVar != nil {
+		header += f.LoopVar.Name + " := "
+	}
+	header += f.Range.String()
 	return header + " {\n" + f.Block.String() + "}"
 }
 

--- a/pkg/parser/operator.go
+++ b/pkg/parser/operator.go
@@ -86,10 +86,7 @@ func op(tok *lexer.Token) Operator {
 }
 
 func (o Operator) String() string {
-	if s, ok := operatorStrings[o]; ok {
-		return s
-	}
-	return "UNKNOWN"
+	return operatorStrings[o]
 }
 
 func (o Operator) GoString() string {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -24,10 +24,6 @@ func Run(input string, builtins Builtins) string {
 	parser := New(input, builtins)
 	prog := parser.Parse()
 	if len(parser.errors) > 0 {
-		errs := make([]string, len(parser.errors))
-		for i, e := range parser.errors {
-			errs[i] = e.String()
-		}
 		return MaxErrorsString(parser.Errors(), 8) + "\n\n" + prog.String()
 	}
 	return prog.String()


### PR DESCRIPTION
Keep UX in frontend for frequent sample switching. K
Keep go code tidy with ForStmt.String() fix and dead code removal.

This PR was shaved off #92 as there were a few too many unrelated fixes.