### PR TITLE
lexer: Fix string tokens for double backslash

### DIFF
--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -191,10 +191,16 @@ func (l *Lexer) readIdent() string {
 
 func (l *Lexer) readString() (string, error) {
 	pos := l.pos
+	backslashCnt := 0
 	for {
 		l.advance()
+		if l.cur == '\\' {
+			backslashCnt++
+		} else {
+			backslashCnt = 0
+		}
 		pr := l.peekRune()
-		if pr == '"' && l.cur != '\\' {
+		if pr == '"' && backslashCnt%2 == 0 {
 			l.advance() // end of string
 			break
 		}

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -332,3 +332,24 @@ func TestRunWS(t *testing.T) {
 		})
 	}
 }
+
+func TestString(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{in: `"abc" `, want: "STRING_LIT 'abc'"},
+		{in: `"abc\"" `, want: `STRING_LIT 'abc"'`},
+		{in: `"abc\\" `, want: `STRING_LIT 'abc\'`},
+		{in: `"abc\\\"" `, want: `STRING_LIT 'abc\"'`},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.in, func(t *testing.T) {
+			got := Run(tt.in)
+			want := tt.want + "\nWS\nEOF\n"
+			assert.Equal(t, want, got)
+		})
+	}
+}


### PR DESCRIPTION
Fix string tokens for 2n backslashes before the closing `"` quotation
mark.