### PR TITLE
frontend: Highlight lines with error

### DIFF
--- a/frontend/img/err-line.svg
+++ b/frontend/img/err-line.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 10 24" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 0 H2 L10 12 L2 24 H0V0 Z" fill="#0057A8"/>
+</svg>

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -2,33 +2,27 @@
   /* theme */
   --ff: "Inter", sans-serif;
   --ff-code: "Fira Code", monospace;
-
   --bg: hsl(210deg 5% 15%);
   --color: hsl(0deg 0% 100%);
   --color-hover: hsl(0deg 0% 100% / 70%);
-
   --header-bg: hsl(213deg 10% 23%);
-
   --output-bg: hsl(0deg 0% 100%);
   --output-color: hsl(0deg 0% 0% / 80%);
   --output-border-dark: hsl(0deg 0% 80%);
   --output-border-mid: hsl(0deg 0% 85%);
   --output-border-light: hsl(0deg 0% 92%);
-
   --syntax-num: hsl(204deg 100% 75%);
   --syntax-string: hsl(203deg 100% 86%);
   --syntax-func: hsl(266deg 100% 86%);
   --syntax-builtin: hsl(27deg 100% 74%);
   --syntax-keyword: hsl(359deg 100% 75%);
-  --syntax-comment: hsl(210deg, 13%, 72%);
+  --syntax-comment: hsl(210deg 13% 72%);
   --syntax-error-bg: hsl(209deg 100% 33%);
-
   --btn-color: hsl(0deg 0% 33%);
   --btn-color-active: hsl(0deg 0% 100%);
   --btn-color-disabled: hsl(0deg 0% 33% / 50%);
   --btn-bg: hsl(0deg 0% 92%);
   --btn-bg-hover: hsl(0deg 0% 80%);
-
   --modal-bg: hsl(210deg 5% 15% / 95%);
   --modal-color: hsl(0deg 0% 100% / 80%);
   --modal-color-hover: hsl(0deg 0% 100% / 100%);
@@ -102,7 +96,7 @@
   }
 }
 
-/* --- Resets --------------------------------------------------------*/
+/* --- Resets -------------------------------------------------------- */
 *,
 ::after,
 ::before {
@@ -110,7 +104,6 @@
   margin: 0;
   box-sizing: border-box;
 }
