### PR TITLE
frontend: Fix pointermove event for mobile

### DIFF
--- a/frontend/index.css
+++ b/frontend/index.css
@@ -384,6 +384,7 @@ main.view-output {
 .output .canvas canvas {
   width: 100%;
   height: 100%;
+  touch-action: pinch-zoom;
 }
 .read {
   display: flex;


### PR DESCRIPTION
Fix pointermove event for mobile touch according to
https://stackoverflow.com/a/48254578

It seems that on mobile the browser captures pointermove events for its
own use (scrolling). This can be disabled with the CSS property
`touch-action: none;`. However, this is not preferable for
accessibility cases, so still allow pinch to zoom.

Tested on Android and iPad

The following sample now also works on mobile:
https://evy-lang--126-hesnlymh.web.app/#draw