### PR TITLE
frontend: Add syntax colouring

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,1 @@
 frontend/wasm_exec.js
-frontend/module/yace-editor.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 frontend/wasm_exec.js
+frontend/module/yace-editor.js

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -15,6 +15,14 @@
   --output-border-mid: hsl(0deg 0% 85%);
   --output-border-light: hsl(0deg 0% 92%);
 
+  --syntax-num: hsl(204deg 100% 75%);
+  --syntax-string: hsl(203deg 100% 86%);
+  --syntax-func: hsl(266deg 100% 86%);
+  --syntax-builtin: hsl(27deg 100% 74%);
+  --syntax-keyword: hsl(359deg 100% 75%);
+  --syntax-comment: hsl(210deg, 13%, 72%);
+  --syntax-error-bg: hsl(209deg 100% 33%);
+
   --btn-color: hsl(0deg 0% 33%);
   --btn-color-active: hsl(0deg 0% 100%);
   --btn-color-disabled: hsl(0deg 0% 33% / 50%);
@@ -222,30 +230,110 @@ main.view-output {
 }
 
 /* --- Editor --------------------------------------------------------*/
-.editor {
-  padding-top: var(--editor-padding);
-  font-size: 1rem;
-  flex: 1;
-  overflow: clip;
-  width: var(--editor-width);
-}
-.editor textarea {
+.editor-wrap {
+  margin-top: var(--editor-padding);
   padding-left: var(--editor-padding);
   padding-right: var(--editor-padding);
+  padding-bottom: var(--editor-padding-bottom);
+  font-size: 1rem;
+  flex: 1;
+  overflow: auto;
+  width: var(--editor-width);
+}
+.editor {
   color: var(--color);
   background: var(--bg);
   font-size: 1rem;
   font-family: var(--ff-code);
   font-variant-ligatures: none;
-  overflow: auto;
-
-  resize: none;
-  outline: none;
-  -webkit-text-fill-color: var(--ccolor);
-  height: 100%;
+  position: relative;
+  overflow: hidden;
+  width: max-content;
+}
+.editor textarea {
+  line-height: inherit;
+  white-space: pre-wrap;
+  background: none;
+  position: absolute;
   width: 100%;
+  height: 100%;
+  z-index: 1;
+  resize: none;
+  caret-color: var(--color);
+  padding: inherit;
+  outline: none;
+  font-size: inherit;
+  font-family: inherit;
+  font-variant-ligatures: inherit;
+  letter-spacing: inherit;
   border: none;
-  padding-bottom: var(--editor-padding-bottom);
+  top: 0px;
+  left: 0px;
+  color: transparent;
+  overflow: hidden;
+}
+.editor pre {
+  line-height: inherit;
+  position: relative;
+  white-space: pre-wrap;
+  word-break: keep-all;
+  padding: 0;
+  width: max-content;
+  margin: 0;
+  font-size: inherit;
+  font-family: inherit;
+  font-variant-ligatures: inherit;
+  letter-spacing: inherit;
+  pointer-events: none;
+  font-family: inherit;
+  overflow: hidden;
+}
+.editor pre.lines {
+  position: absolute;
+  height: 100%;
+  top: 0px;
+  left: 0px;
+  pointer-events: none;
+  overflow: auto;
+}
+.editor pre.lines .num {
+  position: aboslute;
+  color: hsl(212deg 8% 47%);
+  left: 0;
+}
+.editor pre.lines .txt {
+  padding-left: 1ch;
+  color: transparent;
+  pointer-events: none;
+}
+.editor .num,
+.editor .bool {
+  color: var(--syntax-num);
+}
+.editor .str {
+  color: var(--syntax-string);
+}
+.editor .func {
+  color: var(--syntax-func);
+}
+.editor .builtin {
+  color: var(--syntax-builtin);
+}
+.editor .keyword {
+  color: var(--syntax-keyword);
+}
+.editor .error {
+  background: var(--syntax-error-bg);
+  color: var(--color);
+  font-style: italic;
+}
+.editor .op {
+  color: var(--syntax-keyword);
+}
+.editor .comment {
+  color: var(--syntax-comment);
+  font-style: italic;
+  font-weight: 300;
 }
 
 /* --- Output --------------------------------------------------------*/

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,14 +13,14 @@
       href="https://fonts.googleapis.com/css2?family=Fira+Code&family=Inter:wght@400;700&display=swap"
     />
     <script src="wasm_exec.js" defer></script>
-    <script src="index.js" defer></script>
+    <script src="index.js" type="module" defer></script>
   </head>
   <body>
     <div class="max-width-wrapper">
       <header>
         <ul class="breadcrumbs">
-          <li><button onclick="showModal()">Getting Started</button></li>
-          <li><button onclick="showModal()">Welcome</button></li>
+          <li><button>Tour</button></li>
+          <li><button>Welcome</button></li>
         </ul>
         <a href="/" class="logo">
           <img src="img/logo.svg" alt="Evy logo" class="desktop" />
@@ -32,21 +32,8 @@
         </div>
       </header>
       <main>
-        <div class="editor">
-          <textarea id="code" spellcheck="false" autocorrect="off" autocapitalize="none" wrap="off">
-move 10 20
-line 50 50
-rect 25 25
-color "red"
-circle 10
-
-x := 12
-print "x:" x
-if x > 10
-    print "🍦 big x"
-end
-</textarea
-          >
+        <div class="editor-wrap">
+          <div class="editor"></div>
         </div>
         <div class="output">
           <div class="canvas">

--- a/frontend/module/yace-editor.js
+++ b/frontend/module/yace-editor.js
@@ -1,0 +1,457 @@
+//prettier-ignore
+// https://github.com/petersolopov/yace - MIT licensed
+// source: https://github.com/petersolopov/yace/blob/8ed1f99977c4db9bdd60db4e2f5ba4edfcfc1940/src/index.js
+import {
+  textareaStyles,
+  preStyles,
+  rootStyles,
+  linesStyles,
+} from "./styles.js";
+
+class Yace {
+  constructor(selector, options = {}) {
+    if (!selector) {
+      throw new Error("selector is not defined");
+    }
+
+    this.root =
+      selector instanceof Node ? selector : document.querySelector(selector);
+
+    if (!this.root) {
+      throw new Error(`element with "${selector}" selector is not exist`);
+    }
+
+    const defaultOptions = {
+      value: "",
+      styles: {},
+      plugins: [],
+      highlighter: (value) => escape(value),
+    };
+
+    this.options = {
+      ...defaultOptions,
+      ...options,
+    };
+
+    this.init();
+  }
+
+  init() {
+    this.textarea = document.createElement("textarea");
+    this.pre = document.createElement("pre");
+
+    Object.assign(this.root.style, rootStyles, this.options.styles);
+    Object.assign(this.textarea.style, textareaStyles);
+    Object.assign(this.pre.style, preStyles);
+
+    this.root.appendChild(this.textarea);
+    this.root.appendChild(this.pre);
+
+    this.addTextareaEvents();
+    this.update({ value: this.options.value });
+    this.updateLines();
+  }
+
+  addTextareaEvents() {
+    this.handleInput = (event) => {
+      const textareaProps = runPlugins(this.options.plugins, event);
+      this.update(textareaProps);
+    };
+
+    this.handleKeydown = (event) => {
+      const textareaProps = runPlugins(this.options.plugins, event);
+      this.update(textareaProps);
+    };
+
+    this.textarea.addEventListener("input", this.handleInput);
+    this.textarea.addEventListener("keydown", this.handleKeydown);
+  }
+
+  update(textareaProps) {
+    const { value, selectionStart, selectionEnd } = textareaProps;
+    // should be before updating selection otherwise selection will be lost
+    if (value != null) {
+      this.textarea.value = value;
+    }
+
+    this.textarea.selectionStart = selectionStart;
+    this.textarea.selectionEnd = selectionEnd;
+
+    if (value === this.value || value == null) {
+      return;
+    }
+
+    this.value = value;
+
+    const highlighted = this.options.highlighter(value);
+    this.pre.innerHTML = highlighted + "<br/>";
+
+    this.updateLines();
+
+    if (this.updateCallback) {
+      this.updateCallback(value);
+    }
+  }
+
+  updateLines() {
+    if (!this.options.lineNumbers) {
+      return;
+    }
+
+    if (!this.lines) {
+      this.lines = document.createElement("pre");
+      this.root.appendChild(this.lines);
+      Object.assign(this.lines.style, linesStyles);
+    }
+
+    const lines = this.value.split("\n");
+    const length = lines.length.toString().length;
+
+    this.root.style.paddingLeft = `${length + 1}ch`;
+
+    this.lines.innerHTML = lines
+      .map((line, number) => {
+        // prettier-ignore
+        const lineNumber = `<span class="yace-line" style="position: absolute; opacity: .3; left: 0">${1 + number}</span>`
+        // prettier-ignore
+        const lineText = `<span style="color: transparent; pointer-events: none">${escape(line)}</span>`;
+        return `${lineNumber}${lineText}`;
+      })
+      .join("\n");
+  }
+
+  destroy() {
+    this.textarea.removeEventListener("input", this.handleInput);
+    this.textarea.removeEventListener("keydown", this.handleKeydown);
+  }
+
+  onUpdate(callback) {
+    this.updateCallback = callback;
+  }
+}
+
+function runPlugins(plugins, event) {
+  const { value, selectionStart, selectionEnd } = event.target;
+
+  return plugins.reduce(
+    (acc, plugin) => {
+      return {
+        ...acc,
+        ...plugin(acc, event),
+      };
+    },
+    { value, selectionStart, selectionEnd }
+  );
+}
+
+function escape(unsafe) {
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+export default Yace;
+
+// source: https://github.com/petersolopov/yace/blob/8ed1f99977c4db9bdd60db4e2f5ba4edfcfc1940/src/plugins/isKey.js
+const CODES = {
+  backspace: 8,
+  tab: 9,
+  enter: 13,
+  shift: 16,
+  control: 17,
+  alt: 18,
+  pause: 19,
+  capslock: 20,
+  escape: 27,
+  " ": 32,
+  pageup: 33,
+  pagedown: 34,
+  end: 35,
+  home: 36,
+  arrowleft: 37,
+  arrowup: 38,
+  arrowright: 39,
+  arrowdown: 40,
+  insert: 45,
+  delete: 46,
+  meta: 91,
+  numlock: 144,
+  scrolllock: 145,
+  ";": 186,
+  "=": 187,
+  ",": 188,
+  "-": 189,
+  ".": 190,
+  "/": 191,
+  "`": 192,
+  "[": 219,
+  "\\": 220,
+  "]": 221,
+  "'": 222,
+
+  // aliases
+  add: 187,
+};
+
+const IS_MAC =
+  typeof window != "undefined" &&
+  /Mac|iPod|iPhone|iPad/.test(window.navigator.platform);
+
+const MODIFIERS = {
+  alt: "altKey",
+  control: "ctrlKey",
+  meta: "metaKey",
+  shift: "shiftKey",
+  "ctrl/cmd": IS_MAC ? "metaKey" : "ctrlKey",
+};
+
+function toKeyCode(name) {
+  return CODES[name] || name.toUpperCase().charCodeAt(0);
+}
+
+function isKey(string, event) {
+  const keys = string.split("+").reduce(
+    (acc, key) => {
+      if (MODIFIERS[key]) {
+        acc.modifiers[MODIFIERS[key]] = true;
+        return acc;
+      }
+
+      return {
+        ...acc,
+        keyCode: toKeyCode(key),
+      };
+    },
+    {
+      modifiers: {
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+      },
+      keyCode: null,
+    }
+  );
+
+  const hasModifiers = Object.keys(keys.modifiers).every((key) => {
+    const value = keys.modifiers[key];
+    return value ? event[key] : !event[key];
+  });
+
+  const hasKey = keys.keyCode ? event.which === keys.keyCode : true;
+
+  return hasModifiers && hasKey;
+}
+
+export default isKey;
+
+// https://github.com/petersolopov/yace/blob/8ed1f99977c4db9bdd60db4e2f5ba4edfcfc1940/src/plugins/history.js
+import isKey from "./isKey.js";
+
+function history() {
+  let stack = [];
+  let activeIndex = null;
+
+  const initHistory = (record) => {
+    activeIndex = 0;
+    stack.push(record);
+  };
+
+  const rewriteHistory = (record) => {
+    stack = stack.slice(0, activeIndex + 1);
+    stack.push(record);
+    activeIndex = stack.length - 1;
+  };
+
+  const shouldRecord = (record) => {
+    return (
+      stack[activeIndex].value !== record.value ||
+      stack[activeIndex].selectionStart !== record.selectionStart ||
+      stack[activeIndex].selectionEnd !== record.selectionEnd
+    );
+  };
+
+  return (textareaProps, event) => {
+    if (event.type === "keydown") {
+      if (isKey("ctrl/cmd+z", event)) {
+        event.preventDefault();
+
+        if (activeIndex !== null) {
+          // after applying all plugins it can be new props
+          if (shouldRecord(textareaProps)) {
+            stack.push(textareaProps);
+            activeIndex++;
+          }
+
+          const newActiveIndex = Math.max(0, activeIndex - 1);
+          activeIndex = newActiveIndex;
+          return stack[newActiveIndex];
+        }
+      }
+
+      if (isKey("ctrl/cmd+shift+z", event)) {
+        event.preventDefault();
+
+        if (activeIndex !== null) {
+          const newActiveIndex = Math.min(stack.length - 1, activeIndex + 1);
+          activeIndex = newActiveIndex;
+          return stack[newActiveIndex];
+        }
+      }
+
+      if (activeIndex === null) {
+        initHistory(textareaProps);
+        return;
+      }
+
+      if (shouldRecord(textareaProps)) {
+        rewriteHistory(textareaProps);
+        return;
+      }
+    }
+
+    if (event.type === "input") {
+      if (activeIndex === null) {
+        initHistory(textareaProps);
+      } else {
+        rewriteHistory(textareaProps);
+      }
+    }
+  };
+}
+
+export default history;
+
+// source: https://github.com/petersolopov/yace/blob/8ed1f99977c4db9bdd60db4e2f5ba4edfcfc1940/src/plugins/preserveIndent.js
+
+import isKey from "./isKey.js";
+
+const preserveIndent = () => (textareaProps, event) => {
+  const { value, selectionStart, selectionEnd } = textareaProps;
+
+  if (!isKey("enter", event)) {
+    return;
+  }
+
+  if (event.type !== "keydown") {
+    return;
+  }
+
+  const currentLineNumber =
+    value.substring(0, selectionStart).split("\n").length - 1;
+
+  const lines = value.split("\n");
+  const currentLine = lines[currentLineNumber];
+  const matches = /^\s+/.exec(currentLine);
+
+  if (!matches) {
+    return;
+  }
+
+  event.preventDefault();
+  const indent = matches[0];
+  const newLine = "\n";
+
+  const inserted = newLine + indent;
+
+  const newValue =
+    value.substring(0, selectionStart) +
+    inserted +
+    value.substring(selectionEnd);
+
+  return {
+    value: newValue,
+    selectionStart: selectionStart + inserted.length,
+    selectionEnd: selectionStart + inserted.length,
+  };
+};
+
+export default preserveIndent;
+
+// source: https://github.com/petersolopov/yace/blob/8ed1f99977c4db9bdd60db4e2f5ba4edfcfc1940/src/plugins/tab.js
+
+import isKey from "./isKey.js";
+
+const tab = (tabCharacter = "  ") => (textareaProps, event) => {
+  const { value, selectionStart, selectionEnd } = textareaProps;
+
+  if (event.type !== "keydown") {
+    return;
+  }
+
+  if (isKey("shift+tab", event)) {
+    event.preventDefault();
+    const linesBeforeCaret = value.substring(0, selectionStart).split("\n");
+    const startLine = linesBeforeCaret.length - 1;
+    const endLine = value.substring(0, selectionEnd).split("\n").length - 1;
+    const nextValue = value
+      .split("\n")
+      .map((line, i) => {
+        if (i >= startLine && i <= endLine && line.startsWith(tabCharacter)) {
+          return line.substring(tabCharacter.length);
+        }
+
+        return line;
+      })
+      .join("\n");
+
+    if (value !== nextValue) {
+      const startLineText = linesBeforeCaret[startLine];
+
+      return {
+        value: nextValue,
+        // Move the start cursor if first line in selection was modified
+        // It was modified only if it started with a tab
+        selectionStart: startLineText.startsWith(tabCharacter)
+          ? selectionStart - tabCharacter.length
+          : selectionStart,
+        // Move the end cursor by total number of characters removed
+        selectionEnd: selectionEnd - (value.length - nextValue.length),
+      };
+    }
+
+    return;
+  }
+
+  if (isKey("tab", event)) {
+    event.preventDefault();
+    if (selectionStart === selectionEnd) {
+      const updatedSelection = selectionStart + tabCharacter.length;
+      const newValue =
+        value.substring(0, selectionStart) +
+        tabCharacter +
+        value.substring(selectionEnd);
+
+      return {
+        value: newValue,
+        selectionStart: updatedSelection,
+        selectionEnd: updatedSelection,
+      };
+    }
+
+    const linesBeforeCaret = value.substring(0, selectionStart).split("\n");
+    const startLine = linesBeforeCaret.length - 1;
+    const endLine = value.substring(0, selectionEnd).split("\n").length - 1;
+
+    return {
+      value: value
+        .split("\n")
+        .map((line, i) => {
+          if (i >= startLine && i <= endLine) {
+            return tabCharacter + line;
+          }
+
+          return line;
+        })
+        .join("\n"),
+      selectionStart: selectionStart + tabCharacter.length,
+      selectionEnd:
+        selectionEnd + tabCharacter.length * (endLine - startLine + 1),
+    };
+  }
+};
+
+export default tab;

--- a/frontend/module/yace-editor.js
+++ b/frontend/module/yace-editor.js
@@ -1,24 +1,15 @@
-//prettier-ignore
 // https://github.com/petersolopov/yace - MIT licensed
 // source: https://github.com/petersolopov/yace/blob/8ed1f99977c4db9bdd60db4e2f5ba4edfcfc1940/src/index.js
-import {
-  textareaStyles,
-  preStyles,
-  rootStyles,
-  linesStyles,
-} from "./styles.js";
-
 class Yace {
   constructor(selector, options = {}) {
     if (!selector) {
-      throw new Error("selector is not defined");
+      throw new Error("selector is not defined")
     }
 
-    this.root =
-      selector instanceof Node ? selector : document.querySelector(selector);
+    this.root = selector instanceof Node ? selector : document.querySelector(selector)
 
     if (!this.root) {
-      throw new Error(`element with "${selector}" selector is not exist`);
+      throw new Error(`element with "${selector}" selector is not exist`)
     }
 
     const defaultOptions = {
@@ -26,88 +17,88 @@ class Yace {
       styles: {},
       plugins: [],
       highlighter: (value) => escape(value),
-    };
+    }
 
     this.options = {
       ...defaultOptions,
       ...options,
-    };
+    }
 
-    this.init();
+    this.init()
   }
 
   init() {
-    this.textarea = document.createElement("textarea");
-    this.pre = document.createElement("pre");
+    this.textarea = document.createElement("textarea")
+    this.pre = document.createElement("pre")
 
-    Object.assign(this.root.style, rootStyles, this.options.styles);
-    Object.assign(this.textarea.style, textareaStyles);
-    Object.assign(this.pre.style, preStyles);
+    Object.assign(this.root.style, rootStyles, this.options.styles)
+    Object.assign(this.textarea.style, textareaStyles)
+    Object.assign(this.pre.style, preStyles)
 
-    this.root.appendChild(this.textarea);
-    this.root.appendChild(this.pre);
+    this.root.appendChild(this.textarea)
+    this.root.appendChild(this.pre)
 
-    this.addTextareaEvents();
-    this.update({ value: this.options.value });
-    this.updateLines();
+    this.addTextareaEvents()
+    this.update({ value: this.options.value })
+    this.updateLines()
   }
 
   addTextareaEvents() {
     this.handleInput = (event) => {
-      const textareaProps = runPlugins(this.options.plugins, event);
-      this.update(textareaProps);
-    };
+      const textareaProps = runPlugins(this.options.plugins, event)
+      this.update(textareaProps)
+    }
 
     this.handleKeydown = (event) => {
-      const textareaProps = runPlugins(this.options.plugins, event);
-      this.update(textareaProps);
-    };
+      const textareaProps = runPlugins(this.options.plugins, event)
+      this.update(textareaProps)
+    }
 
-    this.textarea.addEventListener("input", this.handleInput);
-    this.textarea.addEventListener("keydown", this.handleKeydown);
+    this.textarea.addEventListener("input", this.handleInput)
+    this.textarea.addEventListener("keydown", this.handleKeydown)
   }
 
   update(textareaProps) {
-    const { value, selectionStart, selectionEnd } = textareaProps;
+    const { value, selectionStart, selectionEnd } = textareaProps
     // should be before updating selection otherwise selection will be lost
     if (value != null) {
-      this.textarea.value = value;
+      this.textarea.value = value
     }
 
-    this.textarea.selectionStart = selectionStart;
-    this.textarea.selectionEnd = selectionEnd;
+    this.textarea.selectionStart = selectionStart
+    this.textarea.selectionEnd = selectionEnd
 
     if (value === this.value || value == null) {
-      return;
+      return
     }
 
-    this.value = value;
+    this.value = value
 
-    const highlighted = this.options.highlighter(value);
-    this.pre.innerHTML = highlighted + "<br/>";
+    const highlighted = this.options.highlighter(value)
+    this.pre.innerHTML = highlighted + "<br/>"
 
-    this.updateLines();
+    this.updateLines()
 
     if (this.updateCallback) {
-      this.updateCallback(value);
+      this.updateCallback(value)
     }
   }
 
   updateLines() {
     if (!this.options.lineNumbers) {
-      return;
+      return
     }
 
     if (!this.lines) {
-      this.lines = document.createElement("pre");
-      this.root.appendChild(this.lines);
-      Object.assign(this.lines.style, linesStyles);
+      this.lines = document.createElement("pre")
+      this.root.appendChild(this.lines)
+      Object.assign(this.lines.style, linesStyles)
     }
 
-    const lines = this.value.split("\n");
-    const length = lines.length.toString().length;
+    const lines = this.value.split("\n")
+    const length = lines.length.toString().length
 
-    this.root.style.paddingLeft = `${length + 1}ch`;
+    this.root.style.paddingLeft = `${length + 1}ch`
 
     this.lines.innerHTML = lines
       .map((line, number) => {
@@ -115,33 +106,33 @@ class Yace {
         const lineNumber = `<span class="yace-line" style="position: absolute; opacity: .3; left: 0">${1 + number}</span>`
         // prettier-ignore
         const lineText = `<span style="color: transparent; pointer-events: none">${escape(line)}</span>`;
-        return `${lineNumber}${lineText}`;
+        return `${lineNumber}${lineText}`
       })
-      .join("\n");
+      .join("\n")
   }
 
   destroy() {
-    this.textarea.removeEventListener("input", this.handleInput);
-    this.textarea.removeEventListener("keydown", this.handleKeydown);
+    this.textarea.removeEventListener("input", this.handleInput)
+    this.textarea.removeEventListener("keydown", this.handleKeydown)
   }
 
   onUpdate(callback) {
-    this.updateCallback = callback;
+    this.updateCallback = callback
   }
 }
 
 function runPlugins(plugins, event) {
-  const { value, selectionStart, selectionEnd } = event.target;
+  const { value, selectionStart, selectionEnd } = event.target
 
   return plugins.reduce(
     (acc, plugin) => {
       return {
         ...acc,
         ...plugin(acc, event),
-      };
+      }
     },
     { value, selectionStart, selectionEnd }
-  );
+  )
 }
 
 function escape(unsafe) {
@@ -150,10 +141,10 @@ function escape(unsafe) {
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
+    .replace(/'/g, "&#039;")
 }
 
-export default Yace;
+export default Yace
 
 // source: https://github.com/petersolopov/yace/blob/8ed1f99977c4db9bdd60db4e2f5ba4edfcfc1940/src/plugins/isKey.js
 const CODES = {
@@ -194,11 +185,10 @@ const CODES = {
 
   // aliases
   add: 187,
-};
+}
 
 const IS_MAC =
-  typeof window != "undefined" &&
-  /Mac|iPod|iPhone|iPad/.test(window.navigator.platform);
+  typeof window != "undefined" && /Mac|iPod|iPhone|iPad/.test(window.navigator.platform)
 
 const MODIFIERS = {
   alt: "altKey",
@@ -206,24 +196,24 @@ const MODIFIERS = {
   meta: "metaKey",
   shift: "shiftKey",
   "ctrl/cmd": IS_MAC ? "metaKey" : "ctrlKey",
-};
+}
 
 function toKeyCode(name) {
-  return CODES[name] || name.toUpperCase().charCodeAt(0);
+  return CODES[name] || name.toUpperCase().charCodeAt(0)
 }
 
 function isKey(string, event) {
   const keys = string.split("+").reduce(
     (acc, key) => {
       if (MODIFIERS[key]) {
-        acc.modifiers[MODIFIERS[key]] = true;
-        return acc;
+        acc.modifiers[MODIFIERS[key]] = true
+        return acc
       }
 
       return {
         ...acc,
         keyCode: toKeyCode(key),
-      };
+      }
     },
     {
       modifiers: {
@@ -234,224 +224,203 @@ function isKey(string, event) {
       },
       keyCode: null,
     }
-  );
+  )
 
   const hasModifiers = Object.keys(keys.modifiers).every((key) => {
-    const value = keys.modifiers[key];
-    return value ? event[key] : !event[key];
-  });
+    const value = keys.modifiers[key]
+    return value ? event[key] : !event[key]
+  })
 
