### PR TITLE
evy: Add drawing style functions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -26,6 +26,7 @@ linters:
     - gomnd
     - ifshort
     - interfacer
+    - interfacebloat
     - ireturn
     - lll
     - maligned

--- a/frontend/courses/courses.json
+++ b/frontend/courses/courses.json
@@ -22,7 +22,9 @@
         { "id": "dot", "title": "Red Dot" },
         { "id": "lines", "title": "Lines" },
         { "id": "squares", "title": "Squares" },
-        { "id": "rainbow", "title": "Rainbow" }
+        { "id": "rainbow", "title": "Rainbow" },
+        { "id": "fill", "title": "Stroke and Fill" },
+        { "id": "linestyle", "title": "Line Styles" }
       ]
     },
     {

--- a/frontend/courses/sample/draw/fill.evy
+++ b/frontend/courses/sample/draw/fill.evy
@@ -1,0 +1,44 @@
+width 2
+
+move 10 65
+color "red"
+circle 7
+move 3 40
+rect 14 14
+move 3 35
+line 17 35
+
+move 30 65
+stroke "blue"
+circle 7
+move 23 40
+rect 14 14
+move 23 35
+line 37 35
+
+move 50 65
+color "green"
+fill "orange"
+circle 7
+move 43 40
+rect 14 14
+move 43 35
+line 57 35
+
+move 70 65
+stroke "deeppink"
+fill "cyan"
+circle 7
+move 63 40
+rect 14 14
+move 63 35
+line 77 35
+
+move 90 65
+stroke "violet"
+fill "none"
+circle 7
+move 83 40
+rect 14 14
+move 83 35
+line 97 35

--- a/frontend/courses/sample/draw/linestyle.evy
+++ b/frontend/courses/sample/draw/linestyle.evy
@@ -1,0 +1,21 @@
+width 3
+linecap "round"
+move 5 80
+line 95 80
+
+linecap "butt"
+move 5 70
+line 95 70
+
+linecap "square"
+move 5 60
+line 95 60
+
+width 1
+move 5 30
+dash 5 3 1 3
+line 95 30
+
+dash
+move 5 20
+line 95 20

--- a/frontend/module/yace-editor.js
+++ b/frontend/module/yace-editor.js
@@ -474,6 +474,11 @@ const builtins = new Set([
   "width",
   "color",
   "colour",
+  "clear",
+  "stroke",
+  "fill",
+  "dash",
+  "linecap",
 ])
 
 const keywords = new Set([

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -90,6 +90,11 @@ func DefaultBuiltins(rt Runtime) Builtins {
 		"color":  stringBuiltin("color", rt.Color),
 		"colour": stringBuiltin("colour", rt.Color),
 		"clear":  {Func: clearFunc(rt.Clear), Decl: clearDecl},
+
+		"stroke":  stringBuiltin("stroke", rt.Stroke),
+		"fill":    stringBuiltin("fill", rt.Fill),
+		"dash":    {Func: dashFunc(rt.Dash), Decl: dashDecl},
+		"linecap": stringBuiltin("linecap", rt.Linecap),
 	}
 	xyParams := []*parser.Var{
 		{Name: "x", T: parser.NUM_TYPE},
@@ -137,6 +142,12 @@ type GraphicsRuntime interface {
 	Width(w float64)
 	Color(s string)
 	Clear(color string)
+
+	// advanced graphics functions
+	Stroke(s string)
+	Fill(s string)
+	Dash(segments []float64)
+	Linecap(s string)
 }
 
 type UnimplementedRuntime struct {
@@ -155,16 +166,20 @@ func (rt *UnimplementedRuntime) Unimplemented(s string) {
 	rt.Print(fmt.Sprintf("%q not implemented\n", s))
 }
 
-func (rt *UnimplementedRuntime) Read() string          { rt.Unimplemented("read"); return "" }
-func (rt *UnimplementedRuntime) Sleep(_ time.Duration) { rt.Unimplemented("sleep") }
-func (rt *UnimplementedRuntime) Yielder() Yielder      { rt.Unimplemented("yielder"); return nil }
-func (rt *UnimplementedRuntime) Move(x, y float64)     { rt.Unimplemented("move") }
-func (rt *UnimplementedRuntime) Line(x, y float64)     { rt.Unimplemented("line") }
-func (rt *UnimplementedRuntime) Rect(x, y float64)     { rt.Unimplemented("rect") }
-func (rt *UnimplementedRuntime) Circle(r float64)      { rt.Unimplemented("circle") }
-func (rt *UnimplementedRuntime) Width(w float64)       { rt.Unimplemented("width") }
-func (rt *UnimplementedRuntime) Color(s string)        { rt.Unimplemented("color") }
-func (rt *UnimplementedRuntime) Clear(color string)    { rt.Unimplemented("clear") }
+func (rt *UnimplementedRuntime) Read() string            { rt.Unimplemented("read"); return "" }
+func (rt *UnimplementedRuntime) Sleep(_ time.Duration)   { rt.Unimplemented("sleep") }
+func (rt *UnimplementedRuntime) Yielder() Yielder        { rt.Unimplemented("yielder"); return nil }
+func (rt *UnimplementedRuntime) Move(x, y float64)       { rt.Unimplemented("move") }
+func (rt *UnimplementedRuntime) Line(x, y float64)       { rt.Unimplemented("line") }
+func (rt *UnimplementedRuntime) Rect(x, y float64)       { rt.Unimplemented("rect") }
+func (rt *UnimplementedRuntime) Circle(r float64)        { rt.Unimplemented("circle") }
+func (rt *UnimplementedRuntime) Width(w float64)         { rt.Unimplemented("width") }
+func (rt *UnimplementedRuntime) Color(s string)          { rt.Unimplemented("color") }
+func (rt *UnimplementedRuntime) Clear(color string)      { rt.Unimplemented("clear") }
+func (rt *UnimplementedRuntime) Stroke(s string)         { rt.Unimplemented("stroke") }
+func (rt *UnimplementedRuntime) Fill(s string)           { rt.Unimplemented("fill") }
+func (rt *UnimplementedRuntime) Dash(segments []float64) { rt.Unimplemented("dash") }
+func (rt *UnimplementedRuntime) Linecap(s string)        { rt.Unimplemented("linecap") }
 
 var readDecl = &parser.FuncDeclStmt{
 	Name:       "read",
@@ -542,6 +557,23 @@ func clearFunc(clearFn func(string)) BuiltinFunc {
 			color = args[0].(*String).Val
 		}
 		clearFn(color)
+		return nil, nil
+	}
+}
+
+var dashDecl = &parser.FuncDeclStmt{
+	Name:          "dash",
+	VariadicParam: &parser.Var{Name: "segments", T: parser.NUM_TYPE},
+	ReturnType:    parser.NONE_TYPE,
+}
+
+func dashFunc(dashFn func([]float64)) BuiltinFunc {
+	return func(_ *scope, args []Value) (Value, error) {
+		segments := make([]float64, len(args))
+		for i, arg := range args {
+			segments[i] = arg.(*Num).Val
+		}
+		dashFn(segments)
 		return nil, nil
 	}
 }

--- a/pkg/wasm/imports.go
+++ b/pkg/wasm/imports.go
@@ -8,6 +8,8 @@ package main
 // implement evaluator.Runtime.
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"foxygo.at/evy/pkg/evaluator"
@@ -24,6 +26,7 @@ func newJSRuntime() *jsRuntime {
 	return &jsRuntime{yielder: newSleepingYielder()}
 }
 
+func (rt *jsRuntime) Yielder() evaluator.Yielder { return rt.yielder }
 func (*jsRuntime) Print(s string)                { jsPrint(s) }
 func (rt *jsRuntime) Read() string               { return rt.yielder.Read() }
 func (rt *jsRuntime) Sleep(dur time.Duration)    { rt.yielder.Sleep(dur) }
@@ -34,7 +37,21 @@ func (rt *jsRuntime) Circle(r float64)           { circle(r) }
 func (rt *jsRuntime) Width(w float64)            { width(w) }
 func (rt *jsRuntime) Color(s string)             { color(s) }
 func (rt *jsRuntime) Clear(color string)         { clear(color) }
-func (rt *jsRuntime) Yielder() evaluator.Yielder { return rt.yielder }
+func (rt *jsRuntime) Stroke(s string)            { stroke(s) }
+func (rt *jsRuntime) Fill(s string)              { fill(s) }
+func (rt *jsRuntime) Dash(segments []float64)    { dash(floatsToString(segments)) }
+func (rt *jsRuntime) Linecap(s string)           { linecap(s) }
+
+func floatsToString(floats []float64) string {
+	if len(floats) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for _, f := range floats {
+		sb.WriteString(fmt.Sprintf(" %f", f))
+	}
+	return sb.String()[1:]
+}
 
 // sleepingYielder yields the CPU so that JavaScript/browser events
 // get a chance to be processed. Currently(Feb 2023) it seems that you
@@ -162,6 +179,24 @@ func color(s string)
 //
 //export clear
 func clear(s string)
+
+//export stroke
+func stroke(s string)
+
+// fill is imported from JS
+//
+//export fill
+func fill(s string)
+
+// dash is imported from JS
+//
+//export dash
+func dash(s string)
+
+// linecap is imported from JS
+//
+//export linecap
+func linecap(s string)
 
 // setEvySource is imported from JS
 //


### PR DESCRIPTION
Add drawing style functions stroke, fill, dash, and linecap defined in
the same terms as HTML canvas styling, with the addition of `"none"`
for stroke and fill.

New examples:

- https://evy-lang--123-x8t7erj2.web.app/#linestyle
- https://evy-lang--123-x8t7erj2.web.app/#fill