### PR TITLE
frontend: Reset error highlight on start

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -203,6 +203,7 @@ async function start() {
   stopped = false
   errors = false
   wasmInst = await WebAssembly.instantiate(wasmModule, go.importObject)
+  editor.update({ errorLines: {} })
   clearOutput()
 
   const runButton = document.querySelector("#run")

--- a/frontend/module/yace-editor.js
+++ b/frontend/module/yace-editor.js
@@ -77,6 +77,7 @@ export default class Yace {
 
     if (
       (value === this.value || value == null) &&
+      Object.keys(this.errorLines).length === 0 &&
       (!errorLines || Object.keys(errorLines).length === 0)
     ) {
       return


### PR DESCRIPTION
Reset error highlight on start (run), so that the error highlight so
that we accurately display new errors or no errors if they are gone.
Previously errors only got reset if the line was updated which
incorrectly kept error line highlight for follow-on errors, e.g.:

	x := "foo"  // line 1: 'x' declared but not used
	print y     // line 2: unknown variable name 'y'

Fixed as

	x := "foo"  // 💣 error remained: line 1: 'x' declared but not used
	print x     // no error

Now all errors get reset.