-  const hasKey = keys.keyCode ? event.which === keys.keyCode : true;
+  const hasKey = keys.keyCode ? event.which === keys.keyCode : true
 
-  return hasModifiers && hasKey;
+  return hasModifiers && hasKey
 }
 
-export default isKey;
-
 // https://github.com/petersolopov/yace/blob/8ed1f99977c4db9bdd60db4e2f5ba4edfcfc1940/src/plugins/history.js
-import isKey from "./isKey.js";
-
 function history() {
-  let stack = [];
-  let activeIndex = null;
+  let stack = []
+  let activeIndex = null
 
   const initHistory = (record) => {
-    activeIndex = 0;
-    stack.push(record);
-  };
+    activeIndex = 0
+    stack.push(record)
+  }
 
   const rewriteHistory = (record) => {
-    stack = stack.slice(0, activeIndex + 1);
-    stack.push(record);
-    activeIndex = stack.length - 1;
-  };
+    stack = stack.slice(0, activeIndex + 1)
+    stack.push(record)
+    activeIndex = stack.length - 1
+  }
 
   const shouldRecord = (record) => {
     return (
       stack[activeIndex].value !== record.value ||
       stack[activeIndex].selectionStart !== record.selectionStart ||
       stack[activeIndex].selectionEnd !== record.selectionEnd
-    );
-  };
+    )
+  }
 
   return (textareaProps, event) => {
     if (event.type === "keydown") {
       if (isKey("ctrl/cmd+z", event)) {
-        event.preventDefault();
+        event.preventDefault()
 
         if (activeIndex !== null) {
           // after applying all plugins it can be new props
           if (shouldRecord(textareaProps)) {
-            stack.push(textareaProps);
-            activeIndex++;
+            stack.push(textareaProps)
+            activeIndex++
           }
 
-          const newActiveIndex = Math.max(0, activeIndex - 1);
-          activeIndex = newActiveIndex;
-          return stack[newActiveIndex];
+          const newActiveIndex = Math.max(0, activeIndex - 1)
+          activeIndex = newActiveIndex
+          return stack[newActiveIndex]
         }
       }
 
       if (isKey("ctrl/cmd+shift+z", event)) {
-        event.preventDefault();
+        event.preventDefault()
 
         if (activeIndex !== null) {
-          const newActiveIndex = Math.min(stack.length - 1, activeIndex + 1);
-          activeIndex = newActiveIndex;
-          return stack[newActiveIndex];
+          const newActiveIndex = Math.min(stack.length - 1, activeIndex + 1)
+          activeIndex = newActiveIndex
+          return stack[newActiveIndex]
         }
       }
 
       if (activeIndex === null) {
-        initHistory(textareaProps);
-        return;
+        initHistory(textareaProps)
+        return
       }
 
       if (shouldRecord(textareaProps)) {
-        rewriteHistory(textareaProps);
-        return;
+        rewriteHistory(textareaProps)
+        return
       }
     }
 
     if (event.type === "input") {
       if (activeIndex === null) {
-        initHistory(textareaProps);
+        initHistory(textareaProps)
       } else {
-        rewriteHistory(textareaProps);
+        rewriteHistory(textareaProps)
       }
     }
-  };
+  }
 }
 
