### PR TITLE
evaluator: Refactor Runtime into interface

### DIFF
--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -40,16 +40,15 @@ func NewEvaluator(builtins Builtins) *Evaluator {
 		scope.set(global.Name, z)
 	}
 	return &Evaluator{
-		print:    builtins.Print,
 		builtins: builtins,
 		scope:    scope,
+		yielder:  builtins.Runtime.Yielder(),
 	}
 }
 
 type Evaluator struct {
 	Stopped       bool
-	Yielder       Yielder // Yield to give JavaScript/browser events a chance to run.
-	print         func(string)
+	yielder       Yielder // Yield to give JavaScript/browser events a chance to run.
 	builtins      Builtins
 	eventHandlers map[string]*parser.EventHandlerStmt
 
@@ -170,8 +169,8 @@ func (e *Evaluator) HandleEvent(ev Event) error {
 }
 
 func (e *Evaluator) yield() {
-	if e.Yielder != nil {
-		e.Yielder.Yield()
+	if e.yielder != nil {
+		e.yielder.Yield()
 	}
 }
 

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -8,16 +8,28 @@ import (
 	"foxygo.at/evy/pkg/assert"
 )
 
+type testRT struct {
+	UnimplementedRuntime
+	b bytes.Buffer
+}
+
+func (rt *testRT) Print(s string) {
+	rt.b.WriteString(s)
+}
+
+func (*testRT) Yielder() Yielder {
+	return nil
+}
+
 func run(input string) string {
-	b := bytes.Buffer{}
-	printFn := func(s string) { b.WriteString(s) }
-	rt := &Runtime{Print: printFn}
+	rt := &testRT{}
+	rt.UnimplementedRuntime.print = rt.Print
 	eval := NewEvaluator(DefaultBuiltins(rt))
 	err := eval.Run(input)
 	if err != nil {
 		return err.Error()
 	}
-	return b.String()
+	return rt.b.String()
 }
 
 func TestBasicEval(t *testing.T) {
@@ -1055,8 +1067,8 @@ if x > 10
     print "🍦 big x"
 end`
 	want := `
-'move' not yet implemented
-'line' not yet implemented
+"move" not implemented
+"line" not implemented
 x: 12
 🍦 big x
 `[1:]

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -14,16 +14,16 @@ var (
 )
 
 func main() {
-	yielder := newSleepingYielder()
-	builtins := evaluator.DefaultBuiltins(newJSRuntime(yielder))
+	rt := newJSRuntime()
+	builtins := evaluator.DefaultBuiltins(rt)
 
 	defer afterStop()
 	source, err := format(builtins)
 	if err != nil {
-		builtins.Print(err.Error())
+		rt.Print(err.Error())
 		return
 	}
-	evaluate(source, builtins, yielder)
+	evaluate(source, builtins, rt.yielder)
 }
 
 func format(evalBuiltins evaluator.Builtins) (string, error) {
@@ -43,7 +43,6 @@ func format(evalBuiltins evaluator.Builtins) (string, error) {
 
 func evaluate(input string, builtins evaluator.Builtins, yielder *sleepingYielder) {
 	eval = evaluator.NewEvaluator(builtins)
-	eval.Yielder = yielder
 
 	eval.Run(input)
 	handleEvents(yielder)


### PR DESCRIPTION
Refactor evaluator.Runtime into interface as it appears to be the more
appropriate structure and works well with jsRuntime and cliRuntime. This
also allows for jsRuntime to track its own sleepingYielder.