### PR TITLE
parser: Insert NL before `func`

### DIFF
--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -205,7 +205,7 @@ func (p *Program) String() string {
 func (p *Program) Format() string {
 	var sb strings.Builder
 	p.formatting.w = &sb
-	p.formatting.format(p)
+	p.formatting.format(p) // todo: maybe formatting.formatProgram(prog, w)
 	return sb.String()
 }
 

--- a/pkg/parser/format_test.go
+++ b/pkg/parser/format_test.go
@@ -594,6 +594,108 @@ print x
 	assert.Equal(t, want, got)
 }
 
+func TestNLInsertion(t *testing.T) {
+	tests := map[string]string{
+		`func f1
+	print 1
+end // needs nl after this line, stmt IDX 0
+func f2
+    print 2
+end`: `
+func f1
+    print 1
+end // needs nl after this line, stmt IDX 0
+
+func f2
+    print 2
+end
+`[1:],
+		`
+func f1
+    print 1
+end // needs nl after this line, stmt IDX 0
+func f2
+    print 2
+end`: `
+func f1
+    print 1
+end // needs nl after this line, stmt IDX 0
+
+func f2
+    print 2
+end
+`,
+		`
+func f1
+    print 1
+end // needs nl after this line, stmt IDX 0
+// f2 comment
+func f2
+    print 2
+end
+`: `
+func f1
+    print 1
+end // needs nl after this line, stmt IDX 0
+
+// f2 comment
+func f2
+    print 2
+end
+`,
+		`
+func f1
+    print 1
+end // needs nl after this line, stmt IDX 0
+// f2 comment
+// f2 comment continued
+on down
+    print 2
+end`: `
+func f1
+    print 1
+end // needs nl after this line, stmt IDX 0
+
+// f2 comment
+// f2 comment continued
+on down
+    print 2
+end
+`,
+		`
+// f1 comment
+func f1
+    print 1
+end // needs nl after this line, stmt IDX 0
+print 1
+// f2 comment
+// f2 comment continued
+on down
+    print 2
+end`: `
+// f1 comment
+func f1
+    print 1
+end // needs nl after this line, stmt IDX 0
+
+print 1
+
+// f2 comment
+// f2 comment continued
+on down
+    print 2
+end
+`,
+	}
+	for input, want := range tests {
+		input, want := input, want
+		t.Run(input, func(t *testing.T) {
+			got := testFormat(t, input)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
 func testFormat(t *testing.T, input string) string {
 	t.Helper()
 	parser := New(input, testBuiltins())


### PR DESCRIPTION
Insert NL before `func` and `on` statements for function and eventhandler
declarations. Honour leading comments. Insert newline after func and event
handler declarations if directly followed by a stmt.