-export default history;
-
 // source: https://github.com/petersolopov/yace/blob/8ed1f99977c4db9bdd60db4e2f5ba4edfcfc1940/src/plugins/preserveIndent.js
-
-import isKey from "./isKey.js";
-
 const preserveIndent = () => (textareaProps, event) => {
-  const { value, selectionStart, selectionEnd } = textareaProps;
+  const { value, selectionStart, selectionEnd } = textareaProps
 
   if (!isKey("enter", event)) {
-    return;
+    return
   }
 
   if (event.type !== "keydown") {
-    return;
+    return
   }
 
-  const currentLineNumber =
-    value.substring(0, selectionStart).split("\n").length - 1;
+  const currentLineNumber = value.substring(0, selectionStart).split("\n").length - 1
 
-  const lines = value.split("\n");
-  const currentLine = lines[currentLineNumber];
-  const matches = /^\s+/.exec(currentLine);
+  const lines = value.split("\n")
+  const currentLine = lines[currentLineNumber]
+  const matches = /^\s+/.exec(currentLine)
 
   if (!matches) {
-    return;
+    return
   }
 
-  event.preventDefault();
-  const indent = matches[0];
-  const newLine = "\n";
+  event.preventDefault()
+  const indent = matches[0]
+  const newLine = "\n"
 
-  const inserted = newLine + indent;
+  const inserted = newLine + indent
 
-  const newValue =
-    value.substring(0, selectionStart) +
-    inserted +
-    value.substring(selectionEnd);
+  const newValue = value.substring(0, selectionStart) + inserted + value.substring(selectionEnd)
 
   return {
     value: newValue,
     selectionStart: selectionStart + inserted.length,
     selectionEnd: selectionStart + inserted.length,
-  };
-};
-
-export default preserveIndent;
+  }
+}
 
 // source: https://github.com/petersolopov/yace/blob/8ed1f99977c4db9bdd60db4e2f5ba4edfcfc1940/src/plugins/tab.js
