### PR TITLE
eval: Fix break to not break more than one level

### DIFF
--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -341,6 +341,9 @@ func (e *Evaluator) evalWhile(w *parser.WhileStmt) (Value, error) {
 	for ok && err == nil && !isReturn(val) && !isBreak(val) {
 		val, ok, err = e.evalConditionalBlock(whileBlock)
 	}
+	if isBreak(val) {
+		val = nil
+	}
 	return val, err
 }
 
@@ -356,7 +359,10 @@ func (e *Evaluator) evalFor(f *parser.ForStmt) (Value, error) {
 		if err != nil {
 			return nil, err
 		}
-		if isBreak(val) || isReturn(val) {
+		if isBreak(val) {
+			return nil, nil
+		}
+		if isReturn(val) {
 			return val, nil
 		}
 	}

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -168,6 +168,22 @@ while true
     end
     continue = false
 end
+`, `
+while true
+    while true
+        break
+    end
+    print "🎈"
+    break
+end
+`, `
+for range 3
+    for range 3
+        break
+    end
+    print "🎈"
+    break
+end
 `,
 	}
 	for _, input := range tests {


### PR DESCRIPTION
Fix the evaluation of the `break` statement so as to not break out of
more than one loop (`for` or `while`). We do this by turning a `Break`
`Value` into a `nil` `Value` when it is handled, breaking a loop.
Further outer loops will no longer break out.

Add tests for this case.