### PR TITLE
evaluator: Implement short-circuit evaluation of AND/OR

### DIFF
--- a/docs/syntax_grammar.md
+++ b/docs/syntax_grammar.md
@@ -473,10 +473,12 @@ division and the [modulo operator]. `+` may also be used as
 concatenation operator for `string` and `array` types. 
 
 Boolean operators `and`, `or` stand for [logical conjunction (AND)] and
-[logical disjunction (OR)]. Comparison operators `<`  `<=`  `>`  `>=`
-stand for less, less or equal, greater, greater or equal. Their
-operands may be `num` or `string` values. For `string` types
-[lexicographical comparison] is used.
+[logical disjunction (OR)]. They perform [short-circuit evaluation]
+where the right-hand side of the operator is not evaluated if the result
+of the operation can be determined from the left-hand side alone.
+Comparison operators `<`  `<=`  `>`  `>=` stand for less, less or equal,
+greater, greater or equal. Their operands may be `num` or `string`
+values. For `string` types [lexicographical comparison] is used.
 
 The unary operator `-` stands for the negative sign and can only be used
 with `num`. The unary operator `!` stands for [logical negation] and
@@ -495,6 +497,7 @@ See section [whitespace](#whitespace) for further details.
 [modulo operator]: https://en.wikipedia.org/wiki/Modulo_operation
 [logical conjunction (AND)]: https://en.wikipedia.org/wiki/Truth_table#Logical_conjunction_(AND)
 [logical disjunction (OR)]: https://en.wikipedia.org/wiki/Truth_table#Logical_disjunction_(OR)
+[short-circuit evaluation]: https://en.wikipedia.org/wiki/Short-circuit_evaluation
 [logical negation]: https://en.wikipedia.org/wiki/Truth_table#Logical_negation
 [lexicographical comparison]: https://en.wikipedia.org/wiki/Lexicographic_order
 

--- a/frontend/courses/courses.json
+++ b/frontend/courses/courses.json
@@ -42,6 +42,12 @@
       ]
     },
     {
+      "id": "sample/games",
+      "title": "Games",
+      "emoji": "🎱",
+      "units": [{ "id": "hanoi", "title": "Towers of Hanoi" }]
+    },
+    {
       "id": "course-01",
       "title": "Learn Coding",
       "emoji": "🌱",

--- a/frontend/courses/sample/games/hanoi.evy
+++ b/frontend/courses/sample/games/hanoi.evy
@@ -1,0 +1,75 @@
+// towers of hanoi
+
+colors := ["red" "orange" "gold" "green" "blue" "darkviolet" "violet" "black"]
+towers := [
+    []
+    [8 7 6 5 4 3 2 1]
+    []
+]
+
+selected := -1
+start_tower := 1
+num_pieces := (len towers[start_tower])
+
+// Drawing / positioning
+towerx := [17 50 83]
+w := 5 // line width
+basey := 20
+
+width w
+linecap "round"
+
+func draw_towers
+    clear "white"
+    color "black"
+    move 0 basey-(w / 2)
+    line 100 basey-(w / 2)
+    for tower := range 3
+        x := towerx[tower]
+        color "black"
+        move x basey
+        line x basey+42
+        for n := range (len towers[tower])
+            y := n * w + (w / 2) + basey
+            if tower == selected and n == (len towers[tower]) - 1
+                y = y + w
+            end
+            piece := towers[tower][n]
+            piece_width := piece * 3 + 5
+            color colors[piece - 1]
+            move x-(piece_width / 2) y
+            line x+(piece_width / 2) y
+        end
+    end
+end
+
+on down x:num _:num
+    tower := floor x/100*3
+    if selected == -1 and (len towers[tower]) == 0
+        print "No pieces on that tower!"
+        return
+    else if selected == -1
+        selected = tower
+    else if selected == tower
+        selected = -1
+    else
+        move_piece selected tower
+        selected = -1
+    end
+    draw_towers
+end
+
+func move_piece from:num to:num
+    if (len towers[to]) > 0 and towers[from][-1] > towers[to][-1]
+        print "Piece too big to move there."
+        return
+    end
+    towers[to] = towers[to] + [towers[from][-1]]
+    towers[from] = towers[from][:-1]
+    if to != start_tower and (len towers[to]) == num_pieces
+        print "You win. Have some confetti."
+        start_tower = to
+    end
+end
+
+draw_towers


### PR DESCRIPTION
Implement short-circuiting of the AND and OR operators so that the
right-hand side is not evaluated if the result can be determined by the
left-hand side. For AND, this means left == false, since the whole
expression will be false regardless of what right is. For OR, this means
left == true, for the same reason.

Update the spec to say these operators perform short-circuit evaluation.

Add a Towers of Hanoi evy program with a new "Games" section in the
course. This program uses short-circuit evaluation to protect against
indexing an array out of bounds, hence its presence with this change.