+const tab =
+  (tabCharacter = "  ") =>
+  (textareaProps, event) => {
+    const { value, selectionStart, selectionEnd } = textareaProps
 
-import isKey from "./isKey.js";
-
-const tab = (tabCharacter = "  ") => (textareaProps, event) => {
-  const { value, selectionStart, selectionEnd } = textareaProps;
-
-  if (event.type !== "keydown") {
-    return;
-  }
-
-  if (isKey("shift+tab", event)) {
-    event.preventDefault();
-    const linesBeforeCaret = value.substring(0, selectionStart).split("\n");
-    const startLine = linesBeforeCaret.length - 1;
-    const endLine = value.substring(0, selectionEnd).split("\n").length - 1;
-    const nextValue = value
-      .split("\n")
-      .map((line, i) => {
-        if (i >= startLine && i <= endLine && line.startsWith(tabCharacter)) {
-          return line.substring(tabCharacter.length);
-        }
-
-        return line;
-      })
-      .join("\n");
-
-    if (value !== nextValue) {
-      const startLineText = linesBeforeCaret[startLine];
-
-      return {
-        value: nextValue,
-        // Move the start cursor if first line in selection was modified
-        // It was modified only if it started with a tab
-        selectionStart: startLineText.startsWith(tabCharacter)
-          ? selectionStart - tabCharacter.length
-          : selectionStart,
-        // Move the end cursor by total number of characters removed
-        selectionEnd: selectionEnd - (value.length - nextValue.length),
-      };
+    if (event.type !== "keydown") {
+      return
     }
 
-    return;
-  }
-
-  if (isKey("tab", event)) {
-    event.preventDefault();
-    if (selectionStart === selectionEnd) {
-      const updatedSelection = selectionStart + tabCharacter.length;
-      const newValue =
-        value.substring(0, selectionStart) +
-        tabCharacter +
-        value.substring(selectionEnd);
-
-      return {
-        value: newValue,
-        selectionStart: updatedSelection,
-        selectionEnd: updatedSelection,
-      };
-    }
-
-    const linesBeforeCaret = value.substring(0, selectionStart).split("\n");
-    const startLine = linesBeforeCaret.length - 1;
-    const endLine = value.substring(0, selectionEnd).split("\n").length - 1;
-
-    return {
-      value: value
+    if (isKey("shift+tab", event)) {
+      event.preventDefault()
+      const linesBeforeCaret = value.substring(0, selectionStart).split("\n")
+      const startLine = linesBeforeCaret.length - 1
+      const endLine = value.substring(0, selectionEnd).split("\n").length - 1
+      const nextValue = value
         .split("\n")
         .map((line, i) => {
-          if (i >= startLine && i <= endLine) {
-            return tabCharacter + line;
+          if (i >= startLine && i <= endLine && line.startsWith(tabCharacter)) {
+            return line.substring(tabCharacter.length)
           }
 
-          return line;
+          return line
         })
-        .join("\n"),
-      selectionStart: selectionStart + tabCharacter.length,
-      selectionEnd:
-        selectionEnd + tabCharacter.length * (endLine - startLine + 1),
-    };
-  }
-};
+        .join("\n")
 
-export default tab;
+      if (value !== nextValue) {
+        const startLineText = linesBeforeCaret[startLine]
+
+        return {
+          value: nextValue,
+          // Move the start cursor if first line in selection was modified
+          // It was modified only if it started with a tab
+          selectionStart: startLineText.startsWith(tabCharacter)
+            ? selectionStart - tabCharacter.length
+            : selectionStart,
+          // Move the end cursor by total number of characters removed
+          selectionEnd: selectionEnd - (value.length - nextValue.length),
+        }
+      }
+
+      return
+    }
+
+    if (isKey("tab", event)) {
+      event.preventDefault()
+      if (selectionStart === selectionEnd) {
+        const updatedSelection = selectionStart + tabCharacter.length
+        const newValue =
+          value.substring(0, selectionStart) + tabCharacter + value.substring(selectionEnd)
+
+        return {
+          value: newValue,
+          selectionStart: updatedSelection,
+          selectionEnd: updatedSelection,
+        }
+      }
+
+      const linesBeforeCaret = value.substring(0, selectionStart).split("\n")
+      const startLine = linesBeforeCaret.length - 1
+      const endLine = value.substring(0, selectionEnd).split("\n").length - 1
+
+      return {
+        value: value
+          .split("\n")
+          .map((line, i) => {
+            if (i >= startLine && i <= endLine) {
+              return tabCharacter + line
+            }
+
+            return line
+          })
+          .join("\n"),
+        selectionStart: selectionStart + tabCharacter.length,
+        selectionEnd: selectionEnd + tabCharacter.length * (endLine - startLine + 1),
+      }
+    }
+  }


### PR DESCRIPTION
Add evy syntax colouring by implementing a custom highlight function for
lightweight JS code editor Yace. 
Copy all relevant Yace source files with minor tweaks into a single file 
`frontend/module/yace-editor.js` as we are not (yet) using a JS bundler.

Link: https://github.com/petersolopov/yace
Link: https://github.com/petersolopov/mdhl
