### PR TITLE
parser: Move scope stack to parser state

### DIFF
--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -177,25 +177,25 @@ func TestParseTopLevelExpression(t *testing.T) {
 		parser := newParser(input, testBuiltins())
 		parser.formatting = newFormatting()
 		parser.advanceTo(0)
-		scope := newScope(nil, &Program{})
-		scope.set("n1", &Var{Name: "n1", T: NUM_TYPE})
-		scope.set("n2", &Var{Name: "n2", T: NUM_TYPE})
-		scope.set("s", &Var{Name: "s", T: STRING_TYPE})
-		scope.set("b", &Var{Name: "b", T: BOOL_TYPE})
+		parser.scope = newScope(nil, &Program{})
+		parser.scope.set("n1", &Var{Name: "n1", T: NUM_TYPE})
+		parser.scope.set("n2", &Var{Name: "n2", T: NUM_TYPE})
+		parser.scope.set("s", &Var{Name: "s", T: STRING_TYPE})
+		parser.scope.set("b", &Var{Name: "b", T: BOOL_TYPE})
 		arrType := &Type{Name: ARRAY, Sub: BOOL_TYPE}
-		scope.set("arr", &Var{Name: "arr", T: arrType})
+		parser.scope.set("arr", &Var{Name: "arr", T: arrType})
 		arrType2 := &Type{Name: ARRAY, Sub: arrType}
-		scope.set("arr2", &Var{Name: "arr2", T: arrType2})
+		parser.scope.set("arr2", &Var{Name: "arr2", T: arrType2})
 		mapType := &Type{Name: MAP, Sub: NUM_TYPE}
-		scope.set("map", &Var{Name: "map", T: mapType})
+		parser.scope.set("map", &Var{Name: "map", T: mapType})
 		mapType2 := &Type{Name: MAP, Sub: mapType}
-		scope.set("map2", &Var{Name: "map2", T: mapType2})
+		parser.scope.set("map2", &Var{Name: "map2", T: mapType2})
 		arrayMapType := &Type{Name: ARRAY, Sub: mapType}
-		scope.set("list", &Var{Name: "list", T: arrayMapType})
+		parser.scope.set("list", &Var{Name: "list", T: arrayMapType})
 		mapArrayType := &Type{Name: MAP, Sub: arrType}
-		scope.set("map3", &Var{Name: "map3", T: mapArrayType})
+		parser.scope.set("map3", &Var{Name: "map3", T: mapArrayType})
 
-		got := parser.parseTopLevelExpr(scope)
+		got := parser.parseTopLevelExpr()
 		assertNoParseError(t, parser, input)
 		assert.Equal(t, want, got.String())
 	}