-
 html,
 body {
   height: 100%;
@@ -118,7 +111,7 @@ body {
   text-size-adjust: 100%;
 }
 
-/* --- Global --------------------------------------------------------*/
+/* --- Global -------------------------------------------------------- */
 body {
   font-family: var(--ff);
   letter-spacing: 0.15px;
@@ -131,29 +124,14 @@ a {
   transition: all 0.3s ease-in-out;
 }
 
-/* --- Header --------------------------------------------------------*/
+/* --- Header -------------------------------------------------------- */
 header {
   background: #34393f;
   padding: var(--header-padding);
   font-family: var(--ff);
   height: var(--header-height);
-
   display: flex;
   flex-direction: row;
-}
-header button {
-  color: var(--color);
-  text-decoration: underline;
-  text-underline-offset: 0.2em;
-  text-decoration-thickness: 1px;
-  border: none;
-  outline: none;
-  background: none;
-  font-size: 1rem;
-  cursor: pointer;
-}
-header button:hover {
-  color: var(--color-hover);
 }
 header .breadcrumbs {
   list-style: none;
@@ -187,19 +165,33 @@ header .share svg {
   position: relative;
   top: 0.2em;
 }
-header .breadcrumbs li {
+.breadcrumbs li {
   white-space: nowrap;
   text-overflow: ellipsis;
 }
-header .breadcrumbs li:not(:last-child) {
+.breadcrumbs li:not(:last-child) {
   display: var(--display-desktop-only);
 }
-header .breadcrumbs li:not(:last-child):after {
+.breadcrumbs li:not(:last-child)::after {
   content: "›";
   padding: 0 10px;
 }
+.breadcrumbs button {
+  color: var(--color);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  text-decoration-thickness: 1px;
+  border: none;
+  outline: none;
+  background: none;
+  font-size: 1rem;
+  cursor: pointer;
+}
+.breadcrumbs button:hover {
+  color: var(--color-hover);
+}
 
-/* --- Main ----------------------------------------------------------*/
+/* --- Main ---------------------------------------------------------- */
 main {
   background: var(--bg);
   width: var(--main-width);
@@ -219,7 +211,6 @@ main.view-output {
   width: 100%;
   margin-left: auto;
   margin-right: auto;
-
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -229,10 +220,9 @@ main.view-output {
   font-size: 1rem;
 }
 
-/* --- Editor --------------------------------------------------------*/
+/* --- Editor -------------------------------------------------------- */
 .editor-wrap {
   margin-top: var(--editor-padding);
-  padding-left: var(--editor-padding);
   padding-right: var(--editor-padding);
   padding-bottom: var(--editor-padding-bottom);
   font-size: 1rem;
@@ -267,8 +257,8 @@ main.view-output {
   font-variant-ligatures: inherit;
   letter-spacing: inherit;
   border: none;
-  top: 0px;
-  left: 0px;
+  top: 0;
+  left: 0;
   color: transparent;
   overflow: hidden;
 }
@@ -281,7 +271,6 @@ main.view-output {
   width: max-content;
   margin: 0;
   font-size: inherit;
-  font-family: inherit;
   font-variant-ligatures: inherit;
   letter-spacing: inherit;
   pointer-events: none;
@@ -291,20 +280,10 @@ main.view-output {
 .editor pre.lines {
   position: absolute;
   height: 100%;
-  top: 0px;
-  left: 0px;
+  top: 0;
+  left: 0;
   pointer-events: none;
   overflow: auto;
-}
-.editor pre.lines .num {
-  position: aboslute;
-  color: hsl(212deg 8% 47%);
-  left: 0;
-}
-.editor pre.lines .txt {
-  padding-left: 1ch;
-  color: transparent;
-  pointer-events: none;
 }
 .editor .num,
 .editor .bool {
@@ -335,15 +314,24 @@ main.view-output {
   font-style: italic;
   font-weight: 300;
 }
+.editor .lines .num {
+  position: absolute;
+  color: hsl(212deg 8% 47%);
+  left: 0;
+}
+.editor .lines .txt {
+  padding-left: 1ch;
+  color: transparent;
+  pointer-events: none;
+}
 
-/* --- Output --------------------------------------------------------*/
+/* --- Output -------------------------------------------------------- */
 .output {
   width: var(--output-width);
   display: flex;
   flex-direction: column;
   overflow: hidden;
   background: var(--output-border-light);
-
   border-radius: var(--output-border-radius);
   margin: var(--output-margin);
   border: var(--output-border);
@@ -363,6 +351,9 @@ main.view-output {
   width: 100%;
   height: 100%;
 }
+.read {
+  display: flex;
+}
 .output .console,
 .output .read,
 .output .input {
@@ -374,9 +365,6 @@ main.view-output {
   border-top: 1px solid var(--output-border-dark);
   border-bottom: 1px solid var(--output-border-light);
   width: var(--console-size);
-}
-.read {
-  display: flex;
 }
 .output .read textarea {
   font-size: 1rem;
@@ -399,7 +387,7 @@ main.view-output {
   padding-bottom: var(--editor-padding-bottom);
 }
 
-/* --- Run -----------------------------------------------------------*/
+/* --- Run ----------------------------------------------------------- */
 .run {
   padding: 8px;
   padding-bottom: 12px;
@@ -415,7 +403,8 @@ main.view-output {
   border-top: 1px solid var(--output-border-dark);
   background: var(--output-bg);
 }
-.run button {
+.run button#run,
+.run button#run-mobile {
   color: var(--btn-color);
   background: var(--btn-bg);
   box-shadow: 0 4px 0 hsl(0deg 0% 42%), 0 16px 12px -8px hsl(0deg 0% 0% / 42%),
@@ -434,19 +423,15 @@ main.view-output {
   transition: background 0.3s ease-in-out;
   text-decoration: none;
 }
-
+.run button:disabled {
+  color: var(--btn-color-disabled);
+  box-shadow: 0 4px 0 hsl(0deg 0% 60%), 0 16px 12px -8px hsl(0deg 0% 0% / 30%),
+    inset 0 -2px 1px 1px hsl(0deg 0% 60%);
+  cursor: not-allowed;
+}
 .run button:hover:enabled {
   background: var(--btn-bg-hover);
 }
-
-.run button:disabled {
-  color: var(--btn-color-disabled);
-  box-shadow: 0 4px 0 hsl(0 0% 60%), 0 16px 12px -8px hsl(0deg 0% 0% / 30%),
-    inset 0 -2px 1px 1px hsl(0 0% 60%);
-
-  cursor: not-allowed;
-}
-
 .run button.running,
 .run button.running:hover {
   color: var(--btn-color-active);
@@ -471,32 +456,33 @@ main.view-output {
   }
 }
 
-/* --- Sample selection modal ----------------------------------------*/
-.modal {
+/* --- Sample selection modal ---------------------------------------- */
+#modal {
   position: fixed;
   z-index: 10;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
+  inset: 0;
   overflow: clip;
 }
-
-.modal header {
+#modal header {
   border-bottom: 1px solid hsl(0deg 0% 100% / 30%);
   color: hsl(0deg 0% 70%);
   background: var(--modal-bg);
   justify-content: right;
 }
-
 #modal-close {
   position: relative;
   top: 0.2em;
   right: 0.2em;
   cursor: pointer;
+  background: none;
+  color: var(--color);
+  border: none;
+  font-size: 1rem;
 }
-
-.modal-main {
+#modal-close:hover {
+  color: var(--hover-color);
+}
+#modal .modal-main {
   padding: 36px 32px;
   overflow-y: auto;
   display: flex;
@@ -504,37 +490,36 @@ main.view-output {
   flex-wrap: wrap;
   height: 100%;
 }
-.modal-main .item {
+#modal .modal-main .item {
   width: var(--modal-item-width);
   padding-bottom: 16px;
 }
-.modal-main h2 {
+#modal .modal-main h2 {
   font-family: var(--ff);
   font-weight: 700;
   font-size: 1rem;
   padding-bottom: 8px;
 }
-.modal-main ul {
+#modal .modal-main ul {
   padding-left: 6px;
   margin-bottom: 0;
   list-style: none;
 }
-.modal-main ul li {
+#modal .modal-main li {
   padding-bottom: 6px;
   line-height: 1.6;
 }
-.modal ul li a {
+#modal li a {
   font-family: var(--ff);
   color: var(--modal-color);
   padding-left: 1.5rem;
   text-decoration: none;
   position: relative;
 }
-.modal ul li a:hover {
+#modal ul li a:hover {
   color: var(--modal-color-hover);
 }
-
-.modal ul li a::before {
+#modal ul li a::before {
   content: "";
   position: absolute;
   height: 1rem;
@@ -547,7 +532,7 @@ main.view-output {
   display: inline-block;
   z-index: 1;
 }
-.modal ul li:not(:last-child) a::after {
+#modal ul li:not(:last-child) a::after {
   content: "";
   position: absolute;
   height: 100%;
@@ -557,7 +542,7 @@ main.view-output {
   background: var(--modal-circle-color);
 }
 
-/* --- Easter egg ----------------------------------------------------*/
+/* --- Easter egg ---------------------------------------------------- */
 .confetti {
   height: 7vw;
   width: 7vw;
@@ -574,7 +559,7 @@ main.view-output {
   transition: opacity 1.5s ease-in-out;
 }
 
-/* --- Utilities -----------------------------------------------------*/
+/* --- Utilities ----------------------------------------------------- */
 .desktop {
   display: var(--display-desktop-only);
 }

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -11,12 +11,14 @@
   --output-border-dark: hsl(0deg 0% 80%);
   --output-border-mid: hsl(0deg 0% 85%);
   --output-border-light: hsl(0deg 0% 92%);
+  --line-num-color: hsl(212deg 8% 47%);
   --syntax-num: hsl(204deg 100% 75%);
   --syntax-string: hsl(203deg 100% 86%);
   --syntax-func: hsl(266deg 100% 86%);
   --syntax-builtin: hsl(27deg 100% 74%);
   --syntax-keyword: hsl(359deg 100% 75%);
   --syntax-comment: hsl(210deg 13% 72%);
+  --syntax-error-line-bg: hsl(210deg 7% 20%);
   --syntax-error-bg: hsl(209deg 100% 33%);
   --btn-color: hsl(0deg 0% 33%);
   --btn-color-active: hsl(0deg 0% 100%);
@@ -223,7 +225,6 @@ main.view-output {
 /* --- Editor -------------------------------------------------------- */
 .editor-wrap {
   margin-top: var(--editor-padding);
-  padding-right: var(--editor-padding);
   padding-bottom: var(--editor-padding-bottom);
   font-size: 1rem;
   flex: 1;
@@ -239,6 +240,7 @@ main.view-output {
   position: relative;
   overflow: hidden;
   width: max-content;
+  min-width: 100%;
 }
 .editor textarea {
   line-height: inherit;
@@ -259,12 +261,11 @@ main.view-output {
   border: none;
   top: 0;
   left: 0;
-  color: transparent;
   overflow: hidden;
+  color: transparent;
 }
 .editor pre {
   line-height: inherit;
-  position: relative;
   white-space: pre-wrap;
   word-break: keep-all;
   padding: 0;
@@ -275,6 +276,9 @@ main.view-output {
   letter-spacing: inherit;
   pointer-events: none;
   font-family: inherit;
+}
+.editor pre.highlighted {
+  position: relative;
   overflow: hidden;
 }
 .editor pre.lines {
@@ -284,6 +288,11 @@ main.view-output {
   left: 0;
   pointer-events: none;
   overflow: auto;
+  min-width: 100%;
+}
+.editor pre.highlighted .err {
+  background: var(--syntax-error-bg);
+  border-radius: 6px;
 }
 .editor .num,
 .editor .bool {
@@ -316,13 +325,34 @@ main.view-output {
 }
 .editor .lines .num {
   position: absolute;
-  color: hsl(212deg 8% 47%);
+  color: var(--line-num-color);
   left: 0;
 }
 .editor .lines .txt {
-  padding-left: 1ch;
   color: transparent;
   pointer-events: none;
+}
+.editor .lines .err.num {
+  background: var(--syntax-error-bg);
+  color: var(--color);
+}
+.editor .lines .err.txt {
+  left: calc(2ch + 1.2rem);
+  right: 0;
+  padding-left: 0.3rem;
+  background: var(--syntax-error-line-bg);
+  border-radius: 6px;
+  position: absolute;
+}
+.editor .lines .err.num::after {
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 10 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M0 0 H2 L10 12 L2 24 H0V0 Z' fill='%230057A8'/%3E%3C/svg%3E%0A");
+  background-repeat: no-repeat;
+  content: "";
+  width: 0.8rem;
+  position: absolute;
+  right: -0.8rem;
+  top: 0;
+  bottom: 0;
 }
 
 /* --- Output -------------------------------------------------------- */

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -60,7 +60,7 @@
     </div>
 
     <!-- Modal evy code sample selection, hidden on load, showed on breadcrumb click-->
-    <div class="modal hidden">
+    <div class="hidden" id="modal">
       <div class="max-width-wrapper">
         <header>
           <button id="modal-close">

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -529,7 +529,7 @@ function animationLoop(ts) {
 // --- UI: modal navigation --------------------------------------------
 
 function initModal() {
-  const modalMain = document.querySelector(".modal-main")
+  const modalMain = document.querySelector("#modal .modal-main")
   modalMain.textContent = ""
   for (const course of courses.courseList) {
     const item = document.createElement("div")
@@ -552,12 +552,12 @@ function initModal() {
 }
 
 function hideModal() {
-  const el = document.querySelector(".modal")
+  const el = document.querySelector("#modal")
   el.classList.add("hidden")
 }
 
 function showModal() {
-  const el = document.querySelector(".modal")
+  const el = document.querySelector("#modal")
   el.classList.remove("hidden")
 }
 

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -789,7 +789,7 @@ func TestHasErr(t *testing.T) {
 	prog := `
 has ["a"] "a" // cannot run 'has' on array
 `
-	want := "line 2 column 15: 'has' takes 1st argument of type '{}', found '[]string'"
+	want := "line 2 column 5: 'has' takes 1st argument of type '{}', found '[]string'"
 	got := run(prog)
 	assert.Equal(t, want, got)
 }
@@ -825,7 +825,7 @@ func TestDelErr(t *testing.T) {
 	prog := `
 del ["a"] "a" // cannot delete from array
 `
-	want := "line 2 column 15: 'del' takes 1st argument of type '{}', found '[]string'"
+	want := "line 2 column 5: 'del' takes 1st argument of type '{}', found '[]string'"
 	got := run(prog)
 	assert.Equal(t, want, got)
 }

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -8,11 +8,13 @@ import (
 )
 
 type Node interface {
+	Token() *lexer.Token
 	String() string
 	Type() *Type
 }
 
 type Program struct {
+	token              *lexer.Token
 	Statements         []Node
 	EventHandlers      map[string]*EventHandlerStmt
 	CalledBuiltinFuncs []string
@@ -22,30 +24,30 @@ type Program struct {
 }
 
 type EmptyStmt struct {
-	Token *lexer.Token // The NL token
+	token *lexer.Token // The NL token
 }
 
 type FuncCallStmt struct {
-	Token    *lexer.Token // The IDENT of the function
+	token    *lexer.Token // The IDENT of the function
 	FuncCall *FuncCall
 }
 
 type FuncCall struct {
-	Token     *lexer.Token // The IDENT of the function
+	token     *lexer.Token // The IDENT of the function
 	Name      string
 	Arguments []Node
 	FuncDecl  *FuncDeclStmt
 }
 
 type UnaryExpression struct {
-	Token *lexer.Token // The unary operation token, e.g. !
+	token *lexer.Token // The unary operation token, e.g. !
 	Op    Operator
 	Right Node
 }
 
 type BinaryExpression struct {
 	T     *Type
-	Token *lexer.Token // The binary operation token, e.g. +
+	token *lexer.Token // The binary operation token, e.g. +
 	Op    Operator
 	Left  Node
 	Right Node
@@ -53,14 +55,14 @@ type BinaryExpression struct {
 
 type IndexExpression struct {
 	T     *Type
-	Token *lexer.Token // The [ token
+	token *lexer.Token // The [ token
 	Left  Node
 	Index Node
 }
 
 type SliceExpression struct {
 	T     *Type
-	Token *lexer.Token // The [ token
+	token *lexer.Token // The [ token
 	Left  Node
 	Start Node
 	End   Node
@@ -68,50 +70,54 @@ type SliceExpression struct {
 
 type DotExpression struct {
 	T     *Type
-	Token *lexer.Token // The . token
+	token *lexer.Token // The . token
 	Left  Node
 	Key   string // m := { age: 42}; m.age => key: "age"
 }
 
 type GroupExpression struct {
-	Token *lexer.Token
+	token *lexer.Token
 	Expr  Node
 }
 
 type Decl struct {
-	Token *lexer.Token
+	token *lexer.Token
 	Var   *Var
 	Value Node // literal, expression, assignable, ...
 }
 
 type TypedDeclStmt struct {
-	Token *lexer.Token
+	token *lexer.Token
 	Decl  *Decl
 }
 
 type InferredDeclStmt struct {
-	Token *lexer.Token
+	token *lexer.Token
 	Decl  *Decl
 }
 
 type AssignmentStmt struct {
-	Token  *lexer.Token
+	token  *lexer.Token
 	Target Node // Variable, index or field expression
 	Value  Node // literal, expression, assignable, ...
 }
 
 type ReturnStmt struct {
-	Token *lexer.Token
+	token *lexer.Token
 	Value Node // literal, expression, assignable, ...
 	T     *Type
 }
 
 type BreakStmt struct {
-	Token *lexer.Token
+	token *lexer.Token
+}
+
+func (f *FuncDeclStmt) Token() *lexer.Token {
+	return f.token
 }
 
 type FuncDeclStmt struct {
-	Token         *lexer.Token // The 'func' token
+	token         *lexer.Token // The 'func' token
 	Name          string
 	Params        []*Var
 	VariadicParam *Var
@@ -121,19 +127,31 @@ type FuncDeclStmt struct {
 	isCalled bool
 }
 
+func (i *IfStmt) Token() *lexer.Token {
+	return i.token
+}
+
 type IfStmt struct {
-	Token        *lexer.Token
+	token        *lexer.Token
 	IfBlock      *ConditionalBlock
 	ElseIfBlocks []*ConditionalBlock
 	Else         *BlockStatement
+}
+
+func (w *WhileStmt) Token() *lexer.Token {
+	return w.token
 }
 
 type WhileStmt struct {
 	ConditionalBlock
 }
 
+func (f *ForStmt) Token() *lexer.Token {
+	return f.token
+}
+
 type ForStmt struct {
-	Token *lexer.Token
+	token *lexer.Token
 
 	LoopVar *Var
 	Range   Node // StepRange or array/map/string expression
@@ -141,66 +159,110 @@ type ForStmt struct {
 	Block *BlockStatement
 }
 
+func (s *StepRange) Token() *lexer.Token {
+	return s.token
+}
+
 type StepRange struct {
-	Token *lexer.Token
+	token *lexer.Token
 
 	Start Node // num expression or nil
 	Stop  Node // num expression
 	Step  Node // num expression or nil
 }
 
+func (c *ConditionalBlock) Token() *lexer.Token {
+	return c.token
+}
+
 type ConditionalBlock struct {
-	Token     *lexer.Token
+	token     *lexer.Token
 	Condition Node // must be of type bool
 	Block     *BlockStatement
 }
 
+func (e *EventHandlerStmt) Token() *lexer.Token {
+	return e.token
+}
+
 type EventHandlerStmt struct {
-	Token  *lexer.Token // The 'on' token
+	token  *lexer.Token // The 'on' token
 	Name   string
 	Params []*Var
 	Body   *BlockStatement
 }
 
+func (v *Var) Token() *lexer.Token {
+	return v.token
+}
+
 type Var struct {
-	Token  *lexer.Token
+	token  *lexer.Token
 	Name   string
 	T      *Type
 	isUsed bool
 }
 
+func (b *BlockStatement) Token() *lexer.Token {
+	return b.token
+}
+
 type BlockStatement struct {
-	Token            *lexer.Token // the NL before the first statement
+	token            *lexer.Token // the NL before the first statement
 	Statements       []Node
 	alwaysTerminates bool
 }
 
+func (b *Bool) Token() *lexer.Token {
+	return b.token
+}
+
 type Bool struct {
-	Token *lexer.Token
+	token *lexer.Token
 	Value bool
 }
 
+func (n *NumLiteral) Token() *lexer.Token {
+	return n.token
+}
+
 type NumLiteral struct {
-	Token *lexer.Token
+	token *lexer.Token
 	Value float64
 }
 
+func (s *StringLiteral) Token() *lexer.Token {
+	return s.token
+}
+
 type StringLiteral struct {
-	Token *lexer.Token
+	token *lexer.Token
 	Value string
 }
 
+func (a *ArrayLiteral) Token() *lexer.Token {
+	return a.token
+}
+
 type ArrayLiteral struct {
-	Token    *lexer.Token
+	token    *lexer.Token
 	Elements []Node
 	T        *Type
 }
 
+func (m *MapLiteral) Token() *lexer.Token {
+	return m.token
+}
+
 type MapLiteral struct {
-	Token *lexer.Token
+	token *lexer.Token
 	Pairs map[string]Node
 	Order []string // Track insertion order of keys for deterministic output.
 	T     *Type
+}
+
+func (p *Program) Token() *lexer.Token {
+	return p.token
 }
 
 func (p *Program) String() string {
@@ -222,11 +284,19 @@ func (p *Program) AlwaysTerminates() bool {
 	return p.alwaysTerminates
 }
 
+func (e *EmptyStmt) Token() *lexer.Token {
+	return e.token
+}
+
 func (e *EmptyStmt) String() string {
 	return ""
 }
 
 func (*EmptyStmt) Type() *Type { return NONE_TYPE }
+
+func (f *FuncCall) Token() *lexer.Token {
+	return f.token
+}
 
 func (f *FuncCall) String() string {
 	s := make([]string, len(f.Arguments))
@@ -241,6 +311,10 @@ func (f *FuncCall) Type() *Type {
 	return f.FuncDecl.ReturnType
 }
 
+func (f *FuncCallStmt) Token() *lexer.Token {
+	return f.token
+}
+
 func (f *FuncCallStmt) String() string {
 	return f.FuncCall.String()
 }
@@ -249,12 +323,20 @@ func (f *FuncCallStmt) Type() *Type {
 	return f.FuncCall.FuncDecl.ReturnType
 }
 
+func (u *UnaryExpression) Token() *lexer.Token {
+	return u.token
+}
+
 func (u *UnaryExpression) String() string {
 	return "(" + u.Op.String() + u.Right.String() + ")"
 }
 
 func (u *UnaryExpression) Type() *Type {
 	return u.Right.Type()
+}
+
+func (b *BinaryExpression) Token() *lexer.Token {
+	return b.token
 }
 
 func (b *BinaryExpression) String() string {
@@ -268,12 +350,20 @@ func (b *BinaryExpression) Type() *Type {
 	return b.T
 }
 
+func (i *IndexExpression) Token() *lexer.Token {
+	return i.token
+}
+
 func (i *IndexExpression) String() string {
 	return "(" + i.Left.String() + "[" + i.Index.String() + "])"
 }
 
 func (i *IndexExpression) Type() *Type {
 	return i.T
+}
+
+func (s *SliceExpression) Token() *lexer.Token {
+	return s.token
 }
 
 func (s *SliceExpression) String() string {
@@ -292,6 +382,10 @@ func (s *SliceExpression) Type() *Type {
 	return s.T
 }
 
+func (d *DotExpression) Token() *lexer.Token {
+	return d.token
+}
+
 func (d *DotExpression) String() string {
 	return "(" + d.Left.String() + "." + d.Key + ")"
 }
@@ -300,12 +394,20 @@ func (d *DotExpression) Type() *Type {
 	return d.T
 }
 
+func (d *GroupExpression) Token() *lexer.Token {
+	return d.token
+}
+
 func (d *GroupExpression) String() string {
 	return d.Expr.String()
 }
 
 func (d *GroupExpression) Type() *Type {
 	return d.Expr.Type()
+}
+
+func (d *Decl) Token() *lexer.Token {
+	return d.token
 }
 
 func (d *Decl) String() string {
@@ -319,6 +421,10 @@ func (d *Decl) Type() *Type {
 	return d.Var.T
 }
 
+func (d *TypedDeclStmt) Token() *lexer.Token {
+	return d.token
+}
+
 func (d *TypedDeclStmt) String() string {
 	return d.Decl.String()
 }
@@ -327,12 +433,20 @@ func (d *TypedDeclStmt) Type() *Type {
 	return d.Decl.Var.T
 }
 
+func (d *InferredDeclStmt) Token() *lexer.Token {
+	return d.token
+}
+
 func (d *InferredDeclStmt) String() string {
 	return d.Decl.String()
 }
 
 func (d *InferredDeclStmt) Type() *Type {
 	return d.Decl.Var.T
+}
+
+func (r *ReturnStmt) Token() *lexer.Token {
+	return r.token
 }
 
 func (r *ReturnStmt) String() string {
@@ -350,6 +464,10 @@ func (*ReturnStmt) AlwaysTerminates() bool {
 	return true
 }
 
+func (b *BreakStmt) Token() *lexer.Token {
+	return b.token
+}
+
 func (*BreakStmt) String() string {
 	return "break"
 }
@@ -360,6 +478,10 @@ func (*BreakStmt) Type() *Type {
 
 func (b *BreakStmt) AlwaysTerminates() bool {
 	return true
+}
+
+func (a *AssignmentStmt) Token() *lexer.Token {
+	return a.token
 }
 
 func (a *AssignmentStmt) String() string {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -130,16 +130,16 @@ func TestFunccallError(t *testing.T) {
 		ReturnType: NONE_TYPE,
 	}
 	tests := map[string]string{
-		`len 2 2`:    "line 1 column 8: 'len' takes 1 argument, found 2",
+		`len 2 2`:    "line 1 column 7: 'len' takes 1 argument, found 2",
 		`len`:        "line 1 column 4: 'len' takes 1 argument, found 0",
 		`a := print`: "line 1 column 11: invalid declaration, function 'print' has no return value",
 		`a := f0`:    "line 1 column 8: invalid declaration, function 'f0' has no return value",
-		`f0 "arg"`:   "line 1 column 9: 'f0' takes 0 arguments, found 1",
+		`f0 "arg"`:   "line 1 column 4: 'f0' takes 0 arguments, found 1",
 		`f2`:         "line 1 column 3: 'f2' takes 1 argument, found 0",
 		`f2 f1`:      "line 1 column 4: function call must be parenthesized: (f1 ...)",
-		`f1 "arg"`:   "line 1 column 9: 'f1' takes variadic arguments of type 'num', found 'string'",
-		`f3 1 2`:     "line 1 column 7: 'f3' takes 2nd argument of type 'string', found 'num'",
-		`f3 "1" "2"`: "line 1 column 11: 'f3' takes 1st argument of type 'num', found 'string'",
+		`f1 "arg"`:   "line 1 column 4: 'f1' takes variadic arguments of type 'num', found 'string'",
+		`f3 1 2`:     "line 1 column 6: 'f3' takes 2nd argument of type 'string', found 'num'",
+		`f3 "1" "2"`: "line 1 column 4: 'f3' takes 1st argument of type 'num', found 'string'",
 		`foo 0`:      "line 1 column 1: unknown function 'foo'",
 	}
 	for input, err1 := range tests {

--- a/pkg/wasm/imports.go
+++ b/pkg/wasm/imports.go
@@ -114,6 +114,14 @@ func jsRead() float64
 //export jsPrint
 func jsPrint(string)
 
+// jsError is imported from JS. jsError is used for setting compile time
+// errors of format:
+//
+//	line NUM column NUM: ERROR_DETAILS
+//
+//export jsError
+func jsError(string)
+
 // afterStop is imported from JS
 //
 //export afterStop

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -23,7 +23,7 @@ func main() {
 	input := getEvySource()
 	ast, err := parse(input, rt)
 	if err != nil {
-		rt.Print(err.Error())
+		jsError(err.Error())
 		return
 	}
 	if actions["fmt"] {


### PR DESCRIPTION
Highlight lines with evy errors in editor. This is done by finding the
correct token by its line and columns and adding the "err" CSS class to it.
It is becoming increasingly obvious that a more fully fledged web code
editor will be needed. Evy files with more than 700ish lines are starting
to get janky when editing. I could work around this by only updating the
relevant lines, but it all seems to get a bit to hacky.

housekeeping: Do a one-off lint pass with stylelint of CSS(requires node
to which I'm not yet ready to commit.)