### PR TITLE
eval: Add token location to evaluator errors

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -14,6 +14,7 @@ let sampleData
 let actions = "fmt,ui,eval"
 let editor
 let errors = false
+
 // --- Initialise ------------------------------------------------------
 
 initWasm()
@@ -147,11 +148,16 @@ function jsError(ptr, len) {
   const code = editor.value
   const lines = code.split("\n")
   const errs = memToString(ptr, len).split("\n")
-  const re = /line (?<line>\d+) column (?<col>\d+): (?<msg>.*)/
+  const re = /line (?<line>\d+) column (?<col>\d+):( runtime error:)? (?<msg>.*)/
   let msgs = ""
   const errorLines = {}
   for (const err of errs) {
-    const g = err.match(re).groups
+    const m = err.match(re)
+    if (!m) {
+      msgs += err + "\n"
+      continue
+    }
+    const g = m.groups
     if (!errorLines[g.line]) {
       errorLines[g.line] = { col: g.col, text: lines[g.line - 1] }
     }

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -17,19 +17,20 @@ var (
 	ErrStopped = errors.New("stopped")
 
 	ErrRuntime       = errors.New("runtime error")
-	ErrAnyConversion = fmt.Errorf("%w:  error converting any to type", ErrRuntime)
+	ErrBounds        = fmt.Errorf("%w: index out of bounds", ErrRuntime)
 	ErrRangeValue    = fmt.Errorf("%w: bad range value", ErrRuntime)
 	ErrMapKey        = fmt.Errorf("%w: no value for map key", ErrRuntime)
-	ErrSlice         = fmt.Errorf("%w: invalid slice", ErrRuntime)
+	ErrSlice         = fmt.Errorf("%w: bad slice", ErrRuntime)
 	ErrBadArguments  = fmt.Errorf("%w: bad arguments", ErrRuntime)
+	ErrAnyConversion = fmt.Errorf("%w: error converting any to type", ErrRuntime)
 
 	ErrInternal         = errors.New("internal error")
 	ErrUnknownNode      = fmt.Errorf("%w: unknown AST node", ErrInternal)
 	ErrType             = fmt.Errorf("%w: type error", ErrInternal)
-	ErrRangeType        = fmt.Errorf("%w: invalid range type", ErrInternal)
+	ErrRangeType        = fmt.Errorf("%w: bad range type", ErrInternal)
 	ErrNoVarible        = fmt.Errorf("%w: no variable", ErrInternal)
 	ErrOperation        = fmt.Errorf("%w: unknown operation", ErrInternal)
-	ErrAssignmentTarget = fmt.Errorf("%w: invalid assignment target", ErrInternal)
+	ErrAssignmentTarget = fmt.Errorf("%w: bad assignment target", ErrInternal)
 )
 
 func NewEvaluator(builtins Builtins) *Evaluator {

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -698,15 +698,17 @@ func (e *Evaluator) evalSliceExpr(expr *parser.SliceExpression) (Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	start, err := e.evalIfNotNil(expr.Start)
-	if err != nil {
-		return nil, err
+	var start, end Value
+	if expr.Start != nil {
+		if start, err = e.Eval(expr.Start); err != nil {
+			return nil, err
+		}
 	}
-	end, err := e.evalIfNotNil(expr.End)
-	if err != nil {
-		return nil, err
+	if expr.End != nil {
+		if end, err = e.Eval(expr.End); err != nil {
+			return nil, err
+		}
 	}
-
 	var val Value
 	switch left := left.(type) {
 	case *Array:
@@ -720,13 +722,6 @@ func (e *Evaluator) evalSliceExpr(expr *parser.SliceExpression) (Value, error) {
 		return nil, newErr(expr, err)
 	}
 	return val, nil
-}
-
-func (e *Evaluator) evalIfNotNil(n parser.Node) (Value, error) {
-	if n == nil {
-		return nil, nil
-	}
-	return e.Eval(n)
 }
 
 func (e *Evaluator) pushScope() {

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -10,6 +10,7 @@ import (
 	"math/rand"
 	"time"
 
+	"foxygo.at/evy/pkg/lexer"
 	"foxygo.at/evy/pkg/parser"
 )
 
@@ -32,6 +33,20 @@ var (
 	ErrOperation        = fmt.Errorf("%w: unknown operation", ErrInternal)
 	ErrAssignmentTarget = fmt.Errorf("%w: bad assignment target", ErrInternal)
 )
+
+// Error is an Evy evaluator error.
+type Error struct {
+	err   error
+	token *lexer.Token
+}
+
+func (e *Error) Error() string {
+	return e.token.Location() + ": " + e.err.Error()
+}
+
+func newErr(node parser.Node, err error) *Error {
+	return &Error{token: node.Token(), err: err}
+}
 
 func NewEvaluator(builtins Builtins) *Evaluator {
 	rand.Seed(time.Now().UnixNano())
@@ -159,7 +174,7 @@ func (e *Evaluator) HandleEvent(ev Event) error {
 	for i, param := range eh.Params {
 		arg, err := valueFromAny(param.Type(), args[i])
 		if err != nil {
-			return err
+			return newErr(param, err)
 		}
 		e.scope.set(param.Name, arg)
 	}
@@ -251,7 +266,11 @@ func (e *Evaluator) evalFunccall(funcCall *parser.FuncCall) (Value, error) {
 	}
 	builtin, ok := e.builtins.Funcs[funcCall.Name]
 	if ok {
-		return builtin.Func(e.scope, args)
+		val, err := builtin.Func(e.scope, args)
+		if err != nil {
+			return nil, newErr(funcCall, err)
+		}
+		return val, nil
 	}
 	restoreScope := e.pushFuncScope()
 	defer restoreScope()
@@ -378,7 +397,7 @@ func (e *Evaluator) newRange(f *parser.ForStmt) (ranger, error) {
 		}
 		return mapRange, nil
 	}
-	return nil, fmt.Errorf("%w: %s", ErrRangeType, f.Range)
+	return nil, newErr(f.Range, ErrRangeType)
 }
 
 func (e *Evaluator) newStepRange(r *parser.StepRange, loopVar *parser.Var) (ranger, error) {
@@ -395,7 +414,7 @@ func (e *Evaluator) newStepRange(r *parser.StepRange, loopVar *parser.Var) (rang
 		return nil, err
 	}
 	if step == 0 {
-		return nil, fmt.Errorf("%w: step cannot by 0, infinite loop", ErrRangeValue)
+		return nil, newErr(r, fmt.Errorf("%w: step cannot be 0, infinite loop", ErrRangeValue))
 	}
 
 	sRange := &stepRange{
@@ -418,7 +437,7 @@ func (e *Evaluator) numVal(n parser.Node) (float64, error) {
 	}
 	numVal, ok := v.(*Num)
 	if !ok {
-		return 0, fmt.Errorf("%w: expected number, found %v", ErrType, v)
+		return 0, newErr(n, fmt.Errorf("%w: expected number, found %v", ErrType, v))
 	}
 	return numVal.Val, nil
 }
@@ -439,7 +458,8 @@ func (e *Evaluator) evalConditionalBlock(condBlock *parser.ConditionalBlock) (Va
 	}
 	boolCond, ok := cond.(*Bool)
 	if !ok {
-		return nil, false, fmt.Errorf("%w: conditional not a bool", ErrType)
+		err := fmt.Errorf("%w: conditional not a bool", ErrType)
+		return nil, false, newErr(condBlock.Condition, err)
 	}
 	if boolCond.Val {
 		val, err := e.Eval(condBlock.Block)
@@ -456,7 +476,7 @@ func (e *Evaluator) evalVar(v *parser.Var) (Value, error) {
 	if val, ok := e.scope.get(v.Name); ok {
 		return val, nil
 	}
-	return nil, fmt.Errorf("%w: %s", ErrNoVarible, v.Name)
+	return nil, newErr(v, fmt.Errorf("%w: %s", ErrNoVarible, v.Name))
 }
 
 func (e *Evaluator) evalExprList(terms []parser.Node) ([]Value, error) {
@@ -489,7 +509,7 @@ func (e *Evaluator) evalUnaryExpr(expr *parser.UnaryExpression) (Value, error) {
 			return &Bool{Val: !right.Val}, nil
 		}
 	}
-	return nil, fmt.Errorf("%w (unary): %v", ErrOperation, expr)
+	return nil, newErr(expr, fmt.Errorf("%w (unary): %v", ErrOperation, expr))
 }
 
 func (e *Evaluator) evalBinaryExpr(expr *parser.BinaryExpression) (Value, error) {
@@ -515,17 +535,23 @@ func (e *Evaluator) evalBinaryExpr(expr *parser.BinaryExpression) (Value, error)
 	if op == parser.OP_NOT_EQ {
 		return &Bool{Val: !left.Equals(right)}, nil
 	}
+	var val Value
 	switch l := left.(type) {
 	case *Num:
-		return evalBinaryNumExpr(op, l, right.(*Num))
+		val, err = evalBinaryNumExpr(op, l, right.(*Num))
 	case *String:
-		return evalBinaryStringExpr(op, l, right.(*String))
+		val, err = evalBinaryStringExpr(op, l, right.(*String))
 	case *Bool:
-		return evalBinaryBoolExpr(op, l, right.(*Bool))
+		val, err = evalBinaryBoolExpr(op, l, right.(*Bool))
 	case *Array:
-		return evalBinaryArrayExpr(op, l, right.(*Array))
+		val, err = evalBinaryArrayExpr(op, l, right.(*Array))
+	default:
+		err = fmt.Errorf("%w (binary): %v", ErrOperation, expr)
 	}
-	return nil, fmt.Errorf("%w (binary): %v", ErrOperation, expr)
+	if err != nil {
+		return nil, newErr(expr, err)
+	}
+	return val, nil
 }
 
 func canShortCircuit(op parser.Operator, left Value) bool {
@@ -611,7 +637,7 @@ func (e *Evaluator) evalTarget(node parser.Node) (Value, error) {
 	case *parser.DotExpression:
 		return e.evalDotExpr(n, true /* forAssign */)
 	}
-	return nil, fmt.Errorf("%w: %v", ErrAssignmentTarget, node)
+	return nil, newErr(node, fmt.Errorf("%w: %v", ErrAssignmentTarget, node))
 }
 
 func (e *Evaluator) evalIndexExpr(expr *parser.IndexExpression, forAssign bool) (Value, error) {
@@ -624,22 +650,28 @@ func (e *Evaluator) evalIndexExpr(expr *parser.IndexExpression, forAssign bool) 
 		return nil, err
 	}
 
+	var val Value
 	switch l := left.(type) {
 	case *Array:
-		return l.Index(index)
+		val, err = l.Index(index)
 	case *String:
-		return l.Index(index)
+		val, err = l.Index(index)
 	case *Map:
 		strIndex, ok := index.(*String)
 		if !ok {
-			return nil, fmt.Errorf("%w: expected string for map index, found %v", ErrType, index)
+			return nil, newErr(expr.Left, fmt.Errorf("%w: expected string for map index, found %v", ErrType, index))
 		}
 		if forAssign {
 			l.InsertKey(strIndex.Val, expr.Type())
 		}
-		return l.Get(strIndex.Val)
+		val, err = l.Get(strIndex.Val)
+	default:
+		err = fmt.Errorf("%w: expected array, string or map with index, found %v", ErrType, left.Type())
 	}
-	return nil, fmt.Errorf("%w: expected array, string or map with index, found %v", ErrType, left.Type())
+	if err != nil {
+		return nil, newErr(expr, err)
+	}
+	return val, nil
 }
 
 func (e *Evaluator) evalDotExpr(expr *parser.DotExpression, forAssign bool) (Value, error) {
@@ -649,12 +681,16 @@ func (e *Evaluator) evalDotExpr(expr *parser.DotExpression, forAssign bool) (Val
 	}
 	m, ok := left.(*Map)
 	if !ok {
-		return nil, fmt.Errorf("%w: expected map before '.', found  %v", ErrType, left)
+		return nil, newErr(expr, fmt.Errorf("%w: expected map before '.', found %v", ErrType, left))
 	}
 	if forAssign {
 		m.InsertKey(expr.Key, expr.Type())
 	}
-	return m.Get(expr.Key)
+	val, err := m.Get(expr.Key)
+	if err != nil {
+		return nil, newErr(expr, err)
+	}
+	return val, nil
 }
 
 func (e *Evaluator) evalSliceExpr(expr *parser.SliceExpression) (Value, error) {
@@ -670,13 +706,20 @@ func (e *Evaluator) evalSliceExpr(expr *parser.SliceExpression) (Value, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	var val Value
 	switch left := left.(type) {
 	case *Array:
-		return left.Slice(start, end)
+		val, err = left.Slice(start, end)
 	case *String:
-		return left.Slice(start, end)
+		val, err = left.Slice(start, end)
+	default:
+		err = fmt.Errorf("%w: expected string or array before '[', found %v", ErrType, left)
 	}
-	return nil, fmt.Errorf("%w: expected map before '.', found  %v", ErrType, left)
+	if err != nil {
+		return nil, newErr(expr, err)
+	}
+	return val, nil
 }
 
 func (e *Evaluator) evalIfNotNil(n parser.Node) (Value, error) {

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -453,10 +453,10 @@ func TestDoubleIndex(t *testing.T) {
 func TestIndexErr(t *testing.T) {
 	tests := map[string]string{
 		// x := ["a","b","c"]; x = "abc"
-		"print x[3]":  "runtime error: index out of bounds: 3",
-		"print x[-4]": "runtime error: index out of bounds: -4",
+		"print x[3]":  "line 2 column 8: runtime error: index out of bounds: 3",
+		"print x[-4]": "line 2 column 8: runtime error: index out of bounds: -4",
 		`m := {}
-		print m[x[1]]`: `runtime error: no value for map key: "b"`,
+		print m[x[1]]`: `line 3 column 10: runtime error: no value for map key: "b"`,
 	}
 	for in, want := range tests {
 		in, want := in, want
@@ -518,7 +518,7 @@ func TestDotErr(t *testing.T) {
 m := {a:1}
 print m.missing_index
 `
-	want := `runtime error: no value for map key: "missing_index"`
+	want := `line 3 column 8: runtime error: no value for map key: "missing_index"`
 	got := run(in)
 	assert.Equal(t, want, got)
 }

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -453,8 +453,8 @@ func TestDoubleIndex(t *testing.T) {
 func TestIndexErr(t *testing.T) {
 	tests := map[string]string{
 		// x := ["a","b","c"]; x = "abc"
-		"print x[3]":  "runtime error: invalid slice: 3 out of bounds (-3 to 2)",
-		"print x[-4]": "runtime error: invalid slice: -4 out of bounds (-3 to 2)",
+		"print x[3]":  "runtime error: index out of bounds: 3",
+		"print x[-4]": "runtime error: index out of bounds: -4",
 		`m := {}
 		print m[x[1]]`: `runtime error: no value for map key: "b"`,
 	}

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -389,7 +389,7 @@ func normalizeIndex(idx Value, length int) (int, error) {
 	}
 	i := int(index.Val)
 	if i < -length || i >= length {
-		return 0, fmt.Errorf("%w: %d out of bounds (%d to %d)", ErrSlice, i, -length, length-1)
+		return 0, fmt.Errorf("%w: %d", ErrBounds, i)
 	}
 	if i < 0 {
 		return length + i, nil // -1 references len-1 i.e. last element

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -85,10 +85,6 @@ type ReturnValue struct {
 
 type Break struct{}
 
-type Error struct {
-	Message string
-}
-
 func (n *Num) Type() ValueType { return NUM }
 func (n *Num) String() string  { return strconv.FormatFloat(n.Val, 'f', -1, 64) }
 func (n *Num) Equals(v Value) bool {

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -179,7 +179,7 @@ func (p *parser) parseIndexOrSliceExpr(scope *scope, left Node, allowSlice bool)
 	p.advance() // advance past [
 	leftType := left.Type().Name
 	if leftType != ARRAY && leftType != MAP && leftType != STRING {
-		p.appendErrorForToken("only array, string and map type can be indexed found "+left.Type().String(), tok)
+		p.appendErrorForToken("only array, string and map type can be indexed, found "+left.Type().String(), tok)
 		return nil
 	}
 	if p.cur.TokenType() == lexer.COLON && allowSlice { // e.g. a[:2]
@@ -224,7 +224,7 @@ func (p *parser) validateIndex(tok *lexer.Token, leftType TypeName, indexType *T
 func (p *parser) parseSlice(scope *scope, tok *lexer.Token, left, start Node) Node {
 	leftType := left.Type().Name
 	if leftType != ARRAY && leftType != STRING {
-		p.appendErrorForToken("only array and string be indexed sliced"+left.Type().String(), tok)
+		p.appendErrorForToken("only array and string can be sliced, found "+left.Type().String(), tok)
 		return nil
 	}
 


### PR DESCRIPTION
Add token location to evaluator errors and surface them in JS and UI.
In two preparatory commits remove the unused `eval.Error` type and
reword some sentinel errors in evaluator.