@@ -258,12 +258,12 @@ func TestParseTopLevelExpressionErr(t *testing.T) {
 		parser := newParser(input, testBuiltins())
 		parser.advanceTo(0)
 		parser.formatting = newFormatting()
-		scope := newScope(nil, &Program{})
-		scope.set("n1", &Var{Name: "n1", T: NUM_TYPE})
+		parser.scope = newScope(nil, &Program{})
+		parser.scope.set("n1", &Var{Name: "n1", T: NUM_TYPE})
 		mapType := &Type{Name: MAP, Sub: NUM_TYPE}
-		scope.set("a", &Var{Name: "a", T: mapType})
+		parser.scope.set("a", &Var{Name: "a", T: mapType})
 
-		_ = parser.parseTopLevelExpr(scope)
+		_ = parser.parseTopLevelExpr()
 		assertParseError(t, parser, input)
 		got := parser.errors.Truncate(1)
 		assert.Equal(t, wantErr, got.Error(), "input: %s\nerrors:\n%s", input, parser.errors)

--- a/pkg/parser/format_test.go
+++ b/pkg/parser/format_test.go
@@ -588,7 +588,7 @@ x := [
 print x
 `[1:]
 	parser := newParser(input, testBuiltins())
-	prog := parser.Parse()
+	prog := parser.parse()
 	assertNoParseError(t, parser, input)
 	got := prog.Format()
 	assert.Equal(t, want, got)
@@ -601,7 +601,7 @@ print x
 `[1:]
 	want := input
 	parser := newParser(input, testBuiltins())
-	prog := parser.Parse()
+	prog := parser.parse()
 	assertNoParseError(t, parser, input)
 	got := prog.Format()
 	assert.Equal(t, want, got)
@@ -619,7 +619,7 @@ end
 `[1:]
 	want := input
 	parser := newParser(input, testBuiltins())
-	prog := parser.Parse()
+	prog := parser.parse()
 	assertNoParseError(t, parser, input)
 	got := prog.Format()
 	assert.Equal(t, want, got)
@@ -730,7 +730,7 @@ end
 func testFormat(t *testing.T, input string) string {
 	t.Helper()
 	parser := newParser(input, testBuiltins())
-	prog := parser.Parse()
+	prog := parser.parse()
 	assertNoParseError(t, parser, input)
 	return prog.Format()
 }

--- a/pkg/parser/multiline_test.go
+++ b/pkg/parser/multiline_test.go
@@ -107,7 +107,7 @@ func TestNLIndices(t *testing.T) {
 	}
 	for input, want := range tests {
 		parser := newParser(input, testBuiltins())
-		prog := parser.Parse()
+		prog := parser.parse()
 		assertNoParseError(t, parser, input)
 		got := nlAfter(prog.Statements, prog.formatting.comments)
 		// cannot equality test maps in tinygo

--- a/pkg/parser/multiline_test.go
+++ b/pkg/parser/multiline_test.go
@@ -24,9 +24,9 @@ func TestArrayLiteralMultiline(t *testing.T) {
 		parser := newParser(input, testBuiltins())
 		parser.formatting = newFormatting()
 		parser.advanceTo(0)
-		scope := newScope(nil, &Program{})
+		parser.scope = newScope(nil, &Program{})
 
-		arrayLit := parser.parseArrayLiteral(scope).(*ArrayLiteral)
+		arrayLit := parser.parseArrayLiteral().(*ArrayLiteral)
 		assertNoParseError(t, parser, input)
 		got := parser.formatting.multiline[ptr(arrayLit)]
 		assert.Equal(t, want, got)
@@ -52,9 +52,9 @@ func TestMapLiteralMultiline(t *testing.T) {
 		parser := newParser(input, testBuiltins())
 		parser.formatting = newFormatting()
 		parser.advanceTo(0)
-		scope := newScope(nil, &Program{})
+		parser.scope = newScope(nil, &Program{})
 
-		mapLit := parser.parseMapLiteral(scope).(*MapLiteral)
+		mapLit := parser.parseMapLiteral().(*MapLiteral)
 		assertNoParseError(t, parser, input)
 		got := parser.formatting.multiline[ptr(mapLit)]
 		assert.Equal(t, want, got)

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -23,7 +23,7 @@ type Builtins struct {
 
 func Parse(input string, builtins Builtins) (*Program, error) {
 	parser := newParser(input, builtins)
-	prog := parser.Parse()
+	prog := parser.parse()
 	if parser.errors != nil {
 		return nil, parser.errors
 	}
@@ -143,7 +143,7 @@ func newParser(input string, builtins Builtins) *parser {
 	return p
 }
 
-func (p *parser) Parse() *Program {
+func (p *parser) parse() *Program {
 	return p.parseProgram()
 }
 
@@ -151,7 +151,7 @@ func (p *parser) Parse() *Program {
 // in grammar doc/syntax_grammar.md.
 func (p *parser) parseProgram() *Program {
 	program := &Program{formatting: p.formatting}
-	scope := newScope(nil, program) // TODO: model scope as stack like evaluator.
+	scope := newScope(nil, program)
 	for _, global := range p.builtins.Globals {
 		global.isUsed = true
 		scope.set(global.Name, global)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -37,7 +37,7 @@ func TestParseDecl(t *testing.T) {
 		wantSlice = append(wantSlice, "print(a)")
 		want := strings.Join(wantSlice, "\n") + "\n"
 		parser := newParser(input, testBuiltins())
-		got := parser.Parse()
+		got := parser.parse()
 		assertNoParseError(t, parser, input)
 		assert.Equal(t, want, got.String())
 	}
@@ -57,7 +57,7 @@ func TestEmptyProgram(t *testing.T) {
 	}
 	for input, want := range tests {
 		parser := newParser(input, testBuiltins())
-		got := parser.Parse()
+		got := parser.parse()
 		assertNoParseError(t, parser, input)
 		assert.Equal(t, want, got.String(), input)
 	}
@@ -89,7 +89,7 @@ print m[s]`: `line 3 column 6: unknown variable name "name"`,
 	}
 	for input, err1 := range tests {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertParseError(t, parser, input)
 		got := parser.errors.Truncate(1)
 		assert.Equal(t, err1, got.Error(), "input: %s\nerrors:\n%s", input, parser.errors)
@@ -113,7 +113,7 @@ func TestFunccall(t *testing.T) {
 	for input, wantSlice := range tests {
 		want := strings.Join(wantSlice, "\n") + "\n"
 		parser := newParser(input, testBuiltins())
-		got := parser.Parse()
+		got := parser.parse()
 		assertNoParseError(t, parser, input)
 		assert.Equal(t, want, got.String())
 	}
@@ -144,7 +144,7 @@ func TestFunccallError(t *testing.T) {
 	}
 	for input, err1 := range tests {
 		parser := newParser(input, builtins)
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertParseError(t, parser, input)
 		got := parser.errors.Truncate(1)
 		assert.Equal(t, err1, got.Error(), "input: %s\nerrors:\n%s", input, parser.errors)
@@ -176,7 +176,7 @@ print("TRUE")
 	}
 	for input, want := range tests {
 		parser := newParser(input, testBuiltins())
-		got := parser.Parse()
+		got := parser.parse()
 		assertNoParseError(t, parser, input)
 		assert.Equal(t, want, got.String())
 	}
@@ -188,7 +188,7 @@ x := len "123"
 print x
 `
 	parser := newParser(input, testBuiltins())
-	got := parser.Parse()
+	got := parser.parse()
 	assertNoParseError(t, parser, input)
 	want := `
 x=len("123")
@@ -238,7 +238,7 @@ func nums5 _:num
 end
 `
 	parser := newParser(input, testBuiltins())
-	_ = parser.Parse()
+	_ = parser.parse()
 	assertNoParseError(t, parser, input)
 	builtinCnt := len(testBuiltins().Funcs)
 	assert.Equal(t, builtinCnt+5, len(parser.funcs))
@@ -271,7 +271,7 @@ fox 1 2 3`,
 	}
 	for _, input := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertNoParseError(t, parser, input)
 	}
 }
