### PR TITLE
main: Drop trailing newline in CLI read function

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func (rt *cliRuntime) Read() string {
 	if err != nil {
 		panic(err)
 	}
-	return s
+	return s[:len(s)-1] // strip trailing newline
 }
 
 func (*cliRuntime) Sleep(dur time.Duration) {


### PR DESCRIPTION
The CLI runtime `Read()` function was returning the line read with the
trailing newline. This is different to how the browser/wasm
implementation works which does not include the trailing newline. This
makes for different behaviour when running an evy program with the
different runtimes.