### PR TITLE
frontend: Fix comment

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -143,7 +143,7 @@ async function handleRun() {
   stopped ? start() : stop()
 }
 
-// handleMob handles three states for mobile devices:
+// handleMobRun handles three states for mobile devices:
 // run -> stop -> code
 async function handleMobRun() {
   if (onCodeScreen()) {


### PR DESCRIPTION
Fix comment for typo in `handleMobRun()`. This is a fixup for an
overlooked review remark.

Link: https://github.com/foxygoat/evy/pull/102#discussion_r1136467397