### PR TITLE
docs: Fix grammar of for loops

### DIFF
--- a/docs/syntax_grammar.md
+++ b/docs/syntax_grammar.md
@@ -104,7 +104,7 @@ not allowed.
     for_stmt   = "for" range NL
                     statements
                  "end" NL .
-    range      = ident ( ":=" | "=" ) "range" range_args .
+    range      = [ ident ":=" ] "range" range_args .
     range_args = <- expr -> [ <- expr -> [ <- expr -> ] ] .
     while_stmt = "while" toplevel_expr NL
                      statements


### PR DESCRIPTION
Fix the grammar docs to specify that the variable declaration is
optional. This removes the assignment option as that is not implemented,
nor is it planned to be implemented.