### PR TITLE
evy: Add canvas poly builtin

### DIFF
--- a/frontend/courses/courses.json
+++ b/frontend/courses/courses.json
@@ -23,6 +23,7 @@
         { "id": "lines", "title": "Lines" },
         { "id": "squares", "title": "Squares" },
         { "id": "rainbow", "title": "Rainbow" },
+        { "id": "poly", "title": "Polygon and Polyline" },
         { "id": "fill", "title": "Stroke and Fill" },
         { "id": "linestyle", "title": "Line Styles" },
         { "id": "text", "title": "Text" }

--- a/frontend/courses/sample/draw/poly.evy
+++ b/frontend/courses/sample/draw/poly.evy
@@ -1,0 +1,8 @@
+width 1
+color "red"
+
+fill "none"
+poly [10 80] [30 60] [50 80] [70 60] [90 80]
+
+fill "gold"
+poly [10 20] [50 50] [20 10] [10 20]

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -56,6 +56,7 @@ function newEvyGo() {
     color,
     clear,
     // advanced canvas
+    poly,
     stroke,
     fill,
     dash,
@@ -95,6 +96,7 @@ function needsCanvas(f) {
     f.color ||
     f.colour ||
     f.clear ||
+    f.poly ||
     f.stroke ||
     f.fill ||
     f.dash ||
@@ -512,6 +514,31 @@ function clear(ptr, len) {
   ctx.fillStyle = color
   ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height)
   ctx.fillStyle = prevColor
+}
+
+// poly is exported to evy go/wasm.
+function poly(ptr, len) {
+  const { x, y, ctx, fill, stroke } = canvas
+  const s = memToString(ptr, len)
+  const points = parsePoints(s)
+  ctx.beginPath()
+  ctx.moveTo(transformX(points[0][0]), transformY(points[0][1]))
+  for (const point of points.slice(1)) {
+    const x = transformX(point[0])
+    const y = transformY(point[1])
+    ctx.lineTo(x, y)
+  }
+  fill && ctx.fill()
+  stroke && ctx.stroke()
+}
+
+function parsePoints(s) {
+  const arr = s.split(" ")
+  const points = []
+  for (let i = 0; i < arr.length; i += 2) {
+    points.push([Number(arr[i]), Number(arr[i + 1])])
+  }
+  return points
 }
 
 // stroke is exported to evy go/wasm.

--- a/frontend/module/yace-editor.js
+++ b/frontend/module/yace-editor.js
@@ -467,7 +467,6 @@ const builtins = new Set([
   "rand",
   "rand1",
   "move",
-  "read",
   "line",
   "rect",
   "circle",

--- a/frontend/module/yace-editor.js
+++ b/frontend/module/yace-editor.js
@@ -474,6 +474,7 @@ const builtins = new Set([
   "color",
   "colour",
   "clear",
+  "poly",
   "stroke",
   "fill",
   "dash",

--- a/pkg/wasm/imports.go
+++ b/pkg/wasm/imports.go
@@ -45,6 +45,13 @@ func (rt *jsRuntime) Text(s string)              { text(s) }
 func (rt *jsRuntime) Textsize(size float64)      { textsize(size) }
 func (rt *jsRuntime) Font(s string)              { font(s) }
 func (rt *jsRuntime) Fontfamily(s string)        { fontfamily(s) }
+func (rt *jsRuntime) Poly(vertices [][]float64) {
+	vStrings := make([]string, len(vertices))
+	for i, vertex := range vertices {
+		vStrings[i] = fmt.Sprintf("%f %f", vertex[0], vertex[1])
+	}
+	poly(strings.Join(vStrings, " "))
+}
 
 func floatsToString(floats []float64) string {
 	if len(floats) == 0 {
@@ -184,6 +191,13 @@ func color(s string)
 //export clear
 func clear(s string)
 
+// poly is imported from JS
+//
+//export poly
+func poly(s string)
+
+// stroke is imported from JS
+//
 //export stroke
 func stroke(s string)
 


### PR DESCRIPTION
Add canvas poly builtin to draw polylines and polygons.

New sample:
https://evy-lang--125-ofi7tbe4.web.app/#poly