### PR TITLE
evaluator: Don't nest function scope inside other function scope

### DIFF
--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -56,6 +56,35 @@ func TestParseDecl(t *testing.T) {
 	}
 }
 
+func TestFuncScope(t *testing.T) {
+	prog := `
+f := "🦊"
+
+func outer
+    f := "🐤"
+    print f
+    if true
+        f := "🎈"
+        print f
+        inner
+        print f
+    end
+    print f
+end
+
+func inner
+    print f
+end
+
+print f
+outer
+print f
+`
+	want := "🦊\n🐤\n🎈\n🦊\n🎈\n🐤\n🦊\n"
+	got := run(prog)
+	assert.Equal(t, want, got)
+}
+
 func TestReturn(t *testing.T) {
 	prog := `
 func fox:string


### PR DESCRIPTION
Do not nest a function scope inside another function scope, since we do
not look up variables across function scopes. A function scope should be
based on the global scope only (and this includes handler scopes too,
which are just a function in disguise).

This program would print "2" instead of "1" as `f2` was traversing the
scope of `f1` when looking up `a` to print. It should skip `f1` and go
straight to the global scope:

    a := 1
    func f1
      a := 2
      f2
    end
    func f2
      print a
    end
    f1