### PR TITLE
go: Use fmt.Sprintf where sensible

### DIFF
--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -231,11 +231,11 @@ func printFunc(printFn func(string)) BuiltinFunc {
 func printfFunc(printFn func(string)) BuiltinFunc {
 	return func(_ *scope, args []Value) (Value, error) {
 		if len(args) < 1 {
-			return nil, fmt.Errorf("%w: 'printf' takes at least 1 argument", ErrBadArguments)
+			return nil, fmt.Errorf(`%w: "printf" takes at least 1 argument`, ErrBadArguments)
 		}
 		format, ok := args[0].(*String)
 		if !ok {
-			return nil, fmt.Errorf("%w: first argument of 'printf' must be a string", ErrBadArguments)
+			return nil, fmt.Errorf(`%w: first argument of "printf" must be a string`, ErrBadArguments)
 		}
 		s := sprintf(format.Val, args[1:])
 		printFn(s)
@@ -255,11 +255,11 @@ func sprintFunc(_ *scope, args []Value) (Value, error) {
 
 func sprintfFunc(_ *scope, args []Value) (Value, error) {
 	if len(args) < 1 {
-		return nil, fmt.Errorf("%w: 'sprintf' takes at least 1 argument", ErrBadArguments)
+		return nil, fmt.Errorf(`%w: "sprintf" takes at least 1 argument`, ErrBadArguments)
 	}
 	format, ok := args[0].(*String)
 	if !ok {
-		return nil, fmt.Errorf("%w: first argument of 'sprintf' must be a string", ErrBadArguments)
+		return nil, fmt.Errorf(`%w: first argument of "sprintf" must be a string`, ErrBadArguments)
 	}
 	return &String{Val: sprintf(format.Val, args[1:])}, nil
 }
@@ -492,7 +492,7 @@ func lenFunc(_ *scope, args []Value) (Value, error) {
 	case *String:
 		return &Num{Val: float64(len(arg.Val))}, nil
 	}
-	return nil, fmt.Errorf("%w: 'len' takes 1 argument of type 'string', array '[]' or map '{}' not %s", ErrBadArguments, args[0].Type())
+	return nil, fmt.Errorf(`%w: "len" takes 1 argument of type "string", array "[]" or map "{}" not %s`, ErrBadArguments, args[0].Type())
 }
 
 var hasDecl = &parser.FuncDeclStmt{
@@ -575,7 +575,7 @@ var clearDecl = &parser.FuncDeclStmt{
 func clearFunc(clearFn func(string)) BuiltinFunc {
 	return func(_ *scope, args []Value) (Value, error) {
 		if len(args) > 1 {
-			return nil, fmt.Errorf("%w: 'clear' takes 0 or 1 string arguments", ErrBadArguments)
+			return nil, fmt.Errorf(`%w: "clear" takes 0 or 1 string arguments`, ErrBadArguments)
 		}
 		color := ""
 		if len(args) == 1 {
@@ -604,7 +604,7 @@ func polyFunc(polyFn func([][]float64)) BuiltinFunc {
 			vertex := arg.(*Array)
 			elements := *vertex.Elements
 			if len(elements) != 2 {
-				return nil, fmt.Errorf("%w: 'poly' argument %d has %d elements, expected 2 (x, y)", ErrBadArguments, i+1, len(elements))
+				return nil, fmt.Errorf(`%w: "poly" argument %d has %d elements, expected 2 (x, y)`, ErrBadArguments, i+1, len(elements))
 			}
 			x := elements[0].(*Num).Val
 			y := elements[1].(*Num).Val
@@ -625,7 +625,7 @@ func ellipseFunc(ellipseFn func(x, y, radiusX, radiusY, rotation, startAngle, en
 	return func(_ *scope, args []Value) (Value, error) {
 		argLen := len(args)
 		if argLen < 3 || argLen == 6 || argLen > 7 {
-			return nil, fmt.Errorf("%w: 'ellipse' requires 3, 4, 5 or 7 arguments, found %d", ErrBadArguments, argLen)
+			return nil, fmt.Errorf(`%w: "ellipse" requires 3, 4, 5 or 7 arguments, found %d`, ErrBadArguments, argLen)
 		}
 		x := args[0].(*Num).Val
 		y := args[1].(*Num).Val

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -687,7 +687,7 @@ func (e *Evaluator) evalDotExpr(expr *parser.DotExpression, forAssign bool) (Val
 	}
 	m, ok := left.(*Map)
 	if !ok {
-		return nil, newErr(expr, fmt.Errorf("%w: expected map before '.', found %v", ErrType, left))
+		return nil, newErr(expr, fmt.Errorf(`%w: expected map before ".", found %v`, ErrType, left))
 	}
 	if forAssign {
 		m.InsertKey(expr.Key, expr.Type())
@@ -722,7 +722,7 @@ func (e *Evaluator) evalSliceExpr(expr *parser.SliceExpression) (Value, error) {
 	case *String:
 		val, err = left.Slice(start, end)
 	default:
-		err = fmt.Errorf("%w: expected string or array before '[', found %v", ErrType, left)
+		err = fmt.Errorf(`%w: expected string or array before "[", found %v`, ErrType, left)
 	}
 	if err != nil {
 		return nil, newErr(expr, err)

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -834,7 +834,7 @@ m.a = 1
 m.b.c = 2
 `
 	got := run(in)
-	want := "line 4 column 4: field access with '.' expects map type, found any"
+	want := `line 4 column 4: field access with "." expects map type, found any`
 	assert.Equal(t, want, got)
 }
 
@@ -859,9 +859,9 @@ print (has m "MISSING")
 
 func TestHasErr(t *testing.T) {
 	prog := `
-has ["a"] "a" // cannot run 'has' on array
+has ["a"] "a" // cannot run "has" on array
 `
-	want := "line 2 column 5: 'has' takes 1st argument of type '{}', found '[]string'"
+	want := `line 2 column 5: "has" takes 1st argument of type {}, found []string`
 	got := run(prog)
 	assert.Equal(t, want, got)
 }
@@ -897,7 +897,7 @@ func TestDelErr(t *testing.T) {
 	prog := `
 del ["a"] "a" // cannot delete from array
 `
-	want := "line 2 column 5: 'del' takes 1st argument of type '{}', found '[]string'"
+	want := `line 2 column 5: "del" takes 1st argument of type {}, found []string`
 	got := run(prog)
 	assert.Equal(t, want, got)
 }

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -298,9 +298,9 @@ func TestRun(t *testing.T) {
 		{in: ":=", want: "DECLARE\n"},
 		{in: "", want: ""},
 		{in: "\n", want: "NL\n"},
-		{in: ` "abc"`, want: "WS\nSTRING_LIT 'abc'\n"},
-		{in: ",", want: "ILLEGAL 💥 ',' at line 1 column 1\n"},
-		{in: `"asdf `, want: "ILLEGAL 💥 'invalid string' at line 1 column 1\n"},
+		{in: ` "abc"`, want: "WS\n" + `STRING_LIT "abc"` + "\n"},
+		{in: ",", want: `ILLEGAL 💥 "," at line 1 column 1` + "\n"},
+		{in: `"asdf `, want: `ILLEGAL 💥 "invalid string" at line 1 column 1` + "\n"},
 	}
 
 	for _, tt := range tests {
@@ -338,10 +338,10 @@ func TestString(t *testing.T) {
 		in   string
 		want string
 	}{
-		{in: `"abc" `, want: "STRING_LIT 'abc'"},
-		{in: `"abc\"" `, want: `STRING_LIT 'abc"'`},
-		{in: `"abc\\" `, want: `STRING_LIT 'abc\'`},
-		{in: `"abc\\\"" `, want: `STRING_LIT 'abc\"'`},
+		{in: `"abc" `, want: `STRING_LIT "abc"`},
+		{in: `"abc\"" `, want: `STRING_LIT "abc\""`},
+		{in: `"abc\\" `, want: `STRING_LIT "abc\\"`},
+		{in: `"abc\\\"" `, want: `STRING_LIT "abc\\\""`},
 	}
 
 	for _, tt := range tests {

--- a/pkg/lexer/token.go
+++ b/pkg/lexer/token.go
@@ -1,6 +1,7 @@
 package lexer
 
 import (
+	"fmt"
 	"strconv"
 )
 
@@ -194,7 +195,7 @@ func (t TokenType) FormatDetails() string {
 	if t == IDENT {
 		return "identifier"
 	}
-	return "'" + t.Format() + "'"
+	return fmt.Sprintf("%q", t.Format())
 }
 
 func (t *Token) SetType(tokenType TokenType) *Token {
@@ -214,9 +215,9 @@ func (t *Token) SetLiteral(literal string) *Token {
 func (t *Token) String() string {
 	switch t.Type {
 	case COMMENT, IDENT, NUM_LIT, STRING_LIT:
-		return t.Type.String() + " '" + t.Literal + "'"
+		return fmt.Sprintf("%s %q", t.Type.String(), t.Literal)
 	case ILLEGAL:
-		return "ILLEGAL 💥 '" + t.Literal + "' at " + t.Location()
+		return fmt.Sprintf("ILLEGAL 💥 %q at %s", t.Literal, t.Location())
 	}
 	return t.Type.String()
 }

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -117,7 +118,7 @@ func (f *FuncDeclStmt) Token() *lexer.Token {
 }
 
 type FuncDeclStmt struct {
-	token         *lexer.Token // The 'func' token
+	token         *lexer.Token // The "func" token
 	Name          string
 	Params        []*Var
 	VariadicParam *Var
@@ -186,7 +187,7 @@ func (e *EventHandlerStmt) Token() *lexer.Token {
 }
 
 type EventHandlerStmt struct {
-	token  *lexer.Token // The 'on' token
+	token  *lexer.Token // The "on" token
 	Name   string
 	Params []*Var
 	Body   *BlockStatement
@@ -653,7 +654,7 @@ func (n *NumLiteral) Type() *Type {
 }
 
 func (s *StringLiteral) String() string {
-	return "'" + s.Value + "'"
+	return fmt.Sprintf("%q", s.Value)
 }
 
 func (s *StringLiteral) Type() *Type {

--- a/pkg/parser/errorstrings.go
+++ b/pkg/parser/errorstrings.go
@@ -1,15 +1,6 @@
 package parser
 
-import (
-	"strconv"
-)
-
-// itoa is a shorthand for strconv.Itoa as it is used a lot when
-// concatenating strings as tinygo does string formatting with
-// fmt.Sprintf.
-func itoa(n int) string {
-	return strconv.Itoa(n)
-}
+import "fmt"
 
 func pluralize(n int, unit string) string {
 	if n == 1 {
@@ -19,15 +10,15 @@ func pluralize(n int, unit string) string {
 }
 
 func quantify(n int, unit string) string {
-	return itoa(n) + " " + pluralize(n, unit)
+	return fmt.Sprintf("%d %s", n, pluralize(n, unit))
 }
 
 // ordinalize returns ordinal number as string. Invalid for negative
 // numbers. E.g. `ordinalize(1) == "1st"`.
 func ordinalize(n int) string {
 	if 10 < n%100 && n%100 < 14 {
-		return itoa(n) + "th"
+		return fmt.Sprintf("%dth", n)
 	}
 	m := map[int]string{0: "th", 1: "st", 2: "nd", 3: "rd", 4: "th", 5: "th", 6: "th", 7: "th", 8: "th", 9: "th"}
-	return itoa(n) + m[n%10]
+	return fmt.Sprintf("%d%s", n, m[n%10])
 }

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -14,7 +14,7 @@ func TestParseTopLevelExpression(t *testing.T) {
 		"n2":  "n2",
 		"s":   "s",
 		"b":   "b",
-		`"b"`: "'b'",
+		`"b"`: `"b"`,
 
 		// binary expressions, arithmetic
 		"1+1":   "(1+1)",
@@ -27,8 +27,8 @@ func TestParseTopLevelExpression(t *testing.T) {
 		// binary expressions, logical
 		"n1<n2":                "(n1<n2)",
 		"1<2":                  "(1<2)",
-		`"a"<"b"`:              `('a'<'b')`,
-		`s<"b"`:                `(s<'b')`,
+		`"a"<"b"`:              `("a"<"b")`,
+		`s<"b"`:                `(s<"b")`,
 		"n1== n2":              "(n1==n2)",
 		"false and true":       "(false and true)",
 		"false or b":           "(false or b)",
@@ -56,7 +56,7 @@ func TestParseTopLevelExpression(t *testing.T) {
 		"print":        "print()",
 		"print 1":      "print(1)",
 		"print 1 true": "print(1, true)",
-		`print 1 "a"`:  "print(1, 'a')",
+		`print 1 "a"`:  `print(1, "a")`,
 
 		// Function calls
 		`print (1+2)`:                 "print((1+2))",
@@ -64,12 +64,12 @@ func TestParseTopLevelExpression(t *testing.T) {
 		`print 1+2 3+4`:               "print((1+2), (3+4))",
 		`print 1-2`:                   "print((1-2))",
 		`print 1 -2`:                  "print(1, (-2))",
-		`len "abc"`:                   "len('abc')",
-		`print (len "abc")`:           "print(len('abc'))",
-		`print 1 (len "abc")`:         "print(1, len('abc'))",
-		`print 1 (len "abc") 2`:       "print(1, len('abc'), 2)",
-		`print (len "abc") 2`:         "print(len('abc'), 2)",
-		`print (len "abc") (len "x")`: "print(len('abc'), len('x'))",
+		`len "abc"`:                   `len("abc")`,
+		`print (len "abc")`:           `print(len("abc"))`,
+		`print 1 (len "abc")`:         `print(1, len("abc"))`,
+		`print 1 (len "abc") 2`:       `print(1, len("abc"), 2)`,
+		`print (len "abc") 2`:         `print(len("abc"), 2)`,
+		`print (len "abc") (len "x")`: `print(len("abc"), len("x"))`,
 		`print s[1]`:                  "print((s[1]))",
 		"print map2[s]":               "print((map2[s]))",
 
@@ -80,8 +80,8 @@ func TestParseTopLevelExpression(t *testing.T) {
 		"arr2[1][n2+2]": "((arr2[1])[(n2+2)])",
 		"arr[1] and b":  "((arr[1]) and b)",
 		"map[s]":        "(map[s])",
-		`map["key"]`:    "(map['key'])",
-		`"abc"[1]`:      "('abc'[1])",
+		`map["key"]`:    `(map["key"])`,
+		`"abc"[1]`:      `("abc"[1])`,
 		`s[1]`:          "(s[1])",
 
 		// Map access - dot expressions
@@ -132,7 +132,7 @@ func TestParseTopLevelExpression(t *testing.T) {
 		"{a: [1] b:2 c: 1+2}":    "{a:[1], b:2, c:(1+2)}",
 		"{a: [1] b:2+n2 c: 1+2}": "{a:[1], b:(2+n2), c:(1+2)}",
 		"{a: 1}.a":               "({a:1}.a)",
-		`{a: 1}["a"]`:            "({a:1}['a'])",
+		`{a: 1}["a"]`:            `({a:1}["a"])`,
 
 		// Array concatenation
 		"[1] + [2]":            "([1]+[2])",
@@ -203,56 +203,56 @@ func TestParseTopLevelExpression(t *testing.T) {
 
 func TestParseTopLevelExpressionErr(t *testing.T) {
 	tests := map[string]string{
-		"x":        "line 1 column 1: unknown variable name 'x'",
-		"+1":       "line 1 column 1: unexpected '+'",
-		"* n1":     "line 1 column 1: unexpected '*'",
-		"and true": "line 1 column 1: unexpected 'and'",
+		"x":        `line 1 column 1: unknown variable name "x"`,
+		"+1":       `line 1 column 1: unexpected "+"`,
+		"* n1":     `line 1 column 1: unexpected "*"`,
+		"and true": `line 1 column 1: unexpected "and"`,
 
 		"1 +":    "line 1 column 4: unexpected end of input",
 		"1 +\n2": "line 1 column 4: unexpected end of line",
 		"1 ==":   "line 1 column 5: unexpected end of input",
 
-		"true + false": "line 1 column 6: '+' takes num, string or array type, found bool",
-		"true - false": "line 1 column 6: '-' takes num type, found bool",
-		"true < false": "line 1 column 6: '<' takes num or string type, found bool",
-		"1 and 2":      "line 1 column 3: 'and' takes bool type, found num",
-		"1 + false":    "line 1 column 3: mismatched type for +: num, bool",
-		"false + 1":    "line 1 column 7: mismatched type for +: bool, num",
-		"(1+2":         "line 1 column 5: expected ')', got end of input",
-		"(1+2\n)":      "line 1 column 5: expected ')', got end of line",
-		"(1+)2":        "line 1 column 4: unexpected ')'",
-		"(1+]2":        "line 1 column 4: unexpected ']'",
-		"(1+2]":        "line 1 column 5: expected ')', got ']'",
+		"true + false": `line 1 column 6: "+" takes num, string or array type, found bool`,
+		"true - false": `line 1 column 6: "-" takes num type, found bool`,
+		"true < false": `line 1 column 6: "<" takes num or string type, found bool`,
+		"1 and 2":      `line 1 column 3: "and" takes bool type, found num`,
+		"1 + false":    `line 1 column 3: mismatched type for +: num, bool`,
+		"false + 1":    `line 1 column 7: mismatched type for +: bool, num`,
+		"(1+2":         `line 1 column 5: expected ")", got end of input`,
+		"(1+2\n)":      `line 1 column 5: expected ")", got end of line`,
+		"(1+)2":        `line 1 column 4: unexpected ")"`,
+		"(1+]2":        `line 1 column 4: unexpected "]"`,
+		"(1+2]":        `line 1 column 5: expected ")", got "]"`,
 
 		`"abc"["a"]`:   "line 1 column 6: string index expects num, found string",
 		`[1 2 3]["a"]`: "line 1 column 8: array index expects num, found string",
 		"{a:2}[2]":     "line 1 column 6: map index expects string, found num",
 
-		"{a:}": "line 1 column 4: unexpected '}'",
-		"{:a}": "line 1 column 2: expected map key, found ':'",
+		"{a:}": `line 1 column 4: unexpected "}"`,
+		"{:a}": `line 1 column 2: expected map key, found ":"`,
 
 		"[1] + [false]": "line 1 column 5: mismatched type for +: []num, []bool",
 
-		"a. b":        "line 1 column 2: unexpected whitespace after '.'",
-		"a .b":        "line 1 column 3: unexpected whitespace before '.'",
-		"- 5":         "line 1 column 1: unexpected whitespace after '-'",
-		"- n1":        "line 1 column 1: unexpected whitespace after '-'",
-		"[3 +5]":      "line 1 column 4: unexpected whitespace before '+'",
-		"[3+ 5]":      "line 1 column 3: unexpected whitespace after '+'",
-		"[ 3+ 5]":     "line 1 column 4: unexpected whitespace after '+'",
-		"print 1 - 2": "line 1 column 9: unexpected whitespace after '-'",
+		"a. b":        `line 1 column 2: unexpected whitespace after "."`,
+		"a .b":        `line 1 column 3: unexpected whitespace before "."`,
+		"- 5":         `line 1 column 1: unexpected whitespace after "-"`,
+		"- n1":        `line 1 column 1: unexpected whitespace after "-"`,
+		"[3 +5]":      `line 1 column 4: unexpected whitespace before "+"`,
+		"[3+ 5]":      `line 1 column 3: unexpected whitespace after "+"`,
+		"[ 3+ 5]":     `line 1 column 4: unexpected whitespace after "+"`,
+		"print 1 - 2": `line 1 column 9: unexpected whitespace after "-"`,
 
-		"- 2":    "line 1 column 1: unexpected whitespace after '-'",
-		"! true": "line 1 column 1: unexpected whitespace after '!'",
+		"- 2":    `line 1 column 1: unexpected whitespace after "-"`,
+		"! true": `line 1 column 1: unexpected whitespace after "!"`,
 
-		"{a: _}":   "line 1 column 5: anonymous variable '_' cannot be read",
-		"[_]":      "line 1 column 2: anonymous variable '_' cannot be read",
-		"{a:1}[_]": "line 1 column 7: anonymous variable '_' cannot be read",
+		"{a: _}":   `line 1 column 5: anonymous variable "_" cannot be read`,
+		"[_]":      `line 1 column 2: anonymous variable "_" cannot be read`,
+		"{a:1}[_]": `line 1 column 7: anonymous variable "_" cannot be read`,
 
-		"[1":    "line 1 column 3: expected ']', got end of input",
-		"[1)":   "line 1 column 3: unexpected ')'",
-		"[1(]":  "line 1 column 4: unexpected ']'",
-		"[1()]": "line 1 column 4: unexpected ')'",
+		"[1":    `line 1 column 3: expected "]", got end of input`,
+		"[1)":   `line 1 column 3: unexpected ")"`,
+		"[1(]":  `line 1 column 4: unexpected "]"`,
+		"[1()]": `line 1 column 4: unexpected ")"`,
 	}
 	for input, wantErr := range tests {
 		parser := newParser(input, testBuiltins())


### PR DESCRIPTION
Use fmt.Sprintf where sensible - it was used before with the assumption
that tinygo doesn't support it (runtime error), but it turns out this
was only because we didn't use main() as mount point. While at it,
change all single to double quotes.