@@ -345,7 +345,7 @@ end
 	}
 	for input, wantErr := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
 		assert.Equal(t, wantErr, gotErr.Error())
@@ -385,7 +385,7 @@ print a
 	}
 	for _, input := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertNoParseError(t, parser, input)
 	}
 }
@@ -422,7 +422,7 @@ fn = 3
 	}
 	for input, wantErr := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
 		assert.Equal(t, wantErr, gotErr.Error())
@@ -473,7 +473,7 @@ print a
 	}
 	for _, input := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertNoParseError(t, parser, input)
 	}
 }
@@ -569,7 +569,7 @@ end
 	}
 	for input, wantErr := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
 		assert.Equal(t, wantErr, gotErr.Error(), input)
@@ -642,7 +642,7 @@ end
 	}
 	for input, wantErr := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
 		assert.Equal(t, wantErr, gotErr.Error())
@@ -689,7 +689,7 @@ func TestIf(t *testing.T) {
 	}
 	for _, input := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertNoParseError(t, parser, input)
 	}
 }
@@ -737,7 +737,7 @@ end`: `line 7 column 4: expected "end", got end of input`,
 	}
 	for input, wantErr := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
 		assert.Equal(t, wantErr, gotErr.Error(), "input: %s", input)
@@ -773,7 +773,7 @@ end
 	}
 	for _, input := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertNoParseError(t, parser, input)
 	}
 }
@@ -794,7 +794,7 @@ end`: "line 2 column 6: unexpected end of line",
 	}
 	for input, wantErr := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
 		assert.Equal(t, wantErr, gotErr.Error(), "input: %s", input)
