### PR TITLE
frontend: Remove focus on stop

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -201,6 +201,9 @@ function afterStop() {
   runButton.innerText = "Run"
   runButtonMob.classList.remove("running")
   runButtonMob.innerText = onCodeScreen() ? "Run" : "Code"
+
+  const readEl = document.querySelector("#read")
+  document.activeElement === readEl && readEl.blur()
 }
 
 function onCodeScreen() {


### PR DESCRIPTION
Remove focus from `read` input when program is stopped as a UX helper
that the program isn't running any longer.