### PR TITLE
go: Clean up error handling and parser state

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,6 +30,7 @@ linters:
     - lll
     - maligned
     - nlreturn
+    - nilnil
     - nosnakecase
     - paralleltest
     - revive

--- a/main.go
+++ b/main.go
@@ -36,6 +36,14 @@ type config struct {
 	Parse    parseCmd    `cmd:"" help:"Parse evy program" hidden:""`
 }
 
+func main() {
+	kctx := kong.Parse(&config{},
+		kong.Description(description),
+		kong.Vars{"version": version},
+	)
+	kctx.FatalIfErrorf(kctx.Run())
+}
+
 type runCmd struct {
 	Source string `arg:"" help:"Source file. Default stdin" default:"-"`
 }
@@ -147,14 +155,6 @@ func (c *parseCmd) Run() error {
 	result := parser.Run(string(b), builtinDecls)
 	fmt.Println(result)
 	return nil
-}
-
-func main() {
-	kctx := kong.Parse(&config{},
-		kong.Description(description),
-		kong.Vars{"version": version},
-	)
-	kctx.FatalIfErrorf(kctx.Run())
 }
 
 func fileBytes(filename string) ([]byte, error) {

--- a/main.go
+++ b/main.go
@@ -70,8 +70,7 @@ func (c *runCmd) Run() error {
 	}
 	builtins := evaluator.DefaultBuiltins(newRuntime())
 	eval := evaluator.NewEvaluator(builtins)
-	eval.Run(string(b))
-	return nil
+	return eval.Run(string(b))
 }
 
 func (c *fmtCmd) Run() error {

--- a/main.go
+++ b/main.go
@@ -117,12 +117,11 @@ func format(r io.Reader, w io.StringWriter, checkOnly bool) error {
 	if err != nil {
 		return err
 	}
-	builtins := evaluator.DefaultBuiltins(newRuntime())
 	in := string(b)
-	p := parser.New(in, evaluator.NewParserBuiltins(builtins))
-	prog := p.Parse()
-	if p.HasErrors() {
-		return fmt.Errorf("%w: %s", errParse, parser.MaxErrorsString(p.Errors(), 8))
+	parserBuiltins := evaluator.DefaultParserBuiltins(newRuntime())
+	prog, err := parser.Parse(in, parserBuiltins)
+	if err != nil {
+		return fmt.Errorf("%w: %s", errParse, parser.TruncateError(err, 8))
 	}
 	out := prog.Format()
 	if checkOnly {
@@ -153,8 +152,11 @@ func (c *parseCmd) Run() error {
 		return err
 	}
 	builtinDecls := evaluator.DefaulParserBuiltins(newRuntime())
-	result := parser.Run(string(b), builtinDecls)
-	fmt.Println(result)
+	ast, err := parser.Parse(string(b), builtinDecls)
+	if err != nil {
+		return fmt.Errorf("%w: %s", errParse, parser.TruncateError(err, 8))
+	}
+	fmt.Println(ast.String())
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -37,10 +37,11 @@ type config struct {
 }
 
 func main() {
-	kctx := kong.Parse(&config{},
+	kopts := []kong.Option{
 		kong.Description(description),
 		kong.Vars{"version": version},
-	)
+	}
+	kctx := kong.Parse(&config{}, kopts...)
 	kctx.FatalIfErrorf(kctx.Run())
 }
 

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -38,7 +38,7 @@ func DefaultParserBuiltins(rt *Runtime) parser.Builtins {
 	return ParserBuiltins(DefaultBuiltins(rt))
 }
 
-type BuiltinFunc func(scope *scope, args []Value) Value
+type BuiltinFunc func(scope *scope, args []Value) (Value, error)
 
 func (b BuiltinFunc) Type() ValueType { return BUILTIN }
 func (b BuiltinFunc) String() string  { return "builtin function" }
@@ -138,9 +138,9 @@ var readDecl = &parser.FuncDeclStmt{
 }
 
 func readFunc(readFn func() string) BuiltinFunc {
-	return func(_ *scope, args []Value) Value {
+	return func(_ *scope, args []Value) (Value, error) {
 		s := readFn()
-		return &String{Val: s}
+		return &String{Val: s}, nil
 	}
 }
 
@@ -151,24 +151,24 @@ var printDecl = &parser.FuncDeclStmt{
 }
 
 func printFunc(printFn func(string)) BuiltinFunc {
-	return func(_ *scope, args []Value) Value {
+	return func(_ *scope, args []Value) (Value, error) {
 		printFn(join(args, " ") + "\n")
-		return nil
+		return nil, nil
 	}
 }
 
 func printfFunc(printFn func(string)) BuiltinFunc {
-	return func(_ *scope, args []Value) Value {
+	return func(_ *scope, args []Value) (Value, error) {
 		if len(args) < 1 {
-			return newError("'printf' takes at least 1 argument")
+			return nil, fmt.Errorf("%w: 'printf' takes at least 1 argument", ErrBadArguments)
 		}
 		format, ok := args[0].(*String)
 		if !ok {
-			return newError("first argument of 'printf' must be a string")
+			return nil, fmt.Errorf("%w: first argument of 'printf' must be a string", ErrBadArguments)
 		}
 		s := sprintf(format.Val, args[1:])
 		printFn(s)
-		return nil
+		return nil, nil
 	}
 }
 
@@ -178,19 +178,19 @@ var sprintDecl = &parser.FuncDeclStmt{
 	ReturnType:    parser.STRING_TYPE,
 }
 
-func sprintFunc(_ *scope, args []Value) Value {
-	return &String{Val: join(args, " ")}
+func sprintFunc(_ *scope, args []Value) (Value, error) {
+	return &String{Val: join(args, " ")}, nil
 }
 
-func sprintfFunc(_ *scope, args []Value) Value {
+func sprintfFunc(_ *scope, args []Value) (Value, error) {
 	if len(args) < 1 {
-		return newError("'sprintf' takes at least 1 argument")
+		return nil, fmt.Errorf("%w: 'sprintf' takes at least 1 argument", ErrBadArguments)
 	}
 	format, ok := args[0].(*String)
 	if !ok {
-		return newError("first argument of 'sprintf' must be a string")
+		return nil, fmt.Errorf("%w: first argument of 'sprintf' must be a string", ErrBadArguments)
 	}
-	return &String{Val: sprintf(format.Val, args[1:])}
+	return &String{Val: sprintf(format.Val, args[1:])}, nil
 }
 
 func sprintf(s string, vals []Value) string {
@@ -210,11 +210,11 @@ var joinDecl = &parser.FuncDeclStmt{
 	ReturnType: parser.STRING_TYPE,
 }
 
-func joinFunc(_ *scope, args []Value) Value {
+func joinFunc(_ *scope, args []Value) (Value, error) {
 	arr := args[0].(*Array)
 	sep := args[1].(*String)
 	s := join(*arr.Elements, sep.Val)
-	return &String{Val: s}
+	return &String{Val: s}, nil
 }
 
 func join(args []Value, sep string) string {
@@ -239,7 +239,7 @@ var splitDecl = &parser.FuncDeclStmt{
 	ReturnType: stringArrayType,
 }
 
-func splitFunc(_ *scope, args []Value) Value {
+func splitFunc(_ *scope, args []Value) (Value, error) {
 	s := args[0].(*String)
 	sep := args[1].(*String)
 	slice := strings.Split(s.Val, sep.Val)
@@ -247,7 +247,7 @@ func splitFunc(_ *scope, args []Value) Value {
 	for i, s := range slice {
 		elements[i] = &String{Val: s}
 	}
-	return &Array{Elements: &elements}
+	return &Array{Elements: &elements}, nil
 }
 
 var upperDecl = &parser.FuncDeclStmt{
@@ -258,9 +258,9 @@ var upperDecl = &parser.FuncDeclStmt{
 	ReturnType: parser.STRING_TYPE,
 }
 
-func upperFunc(_ *scope, args []Value) Value {
+func upperFunc(_ *scope, args []Value) (Value, error) {
 	s := args[0].(*String).Val
-	return &String{Val: strings.ToUpper(s)}
+	return &String{Val: strings.ToUpper(s)}, nil
 }
 
 var lowerDecl = &parser.FuncDeclStmt{
@@ -271,9 +271,9 @@ var lowerDecl = &parser.FuncDeclStmt{
 	ReturnType: parser.STRING_TYPE,
 }
 
-func lowerFunc(_ *scope, args []Value) Value {
+func lowerFunc(_ *scope, args []Value) (Value, error) {
 	s := args[0].(*String).Val
-	return &String{Val: strings.ToLower(s)}
+	return &String{Val: strings.ToLower(s)}, nil
 }
 
 var indexDecl = &parser.FuncDeclStmt{
@@ -285,10 +285,10 @@ var indexDecl = &parser.FuncDeclStmt{
 	ReturnType: parser.NUM_TYPE,
 }
 
-func indexFunc(_ *scope, args []Value) Value {
+func indexFunc(_ *scope, args []Value) (Value, error) {
 	s := args[0].(*String).Val
 	substr := args[1].(*String).Val
-	return &Num{Val: float64(strings.Index(s, substr))}
+	return &Num{Val: float64(strings.Index(s, substr))}, nil
 }
 
 var startswithDecl = &parser.FuncDeclStmt{
@@ -300,10 +300,10 @@ var startswithDecl = &parser.FuncDeclStmt{
 	ReturnType: parser.BOOL_TYPE,
 }
 
-func startswithFunc(_ *scope, args []Value) Value {
+func startswithFunc(_ *scope, args []Value) (Value, error) {
 	s := args[0].(*String).Val
 	prefix := args[1].(*String).Val
-	return &Bool{Val: strings.HasPrefix(s, prefix)}
+	return &Bool{Val: strings.HasPrefix(s, prefix)}, nil
 }
 
 var endswithDecl = &parser.FuncDeclStmt{
@@ -315,10 +315,10 @@ var endswithDecl = &parser.FuncDeclStmt{
 	ReturnType: parser.BOOL_TYPE,
 }
 
-func endswithFunc(_ *scope, args []Value) Value {
+func endswithFunc(_ *scope, args []Value) (Value, error) {
 	s := args[0].(*String).Val
 	suffix := args[1].(*String).Val
-	return &Bool{Val: strings.HasSuffix(s, suffix)}
+	return &Bool{Val: strings.HasSuffix(s, suffix)}, nil
 }
 
 var trimDecl = &parser.FuncDeclStmt{
@@ -330,10 +330,10 @@ var trimDecl = &parser.FuncDeclStmt{
 	ReturnType: parser.STRING_TYPE,
 }
 
-func trimFunc(_ *scope, args []Value) Value {
+func trimFunc(_ *scope, args []Value) (Value, error) {
 	s := args[0].(*String).Val
 	cutset := args[1].(*String).Val
-	return &String{Val: strings.Trim(s, cutset)}
+	return &String{Val: strings.Trim(s, cutset)}, nil
 }
 
 var replaceDecl = &parser.FuncDeclStmt{
@@ -346,11 +346,11 @@ var replaceDecl = &parser.FuncDeclStmt{
 	ReturnType: parser.STRING_TYPE,
 }
 
-func replaceFunc(_ *scope, args []Value) Value {
+func replaceFunc(_ *scope, args []Value) (Value, error) {
 	s := args[0].(*String).Val
 	oldStr := args[1].(*String).Val
 	newStr := args[2].(*String).Val
-	return &String{Val: strings.ReplaceAll(s, oldStr, newStr)}
+	return &String{Val: strings.ReplaceAll(s, oldStr, newStr)}, nil
 }
 
 var str2numDecl = &parser.FuncDeclStmt{
@@ -359,14 +359,14 @@ var str2numDecl = &parser.FuncDeclStmt{
 	ReturnType: parser.NUM_TYPE,
 }
 
-func str2numFunc(scope *scope, args []Value) Value {
+func str2numFunc(scope *scope, args []Value) (Value, error) {
 	resetGlobalErr(scope)
 	s := args[0].(*String)
 	n, err := strconv.ParseFloat(s.Val, 64)
 	if err != nil {
 		setGlobalErr(scope, "str2num: cannot parse "+s.Val)
 	}
-	return &Num{Val: n}
+	return &Num{Val: n}, nil
 }
 
 var str2boolDecl = &parser.FuncDeclStmt{
@@ -375,14 +375,14 @@ var str2boolDecl = &parser.FuncDeclStmt{
 	ReturnType: parser.BOOL_TYPE,
 }
 
-func str2boolFunc(scope *scope, args []Value) Value {
+func str2boolFunc(scope *scope, args []Value) (Value, error) {
 	resetGlobalErr(scope)
 	s := args[0].(*String)
 	b, err := strconv.ParseBool(s.Val)
 	if err != nil {
 		setGlobalErr(scope, "str2bool: cannot parse "+s.Val)
 	}
-	return &Bool{Val: b}
+	return &Bool{Val: b}, nil
 }
 
 func setGlobalErr(scope *scope, msg string) {
@@ -412,16 +412,16 @@ var lenDecl = &parser.FuncDeclStmt{
 	ReturnType: parser.NUM_TYPE,
 }
 
-func lenFunc(_ *scope, args []Value) Value {
+func lenFunc(_ *scope, args []Value) (Value, error) {
 	switch arg := args[0].(type) {
 	case *Map:
-		return &Num{Val: float64(len(arg.Pairs))}
+		return &Num{Val: float64(len(arg.Pairs))}, nil
 	case *Array:
-		return &Num{Val: float64(len(*arg.Elements))}
+		return &Num{Val: float64(len(*arg.Elements))}, nil
 	case *String:
-		return &Num{Val: float64(len(arg.Val))}
+		return &Num{Val: float64(len(arg.Val))}, nil
 	}
-	return newError("'len' takes 1 argument of type 'string', array '[]' or map '{}' not " + args[0].Type().String())
+	return nil, fmt.Errorf("%w: 'len' takes 1 argument of type 'string', array '[]' or map '{}' not %s", ErrBadArguments, args[0].Type())
 }
 
 var hasDecl = &parser.FuncDeclStmt{
@@ -433,11 +433,11 @@ var hasDecl = &parser.FuncDeclStmt{
 	ReturnType: parser.BOOL_TYPE,
 }
 
-func hasFunc(_ *scope, args []Value) Value {
+func hasFunc(_ *scope, args []Value) (Value, error) {
 	m := args[0].(*Map)
 	key := args[1].(*String)
 	_, ok := m.Pairs[key.Val]
-	return &Bool{Val: ok}
+	return &Bool{Val: ok}, nil
 }
 
 var delDecl = &parser.FuncDeclStmt{
@@ -449,11 +449,11 @@ var delDecl = &parser.FuncDeclStmt{
 	ReturnType: parser.NONE_TYPE,
 }
 
-func delFunc(_ *scope, args []Value) Value {
+func delFunc(_ *scope, args []Value) (Value, error) {
 	m := args[0].(*Map)
 	keyStr := args[1].(*String)
 	m.Delete(keyStr.Val)
-	return nil
+	return nil, nil
 }
 
 var sleepDecl = &parser.FuncDeclStmt{
@@ -463,11 +463,11 @@ var sleepDecl = &parser.FuncDeclStmt{
 }
 
 func sleepFunc(sleepFn func(time.Duration)) BuiltinFunc {
-	return func(_ *scope, args []Value) Value {
+	return func(_ *scope, args []Value) (Value, error) {
 		secs := args[0].(*Num)
 		dur := time.Duration(secs.Val * float64(time.Second))
 		sleepFn(dur)
-		return nil
+		return nil, nil
 	}
 }
 
@@ -477,9 +477,9 @@ var randDecl = &parser.FuncDeclStmt{
 	ReturnType: parser.NUM_TYPE,
 }
 
-func randFunc(_ *scope, args []Value) Value {
+func randFunc(_ *scope, args []Value) (Value, error) {
 	upper := int32(args[0].(*Num).Val)
-	return &Num{Val: float64(rand.Int31n(upper))} //nolint: gosec
+	return &Num{Val: float64(rand.Int31n(upper))}, nil //nolint: gosec
 }
 
 var rand1Decl = &parser.FuncDeclStmt{
@@ -488,8 +488,8 @@ var rand1Decl = &parser.FuncDeclStmt{
 	ReturnType: parser.NUM_TYPE,
 }
 
-func rand1Func(_ *scope, args []Value) Value {
-	return &Num{Val: rand.Float64()} //nolint: gosec
+func rand1Func(_ *scope, args []Value) (Value, error) {
+	return &Num{Val: rand.Float64()}, nil //nolint: gosec
 }
 
 func xyDecl(name string) *parser.FuncDeclStmt {
@@ -509,11 +509,11 @@ func xyBuiltin(name string, fn func(x, y float64), printFn func(string)) Builtin
 		result.Func = notImplementedFunc(name, printFn)
 		return result
 	}
-	result.Func = func(_ *scope, args []Value) Value {
+	result.Func = func(_ *scope, args []Value) (Value, error) {
 		x := args[0].(*Num)
 		y := args[1].(*Num)
 		fn(x.Val, y.Val)
-		return nil
+		return nil, nil
 	}
 	return result
 }
@@ -534,10 +534,10 @@ func numBuiltin(name string, fn func(n float64), printFn func(string)) Builtin {
 		result.Func = notImplementedFunc(name, printFn)
 		return result
 	}
-	result.Func = func(_ *scope, args []Value) Value {
+	result.Func = func(_ *scope, args []Value) (Value, error) {
 		n := args[0].(*Num)
 		fn(n.Val)
-		return nil
+		return nil, nil
 	}
 	return result
 }
@@ -558,17 +558,17 @@ func stringBuiltin(name string, fn func(str string), printFn func(string)) Built
 		result.Func = notImplementedFunc(name, printFn)
 		return result
 	}
-	result.Func = func(_ *scope, args []Value) Value {
+	result.Func = func(_ *scope, args []Value) (Value, error) {
 		str := args[0].(*String)
 		fn(str.Val)
-		return nil
+		return nil, nil
 	}
 	return result
 }
 
 func notImplementedFunc(name string, printFn func(string)) BuiltinFunc {
-	return func(_ *scope, args []Value) Value {
+	return func(_ *scope, args []Value) (Value, error) {
 		printFn("'" + name + "' not yet implemented\n")
-		return nil
+		return nil, nil
 	}
 }

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -22,7 +22,7 @@ type Builtins struct {
 	Globals       map[string]*parser.Var
 }
 
-func NewParserBuiltins(builtins Builtins) parser.Builtins {
+func ParserBuiltins(builtins Builtins) parser.Builtins {
 	funcs := make(map[string]*parser.FuncDeclStmt, len(builtins.Funcs))
 	for name, builtin := range builtins.Funcs {
 		funcs[name] = builtin.Decl
@@ -32,6 +32,10 @@ func NewParserBuiltins(builtins Builtins) parser.Builtins {
 		EventHandlers: builtins.EventHandlers,
 		Globals:       builtins.Globals,
 	}
+}
+
+func DefaultParserBuiltins(rt *Runtime) parser.Builtins {
+	return ParserBuiltins(DefaultBuiltins(rt))
 }
 
 type BuiltinFunc func(scope *scope, args []Value) Value
@@ -109,7 +113,7 @@ func DefaultBuiltins(rt *Runtime) Builtins {
 
 func DefaulParserBuiltins(rt *Runtime) parser.Builtins {
 	builtins := DefaultBuiltins(rt)
-	return NewParserBuiltins(builtins)
+	return ParserBuiltins(builtins)
 }
 
 type Runtime struct {

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -4,6 +4,7 @@
 package evaluator
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -41,10 +42,14 @@ type Event struct {
 }
 
 func (e *Evaluator) Run(input string) {
-	p := parser.New(input, NewParserBuiltins(e.builtins))
-	prog := p.Parse()
-	if p.HasErrors() {
-		e.print(parser.MaxErrorsString(p.Errors(), 8))
+	builtins := ParserBuiltins(e.builtins)
+	prog, err := parser.Parse(input, builtins)
+	if err != nil {
+		var parseErrors parser.Errors
+		if errors.As(err, &parseErrors) {
+			err = parseErrors.Truncate(8)
+		}
+		e.print(err.Error())
 		return
 	}
 	val := e.Eval(prog)

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -47,7 +47,6 @@ func (e *Evaluator) Run(input string) {
 		e.print(parser.MaxErrorsString(p.Errors(), 8))
 		return
 	}
-	e.eventHandlers = p.EventHandlers
 	val := e.Eval(prog)
 	if isError(val) {
 		e.print(val.String())
@@ -159,6 +158,7 @@ func (e *Evaluator) yield() {
 }
 
 func (e *Evaluator) evalProgram(program *parser.Program) Value {
+	e.eventHandlers = program.EventHandlers
 	return e.evalStatments(program.Statements)
 }
 

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -13,11 +13,31 @@ import (
 	"foxygo.at/evy/pkg/parser"
 )
 
+var (
+	ErrStopped = errors.New("stopped")
+
+	ErrRuntime       = errors.New("runtime error")
+	ErrAnyConversion = fmt.Errorf("%w:  error converting any to type", ErrRuntime)
+	ErrRangeValue    = fmt.Errorf("%w: bad range value", ErrRuntime)
+	ErrMapKey        = fmt.Errorf("%w: no value for map key", ErrRuntime)
+	ErrSlice         = fmt.Errorf("%w: invalid slice", ErrRuntime)
+	ErrBadArguments  = fmt.Errorf("%w: bad arguments", ErrRuntime)
+
+	ErrInternal         = errors.New("internal error")
+	ErrUnknownNode      = fmt.Errorf("%w: unknown AST node", ErrInternal)
+	ErrType             = fmt.Errorf("%w: type error", ErrInternal)
+	ErrRangeType        = fmt.Errorf("%w: invalid range type", ErrInternal)
+	ErrNoVarible        = fmt.Errorf("%w: no variable", ErrInternal)
+	ErrOperation        = fmt.Errorf("%w: unknown operation", ErrInternal)
+	ErrAssignmentTarget = fmt.Errorf("%w: invalid assignment target", ErrInternal)
+)
+
 func NewEvaluator(builtins Builtins) *Evaluator {
 	rand.Seed(time.Now().UnixNano()) //nolint: staticcheck //still required in tinygo
 	scope := newScope()
 	for _, global := range builtins.Globals {
-		scope.set(global.Name, zero(global.Type()))
+		z := zero(global.Type())
+		scope.set(global.Name, z)
 	}
 	return &Evaluator{
 		print:    builtins.Print,
@@ -41,53 +61,46 @@ type Event struct {
 	Params []any
 }
 
-func (e *Evaluator) Run(input string) {
+func (e *Evaluator) Run(input string) error {
 	builtins := ParserBuiltins(e.builtins)
 	prog, err := parser.Parse(input, builtins)
 	if err != nil {
-		var parseErrors parser.Errors
-		if errors.As(err, &parseErrors) {
-			err = parseErrors.Truncate(8)
-		}
-		e.print(err.Error())
-		return
+		return err
 	}
-	val := e.Eval(prog)
-	if isError(val) {
-		e.print(val.String())
+	if _, err := e.Eval(prog); err != nil {
+		return err
 	}
+	return nil
 }
 
 type Yielder interface {
 	Yield()
 }
 
-var ErrStopped = newError("stopped")
-
-func (e *Evaluator) Eval(node parser.Node) Value {
+func (e *Evaluator) Eval(node parser.Node) (Value, error) {
 	if e.Stopped {
-		return ErrStopped
+		return nil, ErrStopped
 	}
 	e.yield()
 	switch node := node.(type) {
 	case *parser.Program:
 		return e.evalProgram(node)
 	case *parser.Decl:
-		return e.evalDecl(node)
+		return nil, e.evalDecl(node)
 	case *parser.TypedDeclStmt:
-		return e.evalDecl(node.Decl)
+		return nil, e.evalDecl(node.Decl)
 	case *parser.InferredDeclStmt:
-		return e.evalDecl(node.Decl)
+		return nil, e.evalDecl(node.Decl)
 	case *parser.AssignmentStmt:
-		return e.evalAssignment(node)
+		return nil, e.evalAssignment(node)
 	case *parser.Var:
 		return e.evalVar(node)
 	case *parser.NumLiteral:
-		return &Num{Val: node.Value}
+		return &Num{Val: node.Value}, nil
 	case *parser.StringLiteral:
-		return &String{Val: node.Value}
+		return &String{Val: node.Value}, nil
 	case *parser.Bool:
-		return e.evalBool(node)
+		return e.evalBool(node), nil
 	case *parser.ArrayLiteral:
 		return e.evalArrayLiteral(node)
 	case *parser.MapLiteral:
@@ -99,7 +112,7 @@ func (e *Evaluator) Eval(node parser.Node) Value {
 	case *parser.ReturnStmt:
 		return e.evalReturn(node)
 	case *parser.BreakStmt:
-		return e.evalBreak(node)
+		return e.evalBreak(node), nil
 	case *parser.IfStmt:
 		return e.evalIf(node)
 	case *parser.WhileStmt:
@@ -121,9 +134,9 @@ func (e *Evaluator) Eval(node parser.Node) Value {
 	case *parser.GroupExpression:
 		return e.Eval(node.Expr)
 	case *parser.FuncDeclStmt, *parser.EventHandlerStmt, *parser.EmptyStmt:
-		return nil
+		return nil, nil
 	}
-	return newError(fmt.Sprintf("internal error: unknown node type %v", node))
+	return nil, fmt.Errorf("%w: %v", ErrUnknownNode, node)
 }
 
 func (e *Evaluator) EventHandlerNames() []string {
@@ -134,7 +147,7 @@ func (e *Evaluator) EventHandlerNames() []string {
 	return names
 }
 
-func (e *Evaluator) HandleEvent(ev Event) {
+func (e *Evaluator) HandleEvent(ev Event) error {
 	eh := e.eventHandlers[ev.Name]
 	if eh == nil {
 		panic("no event handler for " + ev.Name)
@@ -146,14 +159,14 @@ func (e *Evaluator) HandleEvent(ev Event) {
 		panic("not enough arguments for " + ev.Name)
 	}
 	for i, param := range eh.Params {
-		arg := valueFromAny(param.Type(), args[i])
+		arg, err := valueFromAny(param.Type(), args[i])
+		if err != nil {
+			return err
+		}
 		e.scope.set(param.Name, arg)
 	}
-	result := e.Eval(eh.Body)
-
-	if isError(result) {
-		e.print(result.String())
-	}
+	_, err := e.Eval(eh.Body)
+	return err
 }
 
 func (e *Evaluator) yield() {
@@ -162,31 +175,34 @@ func (e *Evaluator) yield() {
 	}
 }
 
-func (e *Evaluator) evalProgram(program *parser.Program) Value {
+func (e *Evaluator) evalProgram(program *parser.Program) (Value, error) {
 	e.eventHandlers = program.EventHandlers
 	return e.evalStatments(program.Statements)
 }
 
-func (e *Evaluator) evalStatments(statements []parser.Node) Value {
+func (e *Evaluator) evalStatments(statements []parser.Node) (Value, error) {
 	var result Value
 	for _, statement := range statements {
-		result = e.Eval(statement)
+		result, err := e.Eval(statement)
+		if err != nil {
+			return nil, err
+		}
 
-		if isError(result) || isReturn(result) || isBreak(result) {
-			return result
+		if isReturn(result) || isBreak(result) { // TODO: make single: breakFlow check
+			return result, nil
 		}
 	}
-	return result
+	return result, nil
 }
 
 func (e *Evaluator) evalBool(b *parser.Bool) Value {
 	return &Bool{Val: b.Value}
 }
 
-func (e *Evaluator) evalDecl(decl *parser.Decl) Value {
-	val := e.Eval(decl.Value)
-	if isError(val) {
-		return val
+func (e *Evaluator) evalDecl(decl *parser.Decl) error {
+	val, err := e.Eval(decl.Value)
+	if err != nil {
+		return err
 	}
 	if decl.Type() == parser.ANY_TYPE && val.Type() != ANY {
 		val = &Any{Val: val}
@@ -195,45 +211,45 @@ func (e *Evaluator) evalDecl(decl *parser.Decl) Value {
 	return nil
 }
 
-func (e *Evaluator) evalAssignment(assignment *parser.AssignmentStmt) Value {
-	val := e.Eval(assignment.Value)
-	if isError(val) {
-		return val
+func (e *Evaluator) evalAssignment(assignment *parser.AssignmentStmt) error {
+	val, err := e.Eval(assignment.Value)
+	if err != nil {
+		return err
 	}
-	target := e.evalTarget(assignment.Target)
-	if isError(target) {
-		return target
+	target, err := e.evalTarget(assignment.Target)
+	if err != nil {
+		return err
 	}
 	target.Set(val)
 	return nil
 }
 
-func (e *Evaluator) evalArrayLiteral(arr *parser.ArrayLiteral) Value {
-	elements := e.evalExprList(arr.Elements)
-	if len(elements) == 1 && isError(elements[0]) {
-		return elements[0]
+func (e *Evaluator) evalArrayLiteral(arr *parser.ArrayLiteral) (Value, error) {
+	elements, err := e.evalExprList(arr.Elements)
+	if err != nil {
+		return nil, err
 	}
-	return &Array{Elements: &elements}
+	return &Array{Elements: &elements}, nil
 }
 
-func (e *Evaluator) evalMapLiteral(m *parser.MapLiteral) Value {
+func (e *Evaluator) evalMapLiteral(m *parser.MapLiteral) (Value, error) {
 	pairs := map[string]Value{}
 	for key, node := range m.Pairs {
-		val := e.Eval(node)
-		if isError(val) {
-			return val
+		val, err := e.Eval(node)
+		if err != nil {
+			return nil, err
 		}
 		pairs[key] = copyOrRef(val)
 	}
 	order := make([]string, len(m.Order))
 	copy(order, m.Order)
-	return &Map{Pairs: pairs, Order: &order}
+	return &Map{Pairs: pairs, Order: &order}, nil
 }
 
-func (e *Evaluator) evalFunccall(funcCall *parser.FuncCall) Value {
-	args := e.evalExprList(funcCall.Arguments)
-	if len(args) == 1 && isError(args[0]) {
-		return args[0]
+func (e *Evaluator) evalFunccall(funcCall *parser.FuncCall) (Value, error) {
+	args, err := e.evalExprList(funcCall.Arguments)
+	if err != nil {
+		return nil, err
 	}
 	builtin, ok := e.builtins.Funcs[funcCall.Name]
 	if ok {
@@ -252,37 +268,46 @@ func (e *Evaluator) evalFunccall(funcCall *parser.FuncCall) Value {
 		e.scope.set(fd.VariadicParam.Name, varArg)
 	}
 
-	funcResult := e.Eval(fd.Body)
-	if returnValue, ok := funcResult.(*ReturnValue); ok {
-		return returnValue.Val
+	funcResult, err := e.Eval(fd.Body)
+	if err != nil {
+		return nil, err
 	}
-	return funcResult // error or nil
+	if returnValue, ok := funcResult.(*ReturnValue); ok {
+		return returnValue.Val, nil
+	}
+	return nil, nil
 }
 
-func (e *Evaluator) evalReturn(ret *parser.ReturnStmt) Value {
+func (e *Evaluator) evalReturn(ret *parser.ReturnStmt) (Value, error) {
 	if ret.Value == nil {
-		return &ReturnValue{}
+		return &ReturnValue{}, nil
 	}
-	val := e.Eval(ret.Value)
-	if isError(val) {
-		return val
+	val, err := e.Eval(ret.Value)
+	if err != nil {
+		return nil, err
 	}
-	return &ReturnValue{Val: val}
+	return &ReturnValue{Val: val}, nil
 }
 
 func (e *Evaluator) evalBreak(ret *parser.BreakStmt) Value {
 	return &Break{}
 }
 
-func (e *Evaluator) evalIf(i *parser.IfStmt) Value {
-	val, ok := e.evalConditionalBlock(i.IfBlock)
-	if ok || isError(val) {
-		return val
+func (e *Evaluator) evalIf(i *parser.IfStmt) (Value, error) {
+	val, ok, err := e.evalConditionalBlock(i.IfBlock)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return val, nil
 	}
 	for _, elseif := range i.ElseIfBlocks {
-		val, ok := e.evalConditionalBlock(elseif)
-		if ok || isError(val) {
-			return val
+		val, ok, err := e.evalConditionalBlock(elseif)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			return val, nil
 		}
 	}
 	if i.Else != nil {
@@ -290,41 +315,44 @@ func (e *Evaluator) evalIf(i *parser.IfStmt) Value {
 		defer e.popScope()
 		return e.Eval(i.Else)
 	}
-	return nil
+	return nil, nil
 }
 
-func (e *Evaluator) evalWhile(w *parser.WhileStmt) Value {
+func (e *Evaluator) evalWhile(w *parser.WhileStmt) (Value, error) {
 	whileBlock := &w.ConditionalBlock
-	val, ok := e.evalConditionalBlock(whileBlock)
-	for ok && !isError(val) && !isReturn(val) && !isBreak(val) {
-		val, ok = e.evalConditionalBlock(whileBlock)
+	val, ok, err := e.evalConditionalBlock(whileBlock)
+	for ok && err == nil && !isReturn(val) && !isBreak(val) {
+		val, ok, err = e.evalConditionalBlock(whileBlock)
 	}
-	return val
+	return val, err
 }
 
-func (e *Evaluator) evalFor(f *parser.ForStmt) Value {
+func (e *Evaluator) evalFor(f *parser.ForStmt) (Value, error) {
 	e.pushScope()
 	defer e.popScope()
 	r, err := e.newRange(f)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	for r.next() {
-		val := e.Eval(f.Block)
-		if isError(val) || isBreak(val) || isReturn(val) {
-			return val
+		val, err := e.Eval(f.Block)
+		if err != nil {
+			return nil, err
+		}
+		if isBreak(val) || isReturn(val) {
+			return val, nil
 		}
 	}
-	return nil
+	return nil, nil
 }
 
-func (e *Evaluator) newRange(f *parser.ForStmt) (ranger, Value) {
+func (e *Evaluator) newRange(f *parser.ForStmt) (ranger, error) {
 	if r, ok := f.Range.(*parser.StepRange); ok {
 		return e.newStepRange(r, f.LoopVar)
 	}
-	rangeVal := e.Eval(f.Range)
-	if isError(rangeVal) {
-		return nil, rangeVal
+	rangeVal, err := e.Eval(f.Range)
+	if err != nil {
+		return nil, err
 	}
 
 	switch v := rangeVal.(type) {
@@ -352,24 +380,24 @@ func (e *Evaluator) newRange(f *parser.ForStmt) (ranger, Value) {
 		}
 		return mapRange, nil
 	}
-	return nil, newError("cannot create range for " + f.Range.String())
+	return nil, fmt.Errorf("%w: %s", ErrRangeType, f.Range)
 }
 
-func (e *Evaluator) newStepRange(r *parser.StepRange, loopVar *parser.Var) (ranger, Value) {
-	start, errValue := e.numValWithDefault(r.Start, 0.0)
-	if errValue != nil {
-		return nil, errValue
+func (e *Evaluator) newStepRange(r *parser.StepRange, loopVar *parser.Var) (ranger, error) {
+	start, err := e.numValWithDefault(r.Start, 0.0)
+	if err != nil {
+		return nil, err
 	}
-	stop, errValue := e.numVal(r.Stop)
-	if errValue != nil {
-		return nil, errValue
+	stop, err := e.numVal(r.Stop)
+	if err != nil {
+		return nil, err
 	}
-	step, errValue := e.numValWithDefault(r.Step, 1.0)
-	if errValue != nil {
-		return nil, errValue
+	step, err := e.numValWithDefault(r.Step, 1.0)
+	if err != nil {
+		return nil, err
 	}
 	if step == 0 {
-		return nil, newError("step cannot by 0, infinite loop")
+		return nil, fmt.Errorf("%w: step cannot by 0, infinite loop", ErrRangeValue)
 	}
 
 	sRange := &stepRange{
@@ -385,101 +413,102 @@ func (e *Evaluator) newStepRange(r *parser.StepRange, loopVar *parser.Var) (rang
 	return sRange, nil
 }
 
-func (e *Evaluator) numVal(n parser.Node) (float64, Value) {
-	v := e.Eval(n)
-	if isError(v) {
-		return 0, v
+func (e *Evaluator) numVal(n parser.Node) (float64, error) {
+	v, err := e.Eval(n)
+	if err != nil {
+		return 0, err
 	}
 	numVal, ok := v.(*Num)
 	if !ok {
-		return 0, newError("expected number, found " + v.String())
+		return 0, fmt.Errorf("%w: expected number, found %v", ErrType, v)
 	}
 	return numVal.Val, nil
 }
 
-func (e *Evaluator) numValWithDefault(n parser.Node, defaultVal float64) (float64, Value) {
+func (e *Evaluator) numValWithDefault(n parser.Node, defaultVal float64) (float64, error) {
 	if n == nil {
 		return defaultVal, nil
 	}
 	return e.numVal(n)
 }
 
-func (e *Evaluator) evalConditionalBlock(condBlock *parser.ConditionalBlock) (Value, bool) {
+func (e *Evaluator) evalConditionalBlock(condBlock *parser.ConditionalBlock) (Value, bool, error) {
 	e.pushScope()
 	defer e.popScope()
-	cond := e.Eval(condBlock.Condition)
-	if isError(cond) {
-		return cond, false
+	cond, err := e.Eval(condBlock.Condition)
+	if err != nil {
+		return nil, false, err
 	}
 	boolCond, ok := cond.(*Bool)
 	if !ok {
-		return newError("conditional not a bool"), false
+		return nil, false, fmt.Errorf("%w: conditional not a bool", ErrType)
 	}
 	if boolCond.Val {
-		return e.Eval(condBlock.Block), true
+		val, err := e.Eval(condBlock.Block)
+		return val, true, err
 	}
-	return nil, false
+	return nil, false, nil
 }
 
-func (e *Evaluator) evalBlockStatment(block *parser.BlockStatement) Value {
+func (e *Evaluator) evalBlockStatment(block *parser.BlockStatement) (Value, error) {
 	return e.evalStatments(block.Statements)
 }
 
-func (e *Evaluator) evalVar(v *parser.Var) Value {
+func (e *Evaluator) evalVar(v *parser.Var) (Value, error) {
 	if val, ok := e.scope.get(v.Name); ok {
-		return val
+		return val, nil
 	}
-	return newError("cannot find variable " + v.Name)
+	return nil, fmt.Errorf("%w: %s", ErrNoVarible, v.Name)
 }
 
-func (e *Evaluator) evalExprList(terms []parser.Node) []Value {
+func (e *Evaluator) evalExprList(terms []parser.Node) ([]Value, error) {
 	result := make([]Value, len(terms))
 
 	for i, t := range terms {
-		evaluated := e.Eval(t)
-		if isError(evaluated) {
-			return []Value{evaluated}
+		evaluated, err := e.Eval(t)
+		if err != nil {
+			return nil, err
 		}
 		result[i] = copyOrRef(evaluated)
 	}
 
-	return result
+	return result, nil
 }
 
-func (e *Evaluator) evalUnaryExpr(expr *parser.UnaryExpression) Value {
-	right := e.Eval(expr.Right)
-	if isError(right) {
-		return right
+func (e *Evaluator) evalUnaryExpr(expr *parser.UnaryExpression) (Value, error) {
+	right, err := e.Eval(expr.Right)
+	if err != nil {
+		return nil, err
 	}
 	op := expr.Op
 	switch right := right.(type) {
 	case *Num:
 		if op == parser.OP_MINUS {
-			return &Num{Val: -right.Val}
+			return &Num{Val: -right.Val}, nil
 		}
 	case *Bool:
 		if op == parser.OP_BANG {
-			return &Bool{Val: !right.Val}
+			return &Bool{Val: !right.Val}, nil
 		}
 	}
-	return newError("unknown unary operation: " + expr.String())
+	return nil, fmt.Errorf("%w (unary): %v", ErrOperation, expr)
 }
 
-func (e *Evaluator) evalBinaryExpr(expr *parser.BinaryExpression) Value {
-	left := e.Eval(expr.Left)
-	if isError(left) {
-		return left
+func (e *Evaluator) evalBinaryExpr(expr *parser.BinaryExpression) (Value, error) {
+	left, err := e.Eval(expr.Left)
+	if err != nil {
+		return nil, err
 	}
-	right := e.Eval(expr.Right)
-	if isError(right) {
-		return right
+	right, err := e.Eval(expr.Right)
+	if err != nil {
+		return nil, err
 	}
 	op := expr.Op
 	if op == parser.OP_EQ {
-		return &Bool{Val: left.Equals(right)}
+		return &Bool{Val: left.Equals(right)}, nil
 	}
 	if op == parser.OP_NOT_EQ {
-		return &Bool{Val: !left.Equals(right)}
+		return &Bool{Val: !left.Equals(right)}, nil
 	}
 	switch l := left.(type) {
 	case *Num:
@@ -491,70 +520,70 @@ func (e *Evaluator) evalBinaryExpr(expr *parser.BinaryExpression) Value {
 	case *Array:
 		return evalBinaryArrayExpr(op, l, right.(*Array))
 	}
-	return newError("unknown binary operation: " + expr.String())
+	return nil, fmt.Errorf("%w (binary): %v", ErrOperation, expr)
 }
 
-func evalBinaryNumExpr(op parser.Operator, left, right *Num) Value {
+func evalBinaryNumExpr(op parser.Operator, left, right *Num) (Value, error) {
 	switch op {
 	case parser.OP_PLUS:
-		return &Num{Val: left.Val + right.Val}
+		return &Num{Val: left.Val + right.Val}, nil
 	case parser.OP_MINUS:
-		return &Num{Val: left.Val - right.Val}
+		return &Num{Val: left.Val - right.Val}, nil
 	case parser.OP_ASTERISK:
-		return &Num{Val: left.Val * right.Val}
+		return &Num{Val: left.Val * right.Val}, nil
 	case parser.OP_PERCENT:
-		return &Num{Val: math.Mod(left.Val, right.Val)}
+		return &Num{Val: math.Mod(left.Val, right.Val)}, nil
 	case parser.OP_SLASH:
-		return &Num{Val: left.Val / right.Val}
+		return &Num{Val: left.Val / right.Val}, nil
 	case parser.OP_GT:
-		return &Bool{Val: left.Val > right.Val}
+		return &Bool{Val: left.Val > right.Val}, nil
 	case parser.OP_LT:
-		return &Bool{Val: left.Val < right.Val}
+		return &Bool{Val: left.Val < right.Val}, nil
 	case parser.OP_GTEQ:
-		return &Bool{Val: left.Val >= right.Val}
+		return &Bool{Val: left.Val >= right.Val}, nil
 	case parser.OP_LTEQ:
-		return &Bool{Val: left.Val <= right.Val}
+		return &Bool{Val: left.Val <= right.Val}, nil
 	}
-	return newError("unknown num operation: " + op.String())
+	return nil, fmt.Errorf("%w (num): %v", ErrOperation, op.String())
 }
 
-func evalBinaryStringExpr(op parser.Operator, left, right *String) Value {
+func evalBinaryStringExpr(op parser.Operator, left, right *String) (Value, error) {
 	switch op {
 	case parser.OP_PLUS:
-		return &String{Val: left.Val + right.Val}
+		return &String{Val: left.Val + right.Val}, nil
 	case parser.OP_GT:
-		return &Bool{left.Val > right.Val}
+		return &Bool{left.Val > right.Val}, nil
 	case parser.OP_LT:
-		return &Bool{left.Val < right.Val}
+		return &Bool{left.Val < right.Val}, nil
 	case parser.OP_GTEQ:
-		return &Bool{left.Val >= right.Val}
+		return &Bool{left.Val >= right.Val}, nil
 	case parser.OP_LTEQ:
-		return &Bool{left.Val <= right.Val}
+		return &Bool{left.Val <= right.Val}, nil
 	}
-	return newError("unknown string operation: " + op.String())
+	return nil, fmt.Errorf("%w (string): %v", ErrOperation, op.String())
 }
 
-func evalBinaryBoolExpr(op parser.Operator, left, right *Bool) Value {
+func evalBinaryBoolExpr(op parser.Operator, left, right *Bool) (Value, error) {
 	switch op {
 	case parser.OP_AND:
-		return &Bool{Val: left.Val && right.Val}
+		return &Bool{Val: left.Val && right.Val}, nil
 	case parser.OP_OR:
-		return &Bool{Val: left.Val || right.Val}
+		return &Bool{Val: left.Val || right.Val}, nil
 	}
-	return newError("unknown bool operation: " + op.String())
+	return nil, fmt.Errorf("%w (bool): %v", ErrOperation, op.String())
 }
 
-func evalBinaryArrayExpr(op parser.Operator, left, right *Array) Value {
+func evalBinaryArrayExpr(op parser.Operator, left, right *Array) (Value, error) {
 	if op != parser.OP_PLUS {
-		return newError("unknown array operation: " + op.String())
+		return nil, fmt.Errorf("%w (array): %v", ErrOperation, op.String())
 	}
 	result := left.Copy()
 	rightElemnts := *right.Copy().Elements
 	*result.Elements = append(*result.Elements, rightElemnts...)
-	return result
+	return result, nil
 }
 
-func (e *Evaluator) evalTarget(node parser.Node) Value {
+func (e *Evaluator) evalTarget(node parser.Node) (Value, error) {
 	switch n := node.(type) {
 	case *parser.Var:
 		return e.evalVar(n)
@@ -563,17 +592,17 @@ func (e *Evaluator) evalTarget(node parser.Node) Value {
 	case *parser.DotExpression:
 		return e.evalDotExpr(n, true /* forAssign */)
 	}
-	return newError("invalid assignment target " + node.String())
+	return nil, fmt.Errorf("%w: %v", ErrAssignmentTarget, node)
 }
 
-func (e *Evaluator) evalIndexExpr(expr *parser.IndexExpression, forAssign bool) Value {
-	left := e.Eval(expr.Left)
-	if isError(left) {
-		return left
+func (e *Evaluator) evalIndexExpr(expr *parser.IndexExpression, forAssign bool) (Value, error) {
+	left, err := e.Eval(expr.Left)
+	if err != nil {
+		return nil, err
 	}
-	index := e.Eval(expr.Index)
-	if isError(index) {
-		return index
+	index, err := e.Eval(expr.Index)
+	if err != nil {
+		return nil, err
 	}
 
 	switch l := left.(type) {
@@ -584,24 +613,24 @@ func (e *Evaluator) evalIndexExpr(expr *parser.IndexExpression, forAssign bool) 
 	case *Map:
 		strIndex, ok := index.(*String)
 		if !ok {
-			return newError("expected string for map index, found " + index.String())
+			return nil, fmt.Errorf("%w: expected string for map index, found %v", ErrType, index)
 		}
 		if forAssign {
 			l.InsertKey(strIndex.Val, expr.Type())
 		}
 		return l.Get(strIndex.Val)
 	}
-	return nil
+	return nil, fmt.Errorf("%w: expected array, string or map with index, found %v", ErrType, left.Type())
 }
 
-func (e *Evaluator) evalDotExpr(expr *parser.DotExpression, forAssign bool) Value {
-	left := e.Eval(expr.Left)
-	if isError(left) {
-		return left
+func (e *Evaluator) evalDotExpr(expr *parser.DotExpression, forAssign bool) (Value, error) {
+	left, err := e.Eval(expr.Left)
+	if err != nil {
+		return nil, err
 	}
 	m, ok := left.(*Map)
 	if !ok {
-		return newError("expected map before '.', found " + left.String())
+		return nil, fmt.Errorf("%w: expected map before '.', found  %v", ErrType, left)
 	}
 	if forAssign {
 		m.InsertKey(expr.Key, expr.Type())
@@ -609,18 +638,18 @@ func (e *Evaluator) evalDotExpr(expr *parser.DotExpression, forAssign bool) Valu
 	return m.Get(expr.Key)
 }
 
-func (e *Evaluator) evalSliceExpr(expr *parser.SliceExpression) Value {
-	left := e.Eval(expr.Left)
-	if isError(left) {
-		return left
+func (e *Evaluator) evalSliceExpr(expr *parser.SliceExpression) (Value, error) {
+	left, err := e.Eval(expr.Left)
+	if err != nil {
+		return nil, err
 	}
-	start := e.evalIfNotNil(expr.Start)
-	if isError(start) {
-		return start
+	start, err := e.evalIfNotNil(expr.Start)
+	if err != nil {
+		return nil, err
 	}
-	end := e.evalIfNotNil(expr.End)
-	if isError(end) {
-		return end
+	end, err := e.evalIfNotNil(expr.End)
+	if err != nil {
+		return nil, err
 	}
 	switch left := left.(type) {
 	case *Array:
@@ -628,12 +657,12 @@ func (e *Evaluator) evalSliceExpr(expr *parser.SliceExpression) Value {
 	case *String:
 		return left.Slice(start, end)
 	}
-	return newError("cannot slice " + left.String())
+	return nil, fmt.Errorf("%w: expected map before '.', found  %v", ErrType, left)
 }
 
-func (e *Evaluator) evalIfNotNil(n parser.Node) Value {
+func (e *Evaluator) evalIfNotNil(n parser.Node) (Value, error) {
 	if n == nil {
-		return nil
+		return nil, nil
 	}
 	return e.Eval(n)
 }

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -13,7 +13,10 @@ func run(input string) string {
 	printFn := func(s string) { b.WriteString(s) }
 	rt := &Runtime{Print: printFn}
 	eval := NewEvaluator(DefaultBuiltins(rt))
-	eval.Run(input)
+	err := eval.Run(input)
+	if err != nil {
+		return err.Error()
+	}
 	return b.String()
 }
 
@@ -104,7 +107,8 @@ while true
     end
     print "💣"
 end
-`, `
+`,
+		`
 stop := false
 while true
     if stop
@@ -381,10 +385,10 @@ func TestDoubleIndex(t *testing.T) {
 func TestIndexErr(t *testing.T) {
 	tests := map[string]string{
 		// x := ["a","b","c"]; x = "abc"
-		"print x[3]":  "ERROR: index 3 out of bounds, should be between -3 and 2",
-		"print x[-4]": "ERROR: index -4 out of bounds, should be between -3 and 2",
+		"print x[3]":  "runtime error: invalid slice: 3 out of bounds (-3 to 2)",
+		"print x[-4]": "runtime error: invalid slice: -4 out of bounds (-3 to 2)",
 		`m := {}
-		print m[x[1]]`: "ERROR: no value for key b",
+		print m[x[1]]`: `runtime error: no value for map key: "b"`,
 	}
 	for in, want := range tests {
 		in, want := in, want
@@ -446,7 +450,7 @@ func TestDotErr(t *testing.T) {
 m := {a:1}
 print m.missing_index
 `
-	want := "ERROR: no value for key missing_index"
+	want := `runtime error: no value for map key: "missing_index"`
 	got := run(in)
 	assert.Equal(t, want, got)
 }

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -13,7 +13,9 @@ type Node interface {
 }
 
 type Program struct {
-	Statements       []Node
+	Statements    []Node
+	EventHandlers map[string]*EventHandlerStmt
+
 	alwaysTerminates bool
 	formatting       *formatting
 }

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -174,7 +174,7 @@ func TestParseTopLevelExpression(t *testing.T) {
 		}`: "{a:1, b:2}",
 	}
 	for input, want := range tests {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		parser.formatting = newFormatting()
 		parser.advanceTo(0)
 		scope := newScope(nil, &Program{})
@@ -255,7 +255,7 @@ func TestParseTopLevelExpressionErr(t *testing.T) {
 		"[1()]": "line 1 column 4: unexpected ')'",
 	}
 	for input, wantErr := range tests {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		parser.advanceTo(0)
 		parser.formatting = newFormatting()
 		scope := newScope(nil, &Program{})

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -265,7 +265,7 @@ func TestParseTopLevelExpressionErr(t *testing.T) {
 
 		_ = parser.parseTopLevelExpr(scope)
 		assertParseError(t, parser, input)
-		got := MaxErrorsString(parser.Errors(), 1)
-		assert.Equal(t, wantErr, got, "input: %s\nerrors:\n%s", input, ErrorsString(parser.Errors()))
+		got := parser.errors.Truncate(1)
+		assert.Equal(t, wantErr, got.Error(), "input: %s\nerrors:\n%s", input, parser.errors)
 	}
 }

--- a/pkg/parser/format_test.go
+++ b/pkg/parser/format_test.go
@@ -587,7 +587,7 @@ x := [
 ]
 print x
 `[1:]
-	parser := New(input, testBuiltins())
+	parser := newParser(input, testBuiltins())
 	prog := parser.Parse()
 	assertNoParseError(t, parser, input)
 	got := prog.Format()
@@ -698,7 +698,7 @@ end
 
 func testFormat(t *testing.T, input string) string {
 	t.Helper()
-	parser := New(input, testBuiltins())
+	parser := newParser(input, testBuiltins())
 	prog := parser.Parse()
 	assertNoParseError(t, parser, input)
 	return prog.Format()

--- a/pkg/parser/multiline_test.go
+++ b/pkg/parser/multiline_test.go
@@ -21,7 +21,7 @@ func TestArrayLiteralMultiline(t *testing.T) {
 		2]`: {multilineEl, multilineComment("// comment 1\n"), multilineComment("  // comment 2   "), multilineEl},
 	}
 	for input, want := range tests {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		parser.formatting = newFormatting()
 		parser.advanceTo(0)
 		scope := newScope(nil, &Program{})
@@ -49,7 +49,7 @@ func TestMapLiteralMultiline(t *testing.T) {
 		b:2}`: {"a", multilineComment(" // comment 1 "), multilineComment("// comment 2"), "b"},
 	}
 	for input, want := range tests {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		parser.formatting = newFormatting()
 		parser.advanceTo(0)
 		scope := newScope(nil, &Program{})
@@ -106,7 +106,7 @@ func TestNLIndices(t *testing.T) {
 		end`: {2: true, 3: true},
 	}
 	for input, want := range tests {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		prog := parser.Parse()
 		assertNoParseError(t, parser, input)
 		got := nlAfter(prog.Statements, prog.formatting.comments)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -22,7 +22,7 @@ type Builtins struct {
 }
 
 func Parse(input string, builtins Builtins) (*Program, error) {
-	parser := New(input, builtins)
+	parser := newParser(input, builtins)
 	prog := parser.Parse()
 	if parser.errors != nil {
 		return nil, parser.errors
@@ -30,7 +30,7 @@ func Parse(input string, builtins Builtins) (*Program, error) {
 	return prog, nil
 }
 
-type Parser struct {
+type parser struct {
 	errors Errors
 
 	pos  int          // current position in token slice (points to current token)
@@ -84,9 +84,9 @@ func (e *Error) Error() string {
 	return e.token.Location() + ": " + e.message
 }
 
-func New(input string, builtins Builtins) *Parser {
+func newParser(input string, builtins Builtins) *parser {
 	l := lexer.New(input)
-	p := &Parser{
+	p := &parser{
 		funcs:         map[string]*FuncDeclStmt{},
 		eventHandlers: map[string]*EventHandlerStmt{},
 		wssStack:      []bool{false},
@@ -140,13 +140,13 @@ func New(input string, builtins Builtins) *Parser {
 	return p
 }
 
-func (p *Parser) Parse() *Program {
+func (p *parser) Parse() *Program {
 	return p.parseProgram()
 }
 
 // function names matching `parsePRODUCTION` align with production names
 // in grammar doc/syntax_grammar.md.
-func (p *Parser) parseProgram() *Program {
+func (p *parser) parseProgram() *Program {
 	program := &Program{formatting: p.formatting}
 	scope := newScope(nil, program) // TODO: model scope as stack like evaluator.
 	for _, global := range p.builtins.Globals {
@@ -181,7 +181,7 @@ func (p *Parser) parseProgram() *Program {
 	return program
 }
 
-func (p *Parser) parseFunc(scope *scope) Node {
+func (p *parser) parseFunc(scope *scope) Node {
 	p.advance()  // advance past FUNC
 	tok := p.cur // function name
 	funcName := p.cur.Literal
@@ -210,7 +210,7 @@ func (p *Parser) parseFunc(scope *scope) Node {
 	return fd
 }
 
-func (p *Parser) addParamsToScope(scope *scope, fd *FuncDeclStmt) {
+func (p *parser) addParamsToScope(scope *scope, fd *FuncDeclStmt) {
 	for _, param := range fd.Params {
 		p.validateVarDecl(scope, param, param.Token, true /* allowUnderscore */)
 		scope.set(param.Name, param)
@@ -228,7 +228,7 @@ func (p *Parser) addParamsToScope(scope *scope, fd *FuncDeclStmt) {
 	}
 }
 
-func (p *Parser) parseEventHandler(scope *scope) Node {
+func (p *parser) parseEventHandler(scope *scope) Node {
 	e := &EventHandlerStmt{Token: p.cur}
 	p.advance() // advance past ON token
 	if !p.assertToken(lexer.IDENT) {
@@ -264,7 +264,7 @@ func (p *Parser) parseEventHandler(scope *scope) Node {
 	return e
 }
 
-func (p *Parser) addEventParamsToScope(scope *scope, e *EventHandlerStmt) {
+func (p *parser) addEventParamsToScope(scope *scope, e *EventHandlerStmt) {
 	if len(e.Params) == 0 || p.builtins.EventHandlers[e.Name] == nil {
 		return
 	}
@@ -282,7 +282,7 @@ func (p *Parser) addEventParamsToScope(scope *scope, e *EventHandlerStmt) {
 	}
 }
 
-func (p *Parser) parseStatement(scope *scope) Node {
+func (p *parser) parseStatement(scope *scope) Node {
 	switch p.cur.TokenType() {
 	case lexer.WS:
 		p.advance()
@@ -323,7 +323,7 @@ func (p *Parser) parseStatement(scope *scope) Node {
 	return nil
 }
 
-func (p *Parser) parseEmptyStmt() Node {
+func (p *parser) parseEmptyStmt() Node {
 	empty := &EmptyStmt{Token: p.cur}
 	switch p.cur.Type {
 	case lexer.NL:
@@ -339,7 +339,7 @@ func (p *Parser) parseEmptyStmt() Node {
 	}
 }
 
-func (p *Parser) parseAssignmentStatement(scope *scope) Node {
+func (p *parser) parseAssignmentStatement(scope *scope) Node {
 	if p.isFuncCall(p.cur) {
 		p.appendError("cannot assign to '" + p.cur.Literal + "' as it is a function not a variable")
 		p.advancePastNL()
@@ -369,7 +369,7 @@ func (p *Parser) parseAssignmentStatement(scope *scope) Node {
 	return stmt
 }
 
-func (p *Parser) parseAssignmentTarget(scope *scope) Node {
+func (p *parser) parseAssignmentTarget(scope *scope) Node {
 	tok := p.cur
 	name := p.cur.Literal
 	p.advance()
@@ -401,7 +401,7 @@ func (p *Parser) parseAssignmentTarget(scope *scope) Node {
 	return n
 }
 
-func (p *Parser) parseFuncDeclSignature() *FuncDeclStmt {
+func (p *parser) parseFuncDeclSignature() *FuncDeclStmt {
 	fd := &FuncDeclStmt{Token: p.cur, ReturnType: NONE_TYPE}
 	p.advance() // advance past FUNC
 	if !p.assertToken(lexer.IDENT) {
@@ -437,7 +437,7 @@ func (p *Parser) parseFuncDeclSignature() *FuncDeclStmt {
 	return fd
 }
 
-func (p *Parser) parseTypedDeclStatement(scope *scope) Node {
+func (p *parser) parseTypedDeclStatement(scope *scope) Node {
 	decl := p.parseTypedDecl()
 	if decl.Type().Name != ILLEGAL && p.validateVarDecl(scope, decl.Var, decl.Token, false /* allowUnderscore */) {
 		scope.set(decl.Var.Name, decl.Var)
@@ -451,7 +451,7 @@ func (p *Parser) parseTypedDeclStatement(scope *scope) Node {
 
 // parseTypedDecl parses declarations like
 // `x:num` or `y:any[]{}`.
-func (p *Parser) parseTypedDecl() *Decl {
+func (p *parser) parseTypedDecl() *Decl {
 	p.assertToken(lexer.IDENT)
 	varName := p.cur.Literal
 	decl := &Decl{
@@ -469,7 +469,7 @@ func (p *Parser) parseTypedDecl() *Decl {
 	return decl
 }
 
-func (p *Parser) validateVarDecl(scope *scope, v *Var, tok *lexer.Token, allowUnderscore bool) bool {
+func (p *parser) validateVarDecl(scope *scope, v *Var, tok *lexer.Token, allowUnderscore bool) bool {
 	if _, ok := p.builtins.Globals[v.Name]; ok {
 		p.appendErrorForToken("redeclaration of builtin variable '"+v.Name+"'", tok)
 		return false
@@ -489,7 +489,7 @@ func (p *Parser) validateVarDecl(scope *scope, v *Var, tok *lexer.Token, allowUn
 	return true
 }
 
-func (p *Parser) parseInferredDeclStatement(scope *scope) Node {
+func (p *parser) parseInferredDeclStatement(scope *scope) Node {
 	p.assertToken(lexer.IDENT)
 	varName := p.cur.Literal
 	decl := &Decl{
@@ -522,13 +522,13 @@ func (p *Parser) parseInferredDeclStatement(scope *scope) Node {
 	return inferredDecl
 }
 
-func (p *Parser) isFuncCall(tok *lexer.Token) bool {
+func (p *parser) isFuncCall(tok *lexer.Token) bool {
 	funcName := tok.Literal
 	_, ok := p.funcs[funcName]
 	return ok
 }
 
-func (p *Parser) parseFunCallStatement(scope *scope) Node {
+func (p *parser) parseFunCallStatement(scope *scope) Node {
 	fc := p.parseFuncCall(scope).(*FuncCall)
 	p.assertEOL()
 	fcs := &FuncCallStmt{Token: fc.Token, FuncCall: fc}
@@ -538,7 +538,7 @@ func (p *Parser) parseFunCallStatement(scope *scope) Node {
 	return fcs
 }
 
-func (p *Parser) assertArgTypes(decl *FuncDeclStmt, args []Node) {
+func (p *parser) assertArgTypes(decl *FuncDeclStmt, args []Node) {
 	funcName := decl.Name
 	if decl.VariadicParam != nil {
 		paramType := decl.VariadicParam.Type()
@@ -563,7 +563,7 @@ func (p *Parser) assertArgTypes(decl *FuncDeclStmt, args []Node) {
 	}
 }
 
-func (p *Parser) advancePastNL() {
+func (p *parser) advancePastNL() {
 	tt := p.cur.TokenType()
 	for tt != lexer.NL && tt != lexer.EOF {
 		p.advance()
@@ -574,7 +574,7 @@ func (p *Parser) advancePastNL() {
 	}
 }
 
-func (p *Parser) isAtEOL() bool {
+func (p *parser) isAtEOL() bool {
 	return isEOL(p.cur.TokenType())
 }
 
@@ -582,7 +582,7 @@ func isEOL(tt lexer.TokenType) bool {
 	return tt == lexer.NL || tt == lexer.EOF || tt == lexer.COMMENT
 }
 
-func (p *Parser) assertToken(tt lexer.TokenType) bool {
+func (p *parser) assertToken(tt lexer.TokenType) bool {
 	if p.cur.TokenType() != tt {
 		p.appendError("expected " + tt.FormatDetails() + ", got " + p.cur.TokenType().FormatDetails())
 		return false
@@ -590,26 +590,26 @@ func (p *Parser) assertToken(tt lexer.TokenType) bool {
 	return true
 }
 
-func (p *Parser) assertEOL() {
+func (p *parser) assertEOL() {
 	if !p.isAtEOL() {
 		p.appendError("expected end of line, found " + p.cur.FormatDetails())
 	}
 }
 
-func (p *Parser) assertEnd() {
+func (p *parser) assertEnd() {
 	p.assertToken(lexer.END)
 }
 
-func (p *Parser) appendError(message string) {
+func (p *parser) appendError(message string) {
 	p.errors = append(p.errors, &Error{message: message, token: p.cur})
 }
 
-func (p *Parser) appendErrorForToken(message string, token *lexer.Token) {
+func (p *parser) appendErrorForToken(message string, token *lexer.Token) {
 	p.errors = append(p.errors, &Error{message: message, token: token})
 }
 
 // validateScope ensures all variables in scope have been used.
-func (p *Parser) validateScope(scope *scope) {
+func (p *parser) validateScope(scope *scope) {
 	for _, v := range scope.vars {
 		if !v.isUsed {
 			p.appendErrorForToken("'"+v.Name+"' declared but not used", v.Token)
@@ -617,17 +617,17 @@ func (p *Parser) validateScope(scope *scope) {
 	}
 }
 
-func (p *Parser) parseBlock(scope *scope) *BlockStatement {
+func (p *parser) parseBlock(scope *scope) *BlockStatement {
 	endTokens := map[lexer.TokenType]bool{lexer.END: true, lexer.EOF: true}
 	return p.parseBlockWithEndTokens(scope, endTokens)
 }
 
-func (p *Parser) parseIfBlock(scope *scope) *BlockStatement {
+func (p *parser) parseIfBlock(scope *scope) *BlockStatement {
 	endTokens := map[lexer.TokenType]bool{lexer.END: true, lexer.EOF: true, lexer.ELSE: true}
 	return p.parseBlockWithEndTokens(scope, endTokens)
 }
 
-func (p *Parser) parseBlockWithEndTokens(scope *scope, endTokens map[lexer.TokenType]bool) *BlockStatement {
+func (p *parser) parseBlockWithEndTokens(scope *scope, endTokens map[lexer.TokenType]bool) *BlockStatement {
 	block := &BlockStatement{Token: p.cur}
 	for !endTokens[p.cur.TokenType()] {
 		tok := p.cur
@@ -651,7 +651,7 @@ func (p *Parser) parseBlockWithEndTokens(scope *scope, endTokens map[lexer.Token
 	return block
 }
 
-func (p *Parser) advance() {
+func (p *parser) advance() {
 	p.advanceWSS()
 	if p.isWSS() {
 		return
@@ -662,7 +662,7 @@ func (p *Parser) advance() {
 	}
 }
 
-func (p *Parser) advanceIfWS() {
+func (p *parser) advanceIfWS() {
 	if p.cur.Type == lexer.WS {
 		p.advanceWSS()
 	}
@@ -670,7 +670,7 @@ func (p *Parser) advanceIfWS() {
 
 // parseMultilineWS parses multiline whitespace and comments as needed
 // for formatting in Array and Map literals.
-func (p *Parser) parseMulitlineWS() []multilineItem {
+func (p *parser) parseMulitlineWS() []multilineItem {
 	tt := p.cur.Type
 	var multi []multilineItem
 	for tt == lexer.NL || tt == lexer.COMMENT || tt == lexer.WS {
@@ -687,15 +687,15 @@ func (p *Parser) parseMulitlineWS() []multilineItem {
 	return multi
 }
 
-func (p *Parser) isWSS() bool {
+func (p *parser) isWSS() bool {
 	return p.wssStack[len(p.wssStack)-1]
 }
 
-func (p *Parser) pushWSS(wss bool) {
+func (p *parser) pushWSS(wss bool) {
 	p.wssStack = append(p.wssStack, wss)
 }
 
-func (p *Parser) popWSS() {
+func (p *parser) popWSS() {
 	p.wssStack = p.wssStack[:len(p.wssStack)-1]
 	if !p.isWSS() && p.cur.Type == lexer.WS {
 		p.advance()
@@ -703,13 +703,13 @@ func (p *Parser) popWSS() {
 }
 
 // advanceWSS advances to the next token in whitespace sensitive (wss) manner.
-func (p *Parser) advanceWSS() {
+func (p *parser) advanceWSS() {
 	p.pos++
 	p.cur = p.lookAt(p.pos)
 	p.peek = p.lookAt(p.pos + 1)
 }
 
-func (p *Parser) advanceTo(pos int) {
+func (p *parser) advanceTo(pos int) {
 	p.pos = pos
 	p.cur = p.lookAt(pos)
 	p.peek = p.lookAt(pos + 1)
@@ -718,14 +718,14 @@ func (p *Parser) advanceTo(pos int) {
 	}
 }
 
-func (p *Parser) lookAt(pos int) *lexer.Token {
+func (p *parser) lookAt(pos int) *lexer.Token {
 	if pos >= len(p.tokens) || pos < 0 {
 		return p.tokens[len(p.tokens)-1] // EOF with pos
 	}
 	return p.tokens[pos]
 }
 
-func (p *Parser) parseReturnStatement(scope *scope) Node {
+func (p *parser) parseReturnStatement(scope *scope) Node {
 	ret := &ReturnStmt{Token: p.cur}
 	p.advance() // advance past RETURN token
 	retValueToken := p.cur
@@ -752,7 +752,7 @@ func (p *Parser) parseReturnStatement(scope *scope) Node {
 	return ret
 }
 
-func (p *Parser) parseBreakStatement(scope *scope) Node {
+func (p *parser) parseBreakStatement(scope *scope) Node {
 	breakStmt := &BreakStmt{Token: p.cur}
 	if !inLoop(scope) {
 		p.appendError("break is not in a loop")
@@ -764,7 +764,7 @@ func (p *Parser) parseBreakStatement(scope *scope) Node {
 	return breakStmt
 }
 
-func (p *Parser) parseForStatement(scope *scope) Node {
+func (p *parser) parseForStatement(scope *scope) Node {
 	forNode := &ForStmt{Token: p.cur}
 	scope = newScope(scope, forNode)
 	p.advance() // advance past FOR token
@@ -827,7 +827,7 @@ func (p *Parser) parseForStatement(scope *scope) Node {
 	return forNode
 }
 
-func (p *Parser) parseStepRange(nodes []Node, tok *lexer.Token) *StepRange {
+func (p *parser) parseStepRange(nodes []Node, tok *lexer.Token) *StepRange {
 	if len(nodes) > 3 {
 		p.appendErrorForToken("range can take up to 3 num arguments, found "+strconv.Itoa(len(nodes)), tok)
 		return nil
@@ -854,7 +854,7 @@ func (p *Parser) parseStepRange(nodes []Node, tok *lexer.Token) *StepRange {
 	}
 }
 
-func (p *Parser) parseWhileStatement(scope *scope) Node {
+func (p *parser) parseWhileStatement(scope *scope) Node {
 	while := &WhileStmt{}
 	while.Token = p.cur
 	p.advance() // advance past WHILE token
@@ -881,7 +881,7 @@ func inLoop(s *scope) bool {
 	return false
 }
 
-func (p *Parser) parseIfStatement(scope *scope) Node {
+func (p *parser) parseIfStatement(scope *scope) Node {
 	ifStmt := &IfStmt{Token: p.cur}
 	ifStmt.IfBlock = p.parseIfConditionalBlock(newScope(scope, ifStmt))
 	// else if blocks
@@ -907,7 +907,7 @@ func (p *Parser) parseIfStatement(scope *scope) Node {
 	return ifStmt
 }
 
-func (p *Parser) parseIfConditionalBlock(scope *scope) *ConditionalBlock {
+func (p *parser) parseIfConditionalBlock(scope *scope) *ConditionalBlock {
 	ifBlock := &ConditionalBlock{Token: p.cur}
 	p.advance() // advance past IF token
 	ifBlock.Condition = p.parseCondition(scope)
@@ -917,7 +917,7 @@ func (p *Parser) parseIfConditionalBlock(scope *scope) *ConditionalBlock {
 	return ifBlock
 }
 
-func (p *Parser) parseCondition(scope *scope) Node {
+func (p *parser) parseCondition(scope *scope) Node {
 	tok := p.cur
 	condition := p.parseTopLevelExpr(scope)
 	if condition != nil {
@@ -931,7 +931,7 @@ func (p *Parser) parseCondition(scope *scope) Node {
 
 // parseType parses `[]{}num` into
 // `{Name: ARRAY, Sub: {Name: MAP Sub: NUM_TYPE}}`.
-func (p *Parser) parseType() *Type {
+func (p *parser) parseType() *Type {
 	tt := p.cur.TokenType()
 	p.advance()
 	switch tt {
@@ -955,19 +955,19 @@ func (p *Parser) parseType() *Type {
 	return ILLEGAL_TYPE
 }
 
-func (p *Parser) recordComment(n Node) {
+func (p *parser) recordComment(n Node) {
 	if p.cur.Type == lexer.COMMENT {
 		p.formatting.recordComment(n, p.cur.Literal)
 	}
 }
 
-func (p *Parser) recordCommentString(n Node, str string) {
+func (p *parser) recordCommentString(n Node, str string) {
 	if str != "" {
 		p.formatting.recordComment(n, str)
 	}
 }
 
-func (p *Parser) curComment() string {
+func (p *parser) curComment() string {
 	if p.cur.Type == lexer.COMMENT {
 		return p.cur.Literal
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -39,7 +39,7 @@ type Parser struct {
 	tokens        []*lexer.Token
 	builtins      Builtins
 	funcs         map[string]*FuncDeclStmt     // all function declarations by name
-	EventHandlers map[string]*EventHandlerStmt // all event handler declarations by name
+	eventHandlers map[string]*EventHandlerStmt // all event handler declarations by name
 
 	wssStack   []bool
 	formatting *formatting
@@ -59,7 +59,7 @@ func New(input string, builtins Builtins) *Parser {
 	l := lexer.New(input)
 	p := &Parser{
 		funcs:         map[string]*FuncDeclStmt{},
-		EventHandlers: map[string]*EventHandlerStmt{},
+		eventHandlers: map[string]*EventHandlerStmt{},
 		wssStack:      []bool{false},
 		builtins:      builtins,
 		formatting:    newFormatting(),
@@ -156,6 +156,7 @@ func (p *Parser) parseProgram() *Program {
 		}
 	}
 	p.validateScope(scope)
+	program.EventHandlers = p.eventHandlers
 	return program
 }
 
@@ -216,12 +217,12 @@ func (p *Parser) parseEventHandler(scope *scope) Node {
 
 	e.Name = p.cur.Literal
 	switch {
-	case p.EventHandlers[e.Name] != nil:
+	case p.eventHandlers[e.Name] != nil:
 		p.appendError("redeclaration of on " + e.Name)
 	case p.builtins.EventHandlers[e.Name] == nil:
 		p.appendError("unknown event name " + e.Name)
 	default:
-		p.EventHandlers[e.Name] = e
+		p.eventHandlers[e.Name] = e
 	}
 	p.advance() // advance past event name IDENT
 	for !p.isAtEOL() {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -90,8 +90,8 @@ print m[s]`: "line 3 column 6: unknown variable name 'name'",
 		parser := New(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
-		got := MaxErrorsString(parser.Errors(), 1)
-		assert.Equal(t, err1, got, "input: %s\nerrors:\n%s", input, ErrorsString(parser.Errors()))
+		got := parser.errors.Truncate(1)
+		assert.Equal(t, err1, got.Error(), "input: %s\nerrors:\n%s", input, parser.errors)
 	}
 }
 
@@ -145,8 +145,8 @@ func TestFunccallError(t *testing.T) {
 		parser := New(input, builtins)
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
-		got := MaxErrorsString(parser.Errors(), 1)
-		assert.Equal(t, err1, got, "input: %s\nerrors:\n%s", input, ErrorsString(parser.Errors()))
+		got := parser.errors.Truncate(1)
+		assert.Equal(t, err1, got.Error(), "input: %s\nerrors:\n%s", input, parser.errors)
 	}
 }
 
@@ -346,8 +346,8 @@ end
 		parser := New(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
-		gotErr := MaxErrorsString(parser.Errors(), 1)
-		assert.Equal(t, wantErr, gotErr)
+		gotErr := parser.errors.Truncate(1)
+		assert.Equal(t, wantErr, gotErr.Error())
 	}
 }
 
@@ -423,8 +423,8 @@ fn = 3
 		parser := New(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
-		gotErr := MaxErrorsString(parser.Errors(), 1)
-		assert.Equal(t, wantErr, gotErr)
+		gotErr := parser.errors.Truncate(1)
+		assert.Equal(t, wantErr, gotErr.Error())
 	}
 }
 
@@ -570,8 +570,8 @@ end
 		parser := New(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
-		gotErr := MaxErrorsString(parser.Errors(), 1)
-		assert.Equal(t, wantErr, gotErr, input)
+		gotErr := parser.errors.Truncate(1)
+		assert.Equal(t, wantErr, gotErr.Error(), input)
 	}
 }
 
@@ -643,8 +643,8 @@ end
 		parser := New(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
-		gotErr := MaxErrorsString(parser.Errors(), 1)
-		assert.Equal(t, wantErr, gotErr)
+		gotErr := parser.errors.Truncate(1)
+		assert.Equal(t, wantErr, gotErr.Error())
 	}
 }
 
@@ -738,8 +738,8 @@ end`: "line 7 column 4: expected 'end', got end of input",
 		parser := New(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
-		gotErr := MaxErrorsString(parser.Errors(), 1)
-		assert.Equal(t, wantErr, gotErr, "input: %s", input)
+		gotErr := parser.errors.Truncate(1)
+		assert.Equal(t, wantErr, gotErr.Error(), "input: %s", input)
 	}
 }
 
@@ -795,8 +795,8 @@ end`: "line 2 column 6: unexpected end of line",
 		parser := New(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
-		gotErr := MaxErrorsString(parser.Errors(), 1)
-		assert.Equal(t, wantErr, gotErr, "input: %s", input)
+		gotErr := parser.errors.Truncate(1)
+		assert.Equal(t, wantErr, gotErr.Error(), "input: %s", input)
 	}
 }
 
@@ -905,8 +905,8 @@ end
 		parser := New(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
-		gotErr := MaxErrorsString(parser.Errors(), 1)
-		assert.Equal(t, wantErr, gotErr, "input: %s", input)
+		gotErr := parser.errors.Truncate(1)
+		assert.Equal(t, wantErr, gotErr.Error(), "input: %s", input)
 	}
 }
 
@@ -1000,8 +1000,8 @@ end
 		parser := New(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
-		gotErr := MaxErrorsString(parser.Errors(), 1)
-		assert.Equal(t, wantErr, gotErr, "input: %s", input)
+		gotErr := parser.errors.Truncate(1)
+		assert.Equal(t, wantErr, gotErr.Error(), "input: %s", input)
 	}
 }
 
@@ -1086,8 +1086,8 @@ end
 		parser := New(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
-		gotErr := MaxErrorsString(parser.Errors(), 1)
-		assert.Equal(t, wantErr, gotErr, "input: %s", input)
+		gotErr := parser.errors.Truncate(1)
+		assert.Equal(t, wantErr, gotErr.Error(), "input: %s", input)
 	}
 }
 
@@ -1150,8 +1150,8 @@ end`: "line 3 column 4: wrong number of parameters expected 2, got 1",
 		parser := New(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
-		gotErr := MaxErrorsString(parser.Errors(), 1)
-		assert.Equal(t, wantErr, gotErr, "input: %s", input)
+		gotErr := parser.errors.Truncate(1)
+		assert.Equal(t, wantErr, gotErr.Error(), "input: %s", input)
 	}
 }
 
@@ -1173,8 +1173,8 @@ end
 		parser := New(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
-		gotErr := MaxErrorsString(parser.Errors(), 1)
-		assert.Equal(t, wantErr, gotErr)
+		gotErr := parser.errors.Truncate(1)
+		assert.Equal(t, wantErr, gotErr.Error())
 	}
 }
 
@@ -1191,9 +1191,9 @@ end`
 	parser := New(input, testBuiltins())
 	got := parser.Parse()
 	assertParseError(t, parser, input)
-	gotErr := MaxErrorsString(parser.Errors(), 1)
-	assert.Equal(t, "line 2 column 1: unknown function 'move'", gotErr)
-	assert.Equal(t, "line 3 column 1: unknown function 'line'", parser.errors[1].String())
+	gotErr := parser.errors.Truncate(1)
+	assert.Equal(t, "line 2 column 1: unknown function 'move'", gotErr.Error())
+	assert.Equal(t, "line 3 column 1: unknown function 'line'", parser.errors[1].Error())
 	want := `
 
 x=12
@@ -1212,7 +1212,7 @@ func assertParseError(t *testing.T, parser *Parser, input string) {
 
 func assertNoParseError(t *testing.T, parser *Parser, input string) {
 	t.Helper()
-	assert.Equal(t, 0, len(parser.errors), "Unexpected parser error\n input: %s\nerrors:\n%s", input, ErrorsString(parser.Errors()))
+	assert.Equal(t, 0, len(parser.errors), "Unexpected parser error\n input: %s\nerrors:\n%s", input, parser.errors)
 }
 
 func testBuiltins() Builtins {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -35,7 +35,7 @@ func TestParseDecl(t *testing.T) {
 		input += "\n print a"
 		wantSlice = append(wantSlice, "print(a)")
 		want := strings.Join(wantSlice, "\n") + "\n"
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		got := parser.Parse()
 		assertNoParseError(t, parser, input)
 		assert.Equal(t, want, got.String())
@@ -55,7 +55,7 @@ func TestEmptyProgram(t *testing.T) {
 		" \n //blabla":    "\n\n",
 	}
 	for input, want := range tests {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		got := parser.Parse()
 		assertNoParseError(t, parser, input)
 		assert.Equal(t, want, got.String(), input)
@@ -87,7 +87,7 @@ s := name
 print m[s]`: "line 3 column 6: unknown variable name 'name'",
 	}
 	for input, err1 := range tests {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
 		got := parser.errors.Truncate(1)
@@ -111,7 +111,7 @@ func TestFunccall(t *testing.T) {
 	}
 	for input, wantSlice := range tests {
 		want := strings.Join(wantSlice, "\n") + "\n"
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		got := parser.Parse()
 		assertNoParseError(t, parser, input)
 		assert.Equal(t, want, got.String())
@@ -142,7 +142,7 @@ func TestFunccallError(t *testing.T) {
 		`foo 0`:      "line 1 column 1: unknown function 'foo'",
 	}
 	for input, err1 := range tests {
-		parser := New(input, builtins)
+		parser := newParser(input, builtins)
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
 		got := parser.errors.Truncate(1)
@@ -174,7 +174,7 @@ print('TRUE')
 `,
 	}
 	for input, want := range tests {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		got := parser.Parse()
 		assertNoParseError(t, parser, input)
 		assert.Equal(t, want, got.String())
@@ -186,7 +186,7 @@ func TestToplevelExprFuncCall(t *testing.T) {
 x := len "123"
 print x
 `
-	parser := New(input, testBuiltins())
+	parser := newParser(input, testBuiltins())
 	got := parser.Parse()
 	assertNoParseError(t, parser, input)
 	want := `
@@ -236,7 +236,7 @@ func nums5 _:num
 	print "nums5 not yet implemented"
 end
 `
-	parser := New(input, testBuiltins())
+	parser := newParser(input, testBuiltins())
 	_ = parser.Parse()
 	assertNoParseError(t, parser, input)
 	builtinCnt := len(testBuiltins().Funcs)
@@ -269,7 +269,7 @@ end
 fox 1 2 3`,
 	}
 	for _, input := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertNoParseError(t, parser, input)
 	}
@@ -343,7 +343,7 @@ end
 `: "line 6 column 1: missing return",
 	}
 	for input, wantErr := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
@@ -383,7 +383,7 @@ print a
 `,
 	}
 	for _, input := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertNoParseError(t, parser, input)
 	}
@@ -420,7 +420,7 @@ fn = 3
 `: "line 5 column 1: cannot assign to 'fn' as it is a function not a variable",
 	}
 	for input, wantErr := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
@@ -471,7 +471,7 @@ print a
 `,
 	}
 	for _, input := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertNoParseError(t, parser, input)
 	}
@@ -567,7 +567,7 @@ end
 `: "line 2 column 1: 'x' declared but not used",
 	}
 	for input, wantErr := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
@@ -640,7 +640,7 @@ end
 `: "line 2 column 8: invalid declaration of 'x', already used as function name",
 	}
 	for input, wantErr := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
@@ -687,7 +687,7 @@ func TestIf(t *testing.T) {
 		 end`,
 	}
 	for _, input := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertNoParseError(t, parser, input)
 	}
@@ -735,7 +735,7 @@ else
 end`: "line 7 column 4: expected 'end', got end of input",
 	}
 	for input, wantErr := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
@@ -771,7 +771,7 @@ end
 `,
 	}
 	for _, input := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertNoParseError(t, parser, input)
 	}
@@ -792,7 +792,7 @@ while
 end`: "line 2 column 6: unexpected end of line",
 	}
 	for input, wantErr := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
@@ -825,7 +825,7 @@ func foo
 end`,
 	}
 	for _, input := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertNoParseError(t, parser, input)
 	}
@@ -902,7 +902,7 @@ end
 `: "line 9 column 3: unreachable code",
 	}
 	for input, wantErr := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
@@ -943,7 +943,7 @@ for i:= range []
 end`,
 	}
 	for _, input := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertNoParseError(t, parser, input)
 	}
@@ -997,7 +997,7 @@ end
 `: "line 2 column 5: declaration of anonymous variable '_' not allowed here",
 	}
 	for input, wantErr := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
@@ -1033,7 +1033,7 @@ end
 nums []`,
 	}
 	for _, input := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertNoParseError(t, parser, input)
 
@@ -1052,7 +1052,7 @@ for k := range m
 end`,
 	}
 	for _, input := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertNoParseError(t, parser, input)
 
@@ -1083,7 +1083,7 @@ end
 `: "line 3 column 16: anonymous variable '_' cannot be read",
 	}
 	for input, wantErr := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
@@ -1114,7 +1114,7 @@ on down x:num y:num
 end`,
 	}
 	for _, input := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertNoParseError(t, parser, input)
 	}
@@ -1147,7 +1147,7 @@ on down x:num
 end`: "line 3 column 4: wrong number of parameters expected 2, got 1",
 	}
 	for input, wantErr := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
@@ -1170,7 +1170,7 @@ end
 `: "line 2 column 1: cannot override builtin variable 'errmsg'",
 	}
 	for input, wantErr := range inputs {
-		parser := New(input, testBuiltins())
+		parser := newParser(input, testBuiltins())
 		_ = parser.Parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
@@ -1188,7 +1188,7 @@ print "x:" x
 if x > 10
     print "🍦 big x"
 end`
-	parser := New(input, testBuiltins())
+	parser := newParser(input, testBuiltins())
 	got := parser.Parse()
 	assertParseError(t, parser, input)
 	gotErr := parser.errors.Truncate(1)
@@ -1205,12 +1205,12 @@ print('🍦 big x')
 	assert.Equal(t, want, got.String())
 }
 
-func assertParseError(t *testing.T, parser *Parser, input string) {
+func assertParseError(t *testing.T, parser *parser, input string) {
 	t.Helper()
 	assert.Equal(t, true, len(parser.errors) > 0, "expected parser errors, got none: input: %s\n", input)
 }
 
-func assertNoParseError(t *testing.T, parser *Parser, input string) {
+func assertNoParseError(t *testing.T, parser *parser, input string) {
 	t.Helper()
 	assert.Equal(t, 0, len(parser.errors), "Unexpected parser error\n input: %s\nerrors:\n%s", input, parser.errors)
 }

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"errors"
 	"strings"
 	"time"
 	"unsafe"
@@ -33,13 +32,13 @@ func main() {
 	evaluate(source, builtins, yielder)
 }
 
-func format(builtins evaluator.Builtins) (string, error) {
+func format(evalBuiltins evaluator.Builtins) (string, error) {
 	input := getEvySource()
 
-	p := parser.New(input, evaluator.NewParserBuiltins(builtins))
-	prog := p.Parse()
-	if p.HasErrors() {
-		return "", errors.New(parser.MaxErrorsString(p.Errors(), 8))
+	builtins := evaluator.ParserBuiltins(evalBuiltins)
+	prog, err := parser.Parse(input, builtins)
+	if err != nil {
+		return "", parser.TruncateError(err, 8)
 	}
 	formattedInput := prog.Format()
 	if formattedInput != input {


### PR DESCRIPTION
Clean up error handling, using real go errors rather than overloading
the evaluator.Value interface of storing errors as part of the parse
state. Make parser private and attach all state to AST node program.

Reorder main.go for readability.

This is a pure refactor PR without any functional additions.