@@ -827,7 +827,7 @@ end`,
 	}
 	for _, input := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertNoParseError(t, parser, input)
 	}
 }
@@ -904,7 +904,7 @@ end
 	}
 	for input, wantErr := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
 		assert.Equal(t, wantErr, gotErr.Error(), "input: %s", input)
@@ -945,7 +945,7 @@ end`,
 	}
 	for _, input := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertNoParseError(t, parser, input)
 	}
 }
@@ -999,7 +999,7 @@ end
 	}
 	for input, wantErr := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
 		assert.Equal(t, wantErr, gotErr.Error(), "input: %s", input)
@@ -1035,7 +1035,7 @@ nums []`,
 	}
 	for _, input := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertNoParseError(t, parser, input)
 
 		assert.Equal(t, NONE_TYPE, GENERIC_ARRAY.Sub)
@@ -1054,7 +1054,7 @@ end`,
 	}
 	for _, input := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertNoParseError(t, parser, input)
 
 		assert.Equal(t, NONE_TYPE, GENERIC_ARRAY.Sub)
@@ -1085,7 +1085,7 @@ end
 	}
 	for input, wantErr := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
 		assert.Equal(t, wantErr, gotErr.Error(), "input: %s", input)
@@ -1116,7 +1116,7 @@ end`,
 	}
 	for _, input := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertNoParseError(t, parser, input)
 	}
 }
@@ -1149,7 +1149,7 @@ end`: `line 3 column 4: wrong number of parameters expected 2, got 1`,
 	}
 	for input, wantErr := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
 		assert.Equal(t, wantErr, gotErr.Error(), "input: %s", input)
@@ -1172,7 +1172,7 @@ end
 	}
 	for input, wantErr := range inputs {
 		parser := newParser(input, testBuiltins())
-		_ = parser.Parse()
+		_ = parser.parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)
 		assert.Equal(t, wantErr, gotErr.Error())
@@ -1182,7 +1182,7 @@ end
 func TestCalledBuiltinFuncs(t *testing.T) {
 	input := `print (len "ABC")`
 	parser := newParser(input, testBuiltins())
-	prog := parser.Parse()
+	prog := parser.parse()
 	assertNoParseError(t, parser, input)
 	got := prog.CalledBuiltinFuncs
 	sort.Strings(got)
@@ -1197,7 +1197,7 @@ func len x:num
 end
 print (len 5)`
 	parser := newParser(input, testBuiltins())
-	_ = parser.Parse()
+	_ = parser.parse()
 	assertParseError(t, parser, input)
 	gotErrs := parser.errors
 	wantErrs := []string{
@@ -1217,7 +1217,7 @@ func fn s:string n:num
     print s n
 end`
 	parser := newParser(input, testBuiltins())
-	parser.Parse()
+	parser.parse()
 	assertNoParseError(t, parser, input)
 }
 
@@ -1232,7 +1232,7 @@ if x > 10
     print "🍦 big x"
 end`
 	parser := newParser(input, testBuiltins())
-	got := parser.Parse()
+	got := parser.parse()
 	assertParseError(t, parser, input)
 	gotErr := parser.errors.Truncate(1)
 	assert.Equal(t, `line 2 column 1: unknown function "move"`, gotErr.Error())


### PR DESCRIPTION
Refactor parser private function order a little and break up newParser (bit long).

Move scope stack into parser state rather than passing it
around as parameters.