### PR TITLE
evy: Add canvas text builtins

### DIFF
--- a/frontend/courses/courses.json
+++ b/frontend/courses/courses.json
@@ -24,7 +24,8 @@
         { "id": "squares", "title": "Squares" },
         { "id": "rainbow", "title": "Rainbow" },
         { "id": "fill", "title": "Stroke and Fill" },
-        { "id": "linestyle", "title": "Line Styles" }
+        { "id": "linestyle", "title": "Line Styles" },
+        { "id": "text", "title": "Text" }
       ]
     },
     {

--- a/frontend/courses/sample/draw/text.evy
+++ b/frontend/courses/sample/draw/text.evy
@@ -1,0 +1,17 @@
+move 10 80
+text "Hello"
+
+move 10 60
+textsize 10
+text "all 🖖"
+
+move 10 40
+fontfamily "Luminari, fantasy"
+text "Cheriolas!"
+
+move 10 35
+fill "grey"
+// font maps directly to the CSS font property; see:
+// https://developer.mozilla.org/en-US/docs/Web/CSS/font
+font "italic max(2rem, 2vh) \"Comic Sans MS\", cursive"
+text "(Cheering Charm)"

--- a/frontend/module/yace-editor.js
+++ b/frontend/module/yace-editor.js
@@ -479,6 +479,10 @@ const builtins = new Set([
   "fill",
   "dash",
   "linecap",
+  "text",
+  "textsize",
+  "fontfamily",
+  "font",
 ])
 
 const keywords = new Set([

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -95,6 +95,11 @@ func DefaultBuiltins(rt Runtime) Builtins {
 		"fill":    stringBuiltin("fill", rt.Fill),
 		"dash":    {Func: dashFunc(rt.Dash), Decl: dashDecl},
 		"linecap": stringBuiltin("linecap", rt.Linecap),
+
+		"text":       stringBuiltin("text", rt.Text),
+		"textsize":   numBuiltin("textsize", rt.Textsize),
+		"font":       stringBuiltin("font", rt.Font),
+		"fontfamily": stringBuiltin("fontfamily", rt.Fontfamily),
 	}
 	xyParams := []*parser.Var{
 		{Name: "x", T: parser.NUM_TYPE},
@@ -148,6 +153,10 @@ type GraphicsRuntime interface {
 	Fill(s string)
 	Dash(segments []float64)
 	Linecap(s string)
+	Text(s string)
+	Textsize(size float64)
+	Font(s string)
+	Fontfamily(s string)
 }
 
 type UnimplementedRuntime struct {
@@ -180,6 +189,10 @@ func (rt *UnimplementedRuntime) Stroke(s string)         { rt.Unimplemented("str
 func (rt *UnimplementedRuntime) Fill(s string)           { rt.Unimplemented("fill") }
 func (rt *UnimplementedRuntime) Dash(segments []float64) { rt.Unimplemented("dash") }
 func (rt *UnimplementedRuntime) Linecap(s string)        { rt.Unimplemented("linecap") }
+func (rt *UnimplementedRuntime) Text(s string)           { rt.Unimplemented("text") }
+func (rt *UnimplementedRuntime) Textsize(size float64)   { rt.Unimplemented("textsize") }
+func (rt *UnimplementedRuntime) Font(s string)           { rt.Unimplemented("font") }
+func (rt *UnimplementedRuntime) Fontfamily(s string)     { rt.Unimplemented("fontfamily") }
 
 var readDecl = &parser.FuncDeclStmt{
 	Name:       "read",

--- a/pkg/wasm/imports.go
+++ b/pkg/wasm/imports.go
@@ -41,6 +41,10 @@ func (rt *jsRuntime) Stroke(s string)            { stroke(s) }
 func (rt *jsRuntime) Fill(s string)              { fill(s) }
 func (rt *jsRuntime) Dash(segments []float64)    { dash(floatsToString(segments)) }
 func (rt *jsRuntime) Linecap(s string)           { linecap(s) }
+func (rt *jsRuntime) Text(s string)              { text(s) }
+func (rt *jsRuntime) Textsize(size float64)      { textsize(size) }
+func (rt *jsRuntime) Font(s string)              { font(s) }
+func (rt *jsRuntime) Fontfamily(s string)        { fontfamily(s) }
 
 func floatsToString(floats []float64) string {
 	if len(floats) == 0 {
@@ -197,6 +201,26 @@ func dash(s string)
 //
 //export linecap
 func linecap(s string)
+
+// text is imported from JS
+//
+//export text
+func text(s string)
+
+// textsize is imported from JS
+//
+//export textsize
+func textsize(s float64)
+
+// font is imported from JS
+//
+//export font
+func font(s string)
+
+// fontfamily is imported from JS
+//
+//export fontfamily
+func fontfamily(s string)
 
 // setEvySource is imported from JS
 //


### PR DESCRIPTION
Add canvas text builtins `text`, `textsize`, `fontfamily`, and `font`.
Add new example #text. These new primitives are only concerned with
text and text styles on the evy output canvas.