### PR TITLE
parser: Fix formatting bug

### DIFF
--- a/pkg/parser/format.go
+++ b/pkg/parser/format.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -101,7 +102,8 @@ func (f *formatting) format(n Node) {
 	case *FuncCall:
 		f.formatFuncCall(n)
 	case *UnaryExpression:
-		f.writes(n.Op.String(), n.Right.String())
+		f.write(n.Op.String())
+		f.format(n.Right)
 	case *BinaryExpression:
 		f.format(n.Left)
 		f.writeWSS(n)
@@ -132,7 +134,7 @@ func (f *formatting) format(n Node) {
 	case *NumLiteral:
 		f.write(n.String())
 	case *StringLiteral:
-		f.writes(`"`, n.Value, `"`)
+		f.write(strconv.Quote(n.Value))
 	case *ArrayLiteral:
 		f.formatArrayLiteral(n)
 	case *MapLiteral:

--- a/pkg/parser/format_test.go
+++ b/pkg/parser/format_test.go
@@ -594,6 +594,37 @@ print x
 	assert.Equal(t, want, got)
 }
 
+func TestNLStringLit(t *testing.T) {
+	input := `
+x := "a\nb"
+print x
+`[1:]
+	want := input
+	parser := newParser(input, testBuiltins())
+	prog := parser.Parse()
+	assertNoParseError(t, parser, input)
+	got := prog.Format()
+	assert.Equal(t, want, got)
+}
+
+func TestUnaryOP(t *testing.T) {
+	input := `
+func check:bool
+    return false
+end
+
+while !(check)
+    print "x"
+end
+`[1:]
+	want := input
+	parser := newParser(input, testBuiltins())
+	prog := parser.Parse()
+	assertNoParseError(t, parser, input)
+	got := prog.Format()
+	assert.Equal(t, want, got)
+}
+
 func TestNLInsertion(t *testing.T) {
 	tests := map[string]string{
 		`func f1


### PR DESCRIPTION
Fix two formatting bugs that rendered evy program un-executable but
required only minor source updates:

- escape `\n` in stringliterals with strconv.Quote.
  Previously a literal newline was printed inside the string.
- ensure unary operators get formatted properly.
  Previously `while !(check)` formatted to `while !check()`

Add test for the fixes and ensure tests failed previous to fix.