### PR TITLE
all: Implement formatting of evy code

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -53,6 +53,12 @@ function evySource() {
   return stringToMemAddr(code)
 }
 
+// setEvySource is exported to evy go/wasm and called after formatting
+function setEvySource(ptr, len) {
+  const source = memToString(ptr, len)
+  document.querySelector("#code").value = source
+}
+
 function memToString(ptr, len) {
   const buf = new Uint8Array(wasmInst.exports.memory.buffer, ptr, len)
   const s = new TextDecoder("utf8").decode(buf)
@@ -116,6 +122,7 @@ function newEvyGo() {
     jsRead,
     jsPrint,
     evySource,
+    setEvySource,
     move,
     line,
     width,

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -22,7 +22,7 @@ type Builtins struct {
 	Globals       map[string]*parser.Var
 }
 
-func newParserBuiltins(builtins Builtins) parser.Builtins {
+func NewParserBuiltins(builtins Builtins) parser.Builtins {
 	funcs := make(map[string]*parser.FuncDeclStmt, len(builtins.Funcs))
 	for name, builtin := range builtins.Funcs {
 		funcs[name] = builtin.Decl
@@ -109,7 +109,7 @@ func DefaultBuiltins(rt *Runtime) Builtins {
 
 func DefaulParserBuiltins(rt *Runtime) parser.Builtins {
 	builtins := DefaultBuiltins(rt)
-	return newParserBuiltins(builtins)
+	return NewParserBuiltins(builtins)
 }
 
 type Runtime struct {

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -41,7 +41,7 @@ type Event struct {
 }
 
 func (e *Evaluator) Run(input string) {
-	p := parser.New(input, newParserBuiltins(e.builtins))
+	p := parser.New(input, NewParserBuiltins(e.builtins))
 	prog := p.Parse()
 	if p.HasErrors() {
 		e.print(parser.MaxErrorsString(p.Errors(), 8))

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -116,7 +116,7 @@ func (e *Evaluator) Eval(node parser.Node) Value {
 		return e.evalDotExpr(node, false /* forAssign */)
 	case *parser.GroupExpression:
 		return e.Eval(node.Expr)
-	case *parser.FuncDeclStmt, *parser.EventHandlerStmt:
+	case *parser.FuncDeclStmt, *parser.EventHandlerStmt, *parser.EmptyStmt:
 		return nil
 	}
 	return newError(fmt.Sprintf("internal error: unknown node type %v", node))

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -15,6 +15,7 @@ type Node interface {
 type Program struct {
 	Statements       []Node
 	alwaysTerminates bool
+	formatting       *formatting
 }
 
 type EmptyStmt struct {
@@ -199,6 +200,13 @@ type MapLiteral struct {
 
 func (p *Program) String() string {
 	return newlineList(p.Statements)
+}
+
+func (p *Program) Format() string {
+	var sb strings.Builder
+	p.formatting.w = &sb
+	p.formatting.format(p)
+	return sb.String()
 }
 
 func (*Program) Type() *Type {

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -17,6 +17,10 @@ type Program struct {
 	alwaysTerminates bool
 }
 
+type EmptyStmt struct {
+	Token *lexer.Token // The NL token
+}
+
 type FuncCallStmt struct {
 	Token    *lexer.Token // The IDENT of the function
 	FuncCall *FuncCall
@@ -204,6 +208,12 @@ func (*Program) Type() *Type {
 func (p *Program) AlwaysTerminates() bool {
 	return p.alwaysTerminates
 }
+
+func (e *EmptyStmt) String() string {
+	return ""
+}
+
+func (*EmptyStmt) Type() *Type { return NONE_TYPE }
 
 func (f *FuncCall) String() string {
 	s := make([]string, len(f.Arguments))

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -146,6 +146,10 @@ func (p *Parser) parseBinaryExpr(scope *scope, left Node) Node {
 		return nil // previous error
 	}
 	p.validateBinaryType(binaryExp)
+	if p.isWSS() {
+		p.formatting.recordWSS(binaryExp)
+	}
+
 	return binaryExp
 }
 

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -355,8 +355,8 @@ func (p *Parser) parseLiteral(scope *scope) Node {
 
 func (p *Parser) parseArrayLiteral(scope *scope) Node {
 	tok := p.cur
-	p.advance()        // advance past [
-	p.advanceIfWSEOL() // allow whitespace after `[`, eg [ 1 2 3 ]
+	p.advance()                   // advance past [
+	multi := p.parseMulitlineWS() // allow whitespace after `[`, eg [ 1 2 3 ]
 	elements := []Node{}
 	tt := p.cur.TokenType()
 	for tt != lexer.RBRACKET && tt != lexer.EOF {
@@ -365,22 +365,26 @@ func (p *Parser) parseArrayLiteral(scope *scope) Node {
 			return nil // previous error
 		}
 		elements = append(elements, n)
-		p.advanceIfWSEOL()
+		multi = append(multi, multilineEl)
+		multi = append(multi, p.parseMulitlineWS()...)
 		tt = p.cur.TokenType()
 	}
 	if !p.assertToken(lexer.RBRACKET) {
 		return nil
 	}
 	p.advance() // advance past ]
+	arrayLit := &ArrayLiteral{Token: tok, T: GENERIC_ARRAY}
+	p.formatting.recordMultiline(arrayLit, multi)
 	if len(elements) == 0 {
-		return &ArrayLiteral{Token: tok, T: GENERIC_ARRAY}
+		return arrayLit
 	}
 	types := make([]*Type, len(elements))
 	for i, e := range elements {
 		types[i] = e.Type()
 	}
-	t := &Type{Name: ARRAY, Sub: p.combineTypes(types)}
-	return &ArrayLiteral{Token: tok, Elements: elements, T: t}
+	arrayLit.T = &Type{Name: ARRAY, Sub: p.combineTypes(types)}
+	arrayLit.Elements = elements
+	return arrayLit
 }
 
 func (p *Parser) parseExprList(scope *scope) []Node {
@@ -446,7 +450,7 @@ func (p *Parser) parseMapLiteral(scope *scope) Node {
 func (p *Parser) parseMapPairs(scope *scope) (map[string]Node, []string) {
 	pairs := map[string]Node{}
 	var order []string
-	p.advanceIfWSEOL()
+	p.parseMulitlineWS()
 	tt := p.cur.TokenType()
 
 	for tt != lexer.RCURLY && tt != lexer.EOF {
@@ -468,7 +472,7 @@ func (p *Parser) parseMapPairs(scope *scope) (map[string]Node, []string) {
 		}
 		pairs[key] = n
 		order = append(order, key)
-		p.advanceIfWSEOL()
+		p.parseMulitlineWS()
 		tt = p.cur.TokenType()
 	}
 	return pairs, order

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -175,6 +175,7 @@ func TestParseTopLevelExpression(t *testing.T) {
 	}
 	for input, want := range tests {
 		parser := New(input, testBuiltins())
+		parser.formatting = newFormatting()
 		parser.advanceTo(0)
 		scope := newScope(nil, &Program{})
 		scope.set("n1", &Var{Name: "n1", T: NUM_TYPE})
@@ -256,6 +257,7 @@ func TestParseTopLevelExpressionErr(t *testing.T) {
 	for input, wantErr := range tests {
 		parser := New(input, testBuiltins())
 		parser.advanceTo(0)
+		parser.formatting = newFormatting()
 		scope := newScope(nil, &Program{})
 		scope.set("n1", &Var{Name: "n1", T: NUM_TYPE})
 		mapType := &Type{Name: MAP, Sub: NUM_TYPE}

--- a/pkg/parser/format.go
+++ b/pkg/parser/format.go
@@ -1,0 +1,355 @@
+package parser
+
+import (
+	"io"
+	"reflect"
+	"strings"
+)
+
+func newFormatting() *formatting {
+	return &formatting{
+		wss:      map[*BinaryExpression]bool{},
+		comments: map[uintptr]string{},
+	}
+}
+
+type formatting struct {
+	w io.StringWriter
+
+	wss map[*BinaryExpression]bool
+	// TODO: When tinygo 0.28.0 is released replace uintptr keys with Node interface
+	//
+	//     comments  map[Node]string
+	//     multiline map[Node][]multilineItem
+	//
+	// the current implementation is a hack to work around a tinygo but, details:
+	// https://gophers.slack.com/archives/CDJD3SUP6/p1677288675055869
+	comments map[uintptr]string
+
+	indentLevel int
+}
+
+func (f *formatting) recordComment(n Node, comment string) {
+	f.comments[ptr(n)] = comment
+}
+
+func (f *formatting) recordWSS(n *BinaryExpression) {
+	f.wss[n] = true
+}
+
+func (f *formatting) format(n Node) {
+	switch n := n.(type) {
+	case *Program:
+		f.indentLevel = -1
+		f.writeStmts(n.Statements)
+	case *EmptyStmt:
+		f.writeComment(n)
+	case *TypedDeclStmt:
+		f.format(n.Decl)
+		f.writeComment(n)
+	case *InferredDeclStmt:
+		f.format(n.Decl.Var)
+		f.write(" := ")
+		f.format(n.Decl.Value)
+		f.writeComment(n)
+	case *AssignmentStmt:
+		f.format(n.Target)
+		f.write(" = ")
+		f.format(n.Value)
+		f.writeComment(n)
+	case *IfStmt:
+		f.formatIfStmt(n)
+	case *WhileStmt:
+		f.write("while ")
+		f.format(&n.ConditionalBlock)
+	case *BreakStmt:
+		f.write("break")
+		f.writeComment(n)
+	case *ForStmt:
+		f.formatForStmt(n)
+	case *ReturnStmt:
+		f.formatReturnStmt(n)
+	case *FuncDeclStmt:
+		f.formatFuncDeclStmt(n)
+	case *FuncCallStmt:
+		f.format(n.FuncCall)
+		f.writeComment(n)
+	case *EventHandlerStmt:
+		f.formatEventHandlerStmt(n)
+	case *Decl:
+		f.writeDecl(n.Var)
+	case *Var:
+		f.write(n.Name)
+	case *ConditionalBlock:
+		f.format(n.Condition)
+		f.writeComment(n)
+		f.writeLn()
+		f.format(n.Block)
+	case *BlockStatement:
+		f.writeStmts(n.Statements)
+		f.indent()
+		f.write("end")
+		f.writeComment(n)
+	case *StepRange:
+		f.formatStepRange(n)
+	case *FuncCall:
+		f.formatFuncCall(n)
+	case *UnaryExpression:
+		f.writes(n.Op.String(), n.Right.String())
+	case *BinaryExpression:
+		f.format(n.Left)
+		f.writeWSS(n)
+		f.write(n.Op.String())
+		f.writeWSS(n)
+		f.format(n.Right)
+	case *IndexExpression:
+		f.format(n.Left)
+		f.write("[")
+		f.format(n.Index)
+		f.write("]")
+	case *SliceExpression:
+		f.format(n.Left)
+		f.write("[")
+		f.formatIfNotNil(n.Start)
+		f.write(":")
+		f.formatIfNotNil(n.End)
+		f.write("]")
+	case *DotExpression:
+		f.format(n.Left)
+		f.writes(".", n.Key)
+	case *GroupExpression:
+		f.write("(")
+		f.format(n.Expr)
+		f.write(")")
+	case *Bool:
+		f.write(n.String())
+	case *NumLiteral:
+		f.write(n.String())
+	case *StringLiteral:
+		f.writes(`"`, n.Value, `"`)
+	case *ArrayLiteral:
+		f.formatArrayLiteral(n)
+	case *MapLiteral:
+		f.formatMapLiteral(n)
+	default:
+		f.write("format unimplemented for " + n.String())
+	}
+}
+
+func (f *formatting) formatIfStmt(s *IfStmt) {
+	f.write("if ")
+	f.format(s.IfBlock.Condition)
+	f.writeComment(s.IfBlock) // if comment
+	f.write("\n")
+	f.writeStmts(s.IfBlock.Block.Statements)
+	for _, elseif := range s.ElseIfBlocks {
+		f.indent()
+		f.write("else if ")
+		f.format(elseif.Condition)
+		f.writeComment(elseif) // else if comment
+		f.write("\n")
+		f.writeStmts(elseif.Block.Statements)
+	}
+	if s.Else != nil {
+		f.indent()
+		f.write("else")
+		f.writeComment(s.Else) // else comment
+		f.write("\n")
+		f.writeStmts(s.Else.Statements)
+	}
+	f.indent()
+	f.write("end")
+	f.writeComment(s) // end comment
+}
+
+func (f *formatting) formatForStmt(s *ForStmt) {
+	f.write("for ")
+	if s.LoopVar != nil {
+		f.writes(s.LoopVar.Name, " := ")
+	}
+	f.write("range ")
+	f.format(s.Range)
+	f.writeComment(s)
+	f.write("\n")
+	f.format(s.Block)
+}
+
+func (f *formatting) formatReturnStmt(s *ReturnStmt) {
+	f.write("return")
+	if s.Value != nil {
+		f.write(" ")
+		f.format(s.Value)
+	}
+	f.writeComment(s)
+}
+
+func (f *formatting) formatFuncDeclStmt(s *FuncDeclStmt) {
+	f.writes("func ", s.Name)
+	if s.ReturnType != NONE_TYPE {
+		f.write(":")
+		f.formatType(s.ReturnType)
+	}
+	for _, param := range s.Params {
+		f.write(" ")
+		f.writeDecl(param)
+	}
+	if s.VariadicParam != nil {
+		f.write(" ")
+		f.writeDecl(s.VariadicParam)
+		f.write("...")
+	}
+	f.writeComment(s)
+	f.write("\n")
+	f.format(s.Body)
+}
+
+func (f *formatting) formatEventHandlerStmt(s *EventHandlerStmt) {
+	f.writes("on ", s.Name)
+	for _, param := range s.Params {
+		f.write(" ")
+		f.writeDecl(param)
+	}
+	f.writeComment(s)
+	f.write("\n")
+	f.format(s.Body)
+}
+
+func (f *formatting) formatStepRange(n *StepRange) {
+	if n.Start != nil {
+		f.format(n.Start)
+		f.write(" ")
+	}
+	f.format(n.Stop)
+	if n.Step != nil {
+		f.write(" ")
+		f.format(n.Step)
+	}
+}
+
+func (f *formatting) formatFuncCall(n *FuncCall) {
+	f.write(n.Name)
+	for _, arg := range n.Arguments {
+		f.write(" ")
+		f.format(arg)
+	}
+}
+
+func (f *formatting) formatArrayLiteral(n *ArrayLiteral) {
+	// TODO: handle multilines
+	f.write("[")
+	length := len(n.Elements)
+	for i, el := range n.Elements {
+		f.format(el)
+		if i+1 < length {
+			f.write(" ")
+		}
+	}
+	f.write("]")
+}
+
+func (f *formatting) formatMapLiteral(n *MapLiteral) {
+	// TODO: handle multilines
+	f.write("{")
+	length := len(n.Pairs)
+	for i, key := range n.Order {
+		f.writes(key, ":")
+		f.format(n.Pairs[key])
+		if i+1 < length {
+			f.write(" ")
+		}
+	}
+	f.write("}")
+}
+
+func (f *formatting) formatType(t *Type) {
+	f.write(t.Name.String())
+	if t.Sub != nil && t != GENERIC_ARRAY && t != GENERIC_MAP {
+		f.formatType(t.Sub)
+	}
+}
+
+func (f *formatting) formatIfNotNil(n Node) {
+	if n != nil {
+		f.format(n)
+	}
+}
+
+func (f *formatting) write(s string) {
+	if _, err := f.w.WriteString(s); err != nil {
+		panic("formatting.write: " + err.Error())
+	}
+}
+
+func (f *formatting) writes(strs ...string) {
+	for _, str := range strs {
+		f.write(str)
+	}
+}
+
+func (f *formatting) writeLn() {
+	f.write("\n")
+}
+
+func (f *formatting) writeComment(n Node) {
+	c := f.comments[ptr(n)]
+	if c == "" {
+		return
+	}
+	if _, ok := n.(*EmptyStmt); !ok {
+		f.write(" ")
+	}
+	f.write(strings.TrimSpace(c))
+}
+
+func (f *formatting) writeDecl(n *Var) {
+	f.format(n)
+	f.write(":")
+	f.formatType(n.Type())
+}
+
+func (f *formatting) indent() {
+	for i := 0; i < f.indentLevel; i++ {
+		f.write("    ")
+	}
+}
+
+func (f *formatting) writeStmts(stmts []Node) {
+	f.indentLevel++
+
+	if len(stmts) == 0 {
+		stmts = []Node{&EmptyStmt{}} // write at least a single new line
+	}
+
+	empty := false
+	for _, stmt := range stmts {
+		if empty = f.writeEmptyStmt(stmt, empty); empty {
+			continue
+		}
+		f.indent()
+		f.format(stmt)
+		f.writeLn()
+	}
+
+	f.indentLevel--
+}
+
+func (f *formatting) writeEmptyStmt(n Node, lastEmpty bool) bool {
+	_, ok := n.(*EmptyStmt)
+	if ok && f.comments[ptr(n)] == "" {
+		if !lastEmpty {
+			f.writeLn()
+		}
+		return true
+	}
+	return false
+}
+
+func (f *formatting) writeWSS(n *BinaryExpression) {
+	if !f.wss[n] {
+		f.write(" ")
+	}
+}
+
+func ptr(n Node) uintptr {
+	return reflect.ValueOf(n).Pointer()
+}

--- a/pkg/parser/format.go
+++ b/pkg/parser/format.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"io"
 	"reflect"
 	"strings"
@@ -138,7 +139,7 @@ func (f *formatting) format(n Node) {
 	case *MapLiteral:
 		f.formatMapLiteral(n)
 	default:
-		f.write("format unimplemented for " + n.String())
+		f.write(fmt.Sprintf("format unimplemented for %v", n))
 	}
 }
 
@@ -268,7 +269,7 @@ func (f *formatting) formatArrayLiteral(n *ArrayLiteral) {
 		if i+1 == length || !multi[i+1].isNL() { // next is element, comment or `]`
 			f.indent()
 			if i+1 < length {
-				f.write(indentStr) // indent one extra for element or comment
+				f.write(indentStr) // one extra indent for element or comment
 			}
 		}
 	}
@@ -276,14 +277,34 @@ func (f *formatting) formatArrayLiteral(n *ArrayLiteral) {
 }
 
 func (f *formatting) formatMapLiteral(n *MapLiteral) {
-	// TODO: handle multilines
+	multi := formatMultiline(f.multiline[ptr(n)])
+	if len(multi) == 0 {
+		f.write("{}")
+		return
+	}
 	f.write("{")
-	length := len(n.Pairs)
-	for i, key := range n.Order {
-		f.writes(key, ":")
-		f.format(n.Pairs[key])
-		if i+1 < length {
-			f.write(" ")
+	if multi[0].isComment() {
+		f.write(" ")
+	}
+
+	length := len(multi)
+	for i, m := range multi {
+		if m.isKey() { // key
+			key := string(m)
+			f.writes(key, ":")
+			f.format(n.Pairs[key])
+			if i+1 < length && !multi[i+1].isNL() {
+				f.write(" ") // add space before next pair or comment
+			}
+			continue
+		}
+		// newline or comment
+		f.writes(string(m))
+		if i+1 == length || !multi[i+1].isNL() { // next is pair, comment or `}`
+			f.indent()
+			if i+1 < length {
+				f.write(indentStr) // one extra indent for pair or comment
+			}
 		}
 	}
 	f.write("}")

--- a/pkg/parser/format_test.go
+++ b/pkg/parser/format_test.go
@@ -1,0 +1,393 @@
+package parser
+
+import (
+	"testing"
+
+	"foxygo.at/evy/pkg/assert"
+)
+
+func TestReturnStmtFormat(t *testing.T) {
+	tests := map[string]string{
+		"return 1":                 "return 1\n",
+		"return    1  ":            "return 1\n",
+		"return  1   // a comment": "return 1 // a comment\n",
+	}
+	for input, want := range tests {
+		input, want := input, want
+		t.Run(input, func(t *testing.T) {
+			got := testFormat(t, input)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestWhileStmtFormat(t *testing.T) {
+	tests := map[string]string{
+		`while true
+break
+end`: `
+while true
+    break
+end
+`[1:],
+
+		`while true  // while comment
+// line comment
+break     // break comment
+end// end comment`: `
+while true // while comment
+    // line comment
+    break // break comment
+end // end comment
+`[1:],
+	}
+	for input, want := range tests {
+		input, want := input, want
+		t.Run(input, func(t *testing.T) {
+			got := testFormat(t, input)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestIfStmtFormat(t *testing.T) {
+	tests := map[string]string{
+		`if true
+return 1
+else if false
+return 2
+else
+return 3
+end
+`: `
+if true
+    return 1
+else if false
+    return 2
+else
+    return 3
+end
+`[1:],
+		`if true
+  if true
+    return 1
+  else
+    return 1.5
+  end
+else if false
+  if true
+    return 2
+  end
+else
+  if true
+    return 3
+  else if true
+    return 4
+  end
+end
+`: `
+if true
+    if true
+        return 1
+    else
+        return 1.5
+    end
+else if false
+    if true
+        return 2
+    end
+else
+    if true
+        return 3
+    else if true
+        return 4
+    end
+end
+`[1:],
+		`if true  // if comment
+		return 1 // 1 comment
+		else if false // else if comment
+		return 2 // 2 comment
+		else // else comment
+		return 3 // 3 comment
+		end // end comment
+		`: `
+if true // if comment
+    return 1 // 1 comment
+else if false // else if comment
+    return 2 // 2 comment
+else // else comment
+    return 3 // 3 comment
+end // end comment
+`[1:],
+		`if true
+return 1
+end
+`: `
+if true
+    return 1
+end
+`[1:],
+		`if true  // if comment
+		return 1 // 1 comment
+		end // end comment
+		`: `
+if true // if comment
+    return 1 // 1 comment
+end // end comment
+`[1:],
+	}
+
+	for input, want := range tests {
+		input, want := input, want
+		t.Run(input, func(t *testing.T) {
+			got := testFormat(t, input)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestForStmtFormat(t *testing.T) {
+	tests := map[string]string{
+		`for   i:=   range 10
+print    i
+end
+`: `
+for i := range 10
+    print i
+end
+`[1:],
+		`for   i:=   range 10   20
+print    i
+end
+`: `
+for i := range 10 20
+    print i
+end
+`[1:],
+		`for   i:=   range 10   20  3
+print    i
+end
+`: `
+for i := range 10 20 3
+    print i
+end
+`[1:],
+		`for   i:=   range 10   20  3 // for comment
+print    i  // print comment
+end // end comment
+`: `
+for i := range 10 20 3 // for comment
+    print i // print comment
+end // end comment
+`[1:],
+	}
+
+	for input, want := range tests {
+		input, want := input, want
+		t.Run(input, func(t *testing.T) {
+			got := testFormat(t, input)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestDeclAssignStmtFormat(t *testing.T) {
+	tests := map[string]string{
+		`i   :=  7
+		i  =   5
+		print   i
+`: `
+i := 7
+i = 5
+print i
+`[1:],
+		`i :  num
+		print   i
+`: `
+i:num
+print i
+`[1:],
+		`i   :=  7   // comment i
+		print   i
+`: `
+i := 7 // comment i
+print i
+`[1:],
+		`i :  num // comment decl
+i=5 // comment assign
+		print   i
+`: `
+i:num // comment decl
+i = 5 // comment assign
+print i
+`[1:],
+	}
+
+	for input, want := range tests {
+		input, want := input, want
+		t.Run(input, func(t *testing.T) {
+			got := testFormat(t, input)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestFuncDeclFormat(t *testing.T) {
+	tests := map[string]string{
+		`func fox     // func
+		print   "🦊"  // print
+		end  // end
+`: `
+func fox // func
+    print "🦊" // print
+end // end
+`[1:],
+		`func fox : string a:num b : bool     // func
+		print   a   b // print
+		return  "🦊"   // return
+		end  // end
+`: `
+func fox:string a:num b:bool // func
+    print a b // print
+    return "🦊" // return
+end // end
+`[1:],
+	}
+
+	for input, want := range tests {
+		input, want := input, want
+		t.Run(input, func(t *testing.T) {
+			got := testFormat(t, input)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestEventHandlerFormat(t *testing.T) {
+	tests := map[string]string{
+		`on down // on
+		print   "🦊"  // print
+		end  // end
+`: `
+on down // on
+    print "🦊" // print
+end // end
+`[1:],
+		`on down  x:num y:num   // on
+		print  x y // print
+		end  // end
+`: `
+on down x:num y:num // on
+    print x y // print
+end // end
+`[1:],
+	}
+
+	for input, want := range tests {
+		input, want := input, want
+		t.Run(input, func(t *testing.T) {
+			got := testFormat(t, input)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestPrintExpressionFormat(t *testing.T) {
+	tests := map[string]string{
+		"print  1+2":                 "print 1+2\n",
+		"print  1+2 // comment":      "print 1+2 // comment\n",
+		"print  (true  or  false)  ": "print (true or false)\n",
+		"print  1+2*3":               "print 1+2*3\n",
+		"print   [1 2 3][0]":         "print [1 2 3][0]\n",
+	}
+	for input, want := range tests {
+		input, want := input, want
+		t.Run(input, func(t *testing.T) {
+			got := testFormat(t, input)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestExpressionFormat(t *testing.T) {
+	tests := map[string]string{
+		"x := 1+2":            "x := 1 + 2",
+		"x := 1+2*3/n":        "x := 1 + 2 * 3 / n",
+		"x := [[1] [2]] ":     "x := [[1] [2]]",
+		"x := arr[n + 2] ":    "x := arr[n + 2]",
+		"x := [ 2+n   3*n  ]": "x := [2+n 3*n]",
+		"x := s+s":            "x := s + s",
+		"x := s[  0  ]":       "x := s[0]",
+		"x := m.a + n":        "x := m.a + n",
+		"x := [m.a+n]":        "x := [m.a+n]",
+		"x := s[m.a+n]":       "x := s[m.a + n]",
+		"x := arr[1:n+3]":     "x := arr[1:n + 3]",
+		"x := arr[ :n+3]":     "x := arr[:n + 3]",
+		"x := arr[ n+3: ]":    "x := arr[n + 3:]",
+	}
+	for input, want := range tests {
+		before := `
+n := 1
+arr := [1 2 3]
+m := {a:1 b:2}
+s := "a"
+`[1:]
+		after := "\nprint n arr m s x\n"
+		input := before + input + after
+		want := before + want + after
+		t.Run(input, func(t *testing.T) {
+			got := testFormat(t, input)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestTestEmptyStmtFormat(t *testing.T) {
+	tests := map[string]string{
+		"":       "\n",
+		"\n":     "\n",
+		"\n\n":   "\n",
+		"\n\n\n": "\n",
+
+		"//asdf":             "//asdf\n",
+		"//asdf\n\n":         "//asdf\n\n",
+		"//asdf\n\n\n":       "//asdf\n\n",
+		"\n//asdf\n\n\n":     "\n//asdf\n\n",
+		"\n\n//asdf\n\n\n":   "\n//asdf\n\n",
+		"\n\n\n//asdf\n\n\n": "\n//asdf\n\n",
+
+		`
+if true
+
+
+  // tests
+// test1
+
+  print 1
+end`: `
+if true
+
+    // tests
+    // test1
+
+    print 1
+end
+`,
+	}
+	for input, want := range tests {
+		input, want := input, want
+		t.Run(input, func(t *testing.T) {
+			got := testFormat(t, input)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func testFormat(t *testing.T, input string) string {
+	t.Helper()
+	parser := New(input, testBuiltins())
+	prog := parser.Parse()
+	assertNoParseError(t, parser, input)
+	return prog.Format()
+}

--- a/pkg/parser/format_test.go
+++ b/pkg/parser/format_test.go
@@ -474,6 +474,126 @@ print x
 	}
 }
 
+func TestMapLiteralFormat(t *testing.T) {
+	tests := map[string]string{
+		"x:={   }":            "x := {}",
+		"x:= { a : 1 b:2   }": "x := {a:1 b:2}",
+		`
+x:= {
+			a : 1
+			b:2
+		}`: `
+x := {
+    a:1
+    b:2
+}`,
+		`
+x:= {			a : 1
+			b:2	}`: `
+x := {a:1
+    b:2}`,
+		`
+x:{}num
+if true
+  x= {
+			    a : 1
+			    b:2
+		  }
+end`: `
+x:{}num
+if true
+    x = {
+        a:1
+        b:2
+    }
+end`,
+		`
+x:= {			a : 1 // comment 1
+			b:2	} // comment 2`: `
+x := {a:1 // comment 1
+    b:2} // comment 2`,
+		`
+x:= {
+
+
+	  a : 1
+
+
+	  b:2
+
+
+}`: `
+x := {
+
+    a:1
+
+    b:2
+
+}`,
+		`
+x:= {
+
+    // comment 1
+	  a : 1
+
+    // comment 2
+
+	  b:2
+	  // comment 3
+	  // comment 4
+}`: `
+x := {
+
+    // comment 1
+    a:1
+
+    // comment 2
+
+    b:2
+    // comment 3
+    // comment 4
+}`,
+	}
+
+	for input, want := range tests {
+		input, want := input+"\nprint x", want+"\nprint x\n"
+		t.Run(input, func(t *testing.T) {
+			got := testFormat(t, input)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func TestArrayMapLiteralFormat(t *testing.T) {
+	input := `x := [
+  { x:1}
+  { x:2}
+  { x:3}
+  { x:4}
+  { x:3}
+  { x:2}
+  { x:1}
+]
+print x`
+	want := `
+x := [
+    {x:1}
+    {x:2}
+    {x:3}
+    {x:4}
+    {x:3}
+    {x:2}
+    {x:1}
+]
+print x
+`[1:]
+	parser := New(input, testBuiltins())
+	prog := parser.Parse()
+	assertNoParseError(t, parser, input)
+	got := prog.Format()
+	assert.Equal(t, want, got)
+}
+
 func testFormat(t *testing.T, input string) string {
 	t.Helper()
 	parser := New(input, testBuiltins())

--- a/pkg/parser/format_test.go
+++ b/pkg/parser/format_test.go
@@ -384,6 +384,96 @@ end
 	}
 }
 
+func TestArrayLiteralFormat(t *testing.T) {
+	tests := map[string]string{
+		`x := [1 2 3]
+		print x
+`: `
+x := [1 2 3]
+print x
+`[1:],
+		`x := [  1  2    3    ]
+		print    x
+`: `
+x := [1 2 3]
+print x
+`[1:],
+		`x := [
+		1
+		2
+		 ]
+		print    x
+`: `
+x := [
+    1
+    2
+]
+print x
+`[1:],
+		`x := [1
+		1.5
+		2]
+		print    x
+`: `
+x := [1
+    1.5
+    2]
+print x
+`[1:],
+		`x := [
+
+
+		    1
+
+
+		    2
+
+		  ]
+		  print    x
+`: `
+x := [
+
+    1
+
+    2
+
+]
+print x
+`[1:],
+		`x := [ // comment
+// line comment 1
+		1 // comment 1
+
+// line comment 2
+
+
+		2 // comment 2
+// line comment 3
+		 ]
+		print    x
+`: `
+x := [ // comment
+    // line comment 1
+    1 // comment 1
+
+    // line comment 2
+
+    2 // comment 2
+    // line comment 3
+]
+print x
+`[1:],
+	}
+
+	for input, want := range tests {
+		input, want := input, want
+		t.Run(input, func(t *testing.T) {
+			got := testFormat(t, input)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
 func testFormat(t *testing.T, input string) string {
 	t.Helper()
 	parser := New(input, testBuiltins())

--- a/pkg/parser/multiline.go
+++ b/pkg/parser/multiline.go
@@ -1,0 +1,83 @@
+package parser
+
+import "strings"
+
+// multilineItem is used to represent multiline array and map literals
+// as used in formatting. It does not explicitly store array or map
+// values, just placeholders - "el" for next element in arrays, keys for
+// maps.
+//
+// A multilineItem can be:
+// 1. Empty `""` representing a newline.
+// 2. Starting with `"//"` represents a full comment.
+// 3a. For arrays the multiline item `"el"` represents the next array
+// literal element.
+// 3b. For maps all the multiline items that don't represent
+// newline (`""`) or comments (`// …`) are the key of the next map pair.
+//
+// The follow example shows a multiline array literal and its
+// multilineItem slice representation:
+//
+//	arr := [ 1 // commment1
+//	    2
+//
+//	    // comment2
+//	    3
+//	]
+//
+// has the representation:
+//
+//	[ "el", "// comment1", "el", "", "", "// comment2", "el", ""]
+//
+// The next example shows a multiline map literal and its
+// multilineItem slice representation:
+//
+//	map := {
+//	    a: 1 // commment1
+//	    b: 2
+//
+//	    // comment2
+//	    c: 3
+//	}
+//
+// has the representation:
+//
+//	[ "", "a","// comment1", "b", "", "", "// comment2", "c", ""]
+type multilineItem string
+
+func (m multilineItem) isComment() bool {
+	return strings.HasPrefix(string(m), "//")
+}
+
+func (m multilineItem) isNL() bool {
+	return m == multilineNL
+}
+
+const (
+	multilineEl = multilineItem("el")
+	multilineNL = multilineItem("\n")
+)
+
+func multilineComment(s string) multilineItem {
+	s = strings.TrimSpace(s)
+	return multilineItem(s + "\n")
+}
+
+func formatMultiline(multilineItems []multilineItem) []multilineItem {
+	formatted := make([]multilineItem, 0, len(multilineItems))
+	nlCount := 0
+	for _, item := range multilineItems {
+		switch {
+		case item.isNL():
+			nlCount++
+		case item.isComment():
+			nlCount = 1
+		default: // array element or map key
+			nlCount = 0
+		}
+		if nlCount <= 2 {
+			formatted = append(formatted, item)
+		}
+	}
+	return formatted
+}

--- a/pkg/parser/multiline.go
+++ b/pkg/parser/multiline.go
@@ -53,6 +53,10 @@ func (m multilineItem) isNL() bool {
 	return m == multilineNL
 }
 
+func (m multilineItem) isKey() bool {
+	return !m.isNL() && !m.isComment()
+}
+
 const (
 	multilineEl = multilineItem("el")
 	multilineNL = multilineItem("\n")

--- a/pkg/parser/multiline_test.go
+++ b/pkg/parser/multiline_test.go
@@ -1,0 +1,34 @@
+package parser
+
+import (
+	"testing"
+
+	"foxygo.at/evy/pkg/assert"
+)
+
+func TestArrayLiteralMultiline(t *testing.T) {
+	tests := map[string][]multilineItem{
+		"[1]":   {multilineEl},
+		"[1 2]": {multilineEl, multilineEl},
+		`[1
+		2]`: {multilineEl, multilineNL, multilineEl},
+		`[
+		1
+		2
+		]`: {multilineNL, multilineEl, multilineNL, multilineEl, multilineNL},
+		`[1 // comment 1
+		// comment 2
+		2]`: {multilineEl, multilineComment("// comment 1\n"), multilineComment("  // comment 2   "), multilineEl},
+	}
+	for input, want := range tests {
+		parser := New(input, testBuiltins())
+		parser.formatting = newFormatting()
+		parser.advanceTo(0)
+		scope := newScope(nil, &Program{})
+
+		arrayLit := parser.parseArrayLiteral(scope).(*ArrayLiteral)
+		assertNoParseError(t, parser, input)
+		got := parser.formatting.multiline[ptr(arrayLit)]
+		assert.Equal(t, want, got)
+	}
+}

--- a/pkg/parser/multiline_test.go
+++ b/pkg/parser/multiline_test.go
@@ -32,3 +32,31 @@ func TestArrayLiteralMultiline(t *testing.T) {
 		assert.Equal(t, want, got)
 	}
 }
+
+func TestMapLiteralMultiline(t *testing.T) {
+	tests := map[string][]multilineItem{
+		"{a:1}":     {"a"},
+		"{a:1 b:2}": {"a", "b"},
+		`{a:1
+		b:2}`: {"a", multilineNL, "b"},
+		`{
+		a:1
+
+		b:2
+		}`: {multilineNL, "a", multilineNL, multilineNL, "b", multilineNL},
+		`{ a:1 // comment 1
+		// comment 2
+		b:2}`: {"a", multilineComment(" // comment 1 "), multilineComment("// comment 2"), "b"},
+	}
+	for input, want := range tests {
+		parser := New(input, testBuiltins())
+		parser.formatting = newFormatting()
+		parser.advanceTo(0)
+		scope := newScope(nil, &Program{})
+
+		mapLit := parser.parseMapLiteral(scope).(*MapLiteral)
+		assertNoParseError(t, parser, input)
+		got := parser.formatting.multiline[ptr(mapLit)]
+		assert.Equal(t, want, got)
+	}
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -41,7 +41,8 @@ type Parser struct {
 	funcs         map[string]*FuncDeclStmt     // all function declarations by name
 	EventHandlers map[string]*EventHandlerStmt // all event handler declarations by name
 
-	wssStack []bool
+	wssStack   []bool
+	formatting *formatting
 }
 
 // Error is an Evy parse error.
@@ -61,6 +62,7 @@ func New(input string, builtins Builtins) *Parser {
 		EventHandlers: map[string]*EventHandlerStmt{},
 		wssStack:      []bool{false},
 		builtins:      builtins,
+		formatting:    newFormatting(),
 	}
 	for name, funcDecl := range builtins.Funcs {
 		p.funcs[name] = funcDecl
@@ -124,7 +126,7 @@ func (p *Parser) Parse() *Program {
 // function names matching `parsePRODUCTION` align with production names
 // in grammar doc/syntax_grammar.md.
 func (p *Parser) parseProgram() *Program {
-	program := &Program{}
+	program := &Program{formatting: p.formatting}
 	scope := newScope(nil, program) // TODO: model scope as stack like evaluator.
 	for _, global := range p.builtins.Globals {
 		global.isUsed = true
@@ -179,6 +181,8 @@ func (p *Parser) parseFunc(scope *scope) Node {
 		p.appendError("missing return")
 	}
 	p.assertEnd()
+	p.advance()
+	p.recordComment(block)
 	p.advancePastNL()
 	fd.Body = block
 	return fd
@@ -225,12 +229,15 @@ func (p *Parser) parseEventHandler(scope *scope) Node {
 		decl := p.parseTypedDecl()
 		e.Params = append(e.Params, decl.Var)
 	}
+	p.recordComment(e)
 	p.advancePastNL()
 
 	scope = newScopeWithReturnType(scope, e, NONE_TYPE) // only bare returns
 	p.addEventParamsToScope(scope, e)
 	e.Body = p.parseBlock(scope)
 	p.assertEnd()
+	p.advance()
+	p.recordComment(e.Body)
 	p.advancePastNL()
 	return e
 }
@@ -301,6 +308,7 @@ func (p *Parser) parseEmptyStmt() Node {
 		p.advance()
 		return empty
 	case lexer.COMMENT:
+		p.recordComment(empty)
 		p.advance() // COMMENT
 		p.advance() // NL
 		return empty
@@ -333,8 +341,10 @@ func (p *Parser) parseAssignmentStatement(scope *scope) Node {
 		p.appendErrorForToken(msg, tok)
 	}
 	p.assertEOL()
+	stmt := &AssignmentStmt{Token: tok, Target: target, Value: value}
+	p.recordComment(stmt)
 	p.advancePastNL()
-	return &AssignmentStmt{Token: tok, Target: target, Value: value}
+	return stmt
 }
 
 func (p *Parser) parseAssignmentTarget(scope *scope) Node {
@@ -400,6 +410,7 @@ func (p *Parser) parseFuncDeclSignature() *FuncDeclStmt {
 		}
 	}
 	p.assertEOL()
+	p.recordComment(fd)
 	p.advancePastNL()
 	return fd
 }
@@ -410,8 +421,10 @@ func (p *Parser) parseTypedDeclStatement(scope *scope) Node {
 		scope.set(decl.Var.Name, decl.Var)
 		p.assertEOL()
 	}
+	typeDecl := &TypedDeclStmt{Token: decl.Token, Decl: decl}
+	p.recordComment(typeDecl)
 	p.advancePastNL()
-	return &TypedDeclStmt{Token: decl.Token, Decl: decl}
+	return typeDecl
 }
 
 // parseTypedDecl parses declarations like
@@ -481,7 +494,10 @@ func (p *Parser) parseInferredDeclStatement(scope *scope) Node {
 	decl.Value = val
 	scope.set(varName, decl.Var)
 	p.assertEOL()
-	return &InferredDeclStmt{Token: decl.Token, Decl: decl}
+
+	inferredDecl := &InferredDeclStmt{Token: decl.Token, Decl: decl}
+	p.recordComment(inferredDecl)
+	return inferredDecl
 }
 
 func (p *Parser) isFuncCall(tok *lexer.Token) bool {
@@ -493,8 +509,11 @@ func (p *Parser) isFuncCall(tok *lexer.Token) bool {
 func (p *Parser) parseFunCallStatement(scope *scope) Node {
 	fc := p.parseFuncCall(scope).(*FuncCall)
 	p.assertEOL()
+	fcs := &FuncCallStmt{Token: fc.Token, FuncCall: fc}
+	p.recordComment(fcs)
+
 	p.advancePastNL()
-	return &FuncCallStmt{Token: fc.Token, FuncCall: fc}
+	return fcs
 }
 
 func (p *Parser) assertArgTypes(decl *FuncDeclStmt, args []Node) {
@@ -630,6 +649,10 @@ func (p *Parser) advanceIfWS() {
 func (p *Parser) advanceIfWSEOL() {
 	tt := p.cur.Type
 	for tt == lexer.NL || tt == lexer.COMMENT || tt == lexer.WS {
+		if tt == lexer.COMMENT {
+			p.advanceWSS() // advance past NL
+			p.assertToken(lexer.NL)
+		}
 		p.advanceWSS()
 		tt = p.cur.Type
 	}
@@ -710,6 +733,7 @@ func (p *Parser) parseReturnStatement(scope *scope) Node {
 		}
 		p.appendErrorForToken(msg, retValueToken)
 	}
+	p.recordComment(ret)
 	p.advancePastNL()
 	return ret
 }
@@ -721,6 +745,7 @@ func (p *Parser) parseBreakStatement(scope *scope) Node {
 	}
 	p.advance() // advance past BREAK token
 	p.assertEOL()
+	p.recordComment(breakStmt)
 	p.advancePastNL()
 	return breakStmt
 }
@@ -778,9 +803,12 @@ func (p *Parser) parseForStatement(scope *scope) Node {
 	default:
 		p.appendError("expected num, string, array or map after range, found " + t.String())
 	}
+	p.recordComment(forNode)
 	p.advancePastNL()
 	forNode.Block = p.parseBlock(scope)
 	p.assertEnd()
+	p.advance()
+	p.recordComment(forNode.Block)
 	p.advancePastNL()
 	return forNode
 }
@@ -818,9 +846,13 @@ func (p *Parser) parseWhileStatement(scope *scope) Node {
 	p.advance() // advance past WHILE token
 	scope = newScope(scope, while)
 	while.Condition = p.parseCondition(scope)
+	comment := p.curComment()
 	p.advancePastNL()
 	while.Block = p.parseBlock(scope)
+	p.recordCommentString(&while.ConditionalBlock, comment)
 	p.assertEnd()
+	p.advance()
+	p.recordComment(while.ConditionalBlock.Block)
 	p.advancePastNL()
 	return while
 }
@@ -848,10 +880,15 @@ func (p *Parser) parseIfStatement(scope *scope) Node {
 	if p.cur.TokenType() == lexer.ELSE {
 		p.advance() // advance past ELSE token
 		p.assertEOL()
+		comment := p.curComment()
 		p.advancePastNL()
-		ifStmt.Else = p.parseBlock(newScope(scope, ifStmt))
+		elseBlock := p.parseBlock(newScope(scope, ifStmt))
+		p.recordCommentString(elseBlock, comment)
+		ifStmt.Else = elseBlock
 	}
 	p.assertEnd()
+	p.advance()
+	p.recordComment(ifStmt)
 	p.advancePastNL()
 	return ifStmt
 }
@@ -860,6 +897,7 @@ func (p *Parser) parseIfConditionalBlock(scope *scope) *ConditionalBlock {
 	ifBlock := &ConditionalBlock{Token: p.cur}
 	p.advance() // advance past IF token
 	ifBlock.Condition = p.parseCondition(scope)
+	p.recordComment(ifBlock)
 	p.advancePastNL()
 	ifBlock.Block = p.parseIfBlock(scope)
 	return ifBlock
@@ -901,4 +939,23 @@ func (p *Parser) parseType() *Type {
 		}
 	}
 	return ILLEGAL_TYPE
+}
+
+func (p *Parser) recordComment(n Node) {
+	if p.cur.Type == lexer.COMMENT {
+		p.formatting.recordComment(n, p.cur.Literal)
+	}
+}
+
+func (p *Parser) recordCommentString(n Node, str string) {
+	if str != "" {
+		p.formatting.recordComment(n, str)
+	}
+}
+
+func (p *Parser) curComment() string {
+	if p.cur.Type == lexer.COMMENT {
+		return p.cur.Literal
+	}
+	return ""
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -255,13 +255,11 @@ func (p *Parser) addEventParamsToScope(scope *scope, e *EventHandlerStmt) {
 
 func (p *Parser) parseStatement(scope *scope) Node {
 	switch p.cur.TokenType() {
-	// empty statement
-	case lexer.NL, lexer.EOF, lexer.COMMENT:
-		p.advancePastNL()
-		return nil
 	case lexer.WS:
 		p.advance()
 		return nil
+	case lexer.NL, lexer.COMMENT:
+		return p.parseEmptyStmt()
 	case lexer.IDENT:
 		switch p.peek.Type {
 		case lexer.ASSIGN, lexer.DOT:
@@ -294,6 +292,21 @@ func (p *Parser) parseStatement(scope *scope) Node {
 	p.appendError("unexpected input " + p.cur.FormatDetails())
 	p.advancePastNL()
 	return nil
+}
+
+func (p *Parser) parseEmptyStmt() Node {
+	empty := &EmptyStmt{Token: p.cur}
+	switch p.cur.Type {
+	case lexer.NL:
+		p.advance()
+		return empty
+	case lexer.COMMENT:
+		p.advance() // COMMENT
+		p.advance() // NL
+		return empty
+	default:
+		panic("internal error: parseEmptyStmt of invalid type")
+	}
 }
 
 func (p *Parser) parseAssignmentStatement(scope *scope) Node {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -646,16 +646,23 @@ func (p *Parser) advanceIfWS() {
 	}
 }
 
-func (p *Parser) advanceIfWSEOL() {
+// parseMultilineWS parses multiline whitespace and comments as needed
+// for formatting in Array and Map literals.
+func (p *Parser) parseMulitlineWS() []multilineItem {
 	tt := p.cur.Type
+	var multi []multilineItem
 	for tt == lexer.NL || tt == lexer.COMMENT || tt == lexer.WS {
-		if tt == lexer.COMMENT {
+		if tt == lexer.NL {
+			multi = append(multi, multilineNL)
+		} else if tt == lexer.COMMENT {
+			multi = append(multi, multilineComment(p.cur.Literal))
 			p.advanceWSS() // advance past NL
 			p.assertToken(lexer.NL)
 		}
 		p.advanceWSS()
 		tt = p.cur.Type
 	}
+	return multi
 }
 
 func (p *Parser) isWSS() bool {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -11,7 +11,7 @@ func TestParseDecl(t *testing.T) {
 	tests := map[string][]string{
 		"a := 1":     {"a=1"},
 		"a:bool":     {"a=false"},
-		"\na:bool\n": {"a=false"},
+		"\na:bool\n": {"\na=false\n"},
 		`a := "abc"
 		b:bool
 		c := true
@@ -43,22 +43,22 @@ func TestParseDecl(t *testing.T) {
 }
 
 func TestEmptyProgram(t *testing.T) {
-	tests := []string{
-		"",
-		"\n",
-		"\n\n\n",
-		" ",
-		" \n //adf \n",
-		"//blabla",
-		"//blabla\n",
-		" \n //blabla \n",
-		" \n //blabla",
+	tests := map[string]string{
+		"":                "\n",
+		"\n":              "\n",
+		"\n\n\n":          "\n\n\n",
+		" ":               "\n",
+		" \n //adf \n":    "\n\n",
+		"//blabla":        "\n",
+		"//blabla\n":      "\n",
+		" \n //blabla \n": "\n\n",
+		" \n //blabla":    "\n\n",
 	}
-	for _, input := range tests {
+	for input, want := range tests {
 		parser := New(input, testBuiltins())
 		got := parser.Parse()
 		assertNoParseError(t, parser, input)
-		assert.Equal(t, "\n", got.String())
+		assert.Equal(t, want, got.String(), input)
 	}
 }
 
@@ -159,7 +159,7 @@ end`: `
 if (true) {
 print('TRUE')
 }
-`[1:],
+`,
 		`
 if true
 	if true
@@ -171,7 +171,7 @@ if (true) {
 print('TRUE')
 }
 }
-`[1:],
+`,
 	}
 	for input, want := range tests {
 		parser := New(input, testBuiltins())
@@ -192,7 +192,7 @@ print x
 	want := `
 x=len('123')
 print(x)
-`[1:]
+`
 	assert.Equal(t, want, got.String())
 }
 
@@ -1195,12 +1195,13 @@ end`
 	assert.Equal(t, "line 2 column 1: unknown function 'move'", gotErr)
 	assert.Equal(t, "line 3 column 1: unknown function 'line'", parser.errors[1].String())
 	want := `
+
 x=12
 print('x:', x)
 if ((x>10)) {
 print('🍦 big x')
 }
-`[1:]
+`
 	assert.Equal(t, want, got.String())
 }
 


### PR DESCRIPTION
Implement formatting in parser and wire in frontend prior to every
evaluation. Formatting was purposefully kept mostly to the
`parser/format.go` file.

This is feature complete formatting, the only outstanding work
is to add `evy format [-w] FILE...` to evy CLI.

Reformat sample code by running:

https://evy-lang--94-x5xuqzz3.web.app/#animate
https://evy-lang--94-x5xuqzz3.web.app/#dot
https://evy-lang--94-x5xuqzz3.web.app/#draw
https://evy-lang--94-x5xuqzz3.web.app/#echo
https://evy-lang--94-x5xuqzz3.web.app/#rand
https://evy-lang--94-x5xuqzz3.web.app/#sliders
https://evy-lang--94-x5xuqzz3.web.app/#strings

We had to hack around not using interfaces as map keys by converting them
`uinptr` to work around a tinygo-0.27.0 bug which has been fixed on 
dev, see gophers slack link for details. Thanks for the idea and implementation
help @camh- !


Link: https://gophers.slack.com/archives/CDJD3SUP6/p1677288675055869