### PR TITLE
eval: Replace ValueType with *parser.Type

### DIFF
--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -315,7 +315,7 @@ func splitFunc(_ *scope, args []Value) (Value, error) {
 	for i, s := range slice {
 		elements[i] = &String{Val: s}
 	}
-	return &Array{Elements: &elements}, nil
+	return &Array{Elements: &elements, T: stringArrayType}, nil
 }
 
 var upperDecl = &parser.FuncDeclStmt{

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -37,9 +37,6 @@ func (b Builtins) ParserBuiltins() parser.Builtins {
 
 type BuiltinFunc func(scope *scope, args []Value) (Value, error)
 
-func (b BuiltinFunc) Type() ValueType { return BUILTIN }
-func (b BuiltinFunc) String() string  { return "builtin function" }
-
 func DefaultBuiltins(rt Runtime) Builtins {
 	funcs := map[string]Builtin{
 		"read":   {Func: readFunc(rt.Read), Decl: readDecl},

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -224,7 +224,7 @@ var printDecl = &parser.FuncDeclStmt{
 func printFunc(printFn func(string)) BuiltinFunc {
 	return func(_ *scope, args []Value) (Value, error) {
 		printFn(join(args, " ") + "\n")
-		return nil, nil
+		return &None{}, nil
 	}
 }
 
@@ -239,7 +239,7 @@ func printfFunc(printFn func(string)) BuiltinFunc {
 		}
 		s := sprintf(format.Val, args[1:])
 		printFn(s)
-		return nil, nil
+		return &None{}, nil
 	}
 }
 
@@ -524,7 +524,7 @@ func delFunc(_ *scope, args []Value) (Value, error) {
 	m := args[0].(*Map)
 	keyStr := args[1].(*String)
 	m.Delete(keyStr.Val)
-	return nil, nil
+	return &None{}, nil
 }
 
 var sleepDecl = &parser.FuncDeclStmt{
@@ -538,7 +538,7 @@ func sleepFunc(sleepFn func(time.Duration)) BuiltinFunc {
 		secs := args[0].(*Num)
 		dur := time.Duration(secs.Val * float64(time.Second))
 		sleepFn(dur)
-		return nil, nil
+		return &None{}, nil
 	}
 }
 
@@ -582,7 +582,7 @@ func clearFunc(clearFn func(string)) BuiltinFunc {
 			color = args[0].(*String).Val
 		}
 		clearFn(color)
-		return nil, nil
+		return &None{}, nil
 	}
 }
 
@@ -611,7 +611,7 @@ func polyFunc(polyFn func([][]float64)) BuiltinFunc {
 			vertices[i] = []float64{x, y}
 		}
 		polyFn(vertices)
-		return nil, nil
+		return &None{}, nil
 	}
 }
 
@@ -645,7 +645,7 @@ func ellipseFunc(ellipseFn func(x, y, radiusX, radiusY, rotation, startAngle, en
 			endAngle = args[6].(*Num).Val
 		}
 		ellipseFn(x, y, radiusX, radiusY, rotation, startAngle, endAngle)
-		return nil, nil
+		return &None{}, nil
 	}
 }
 
@@ -662,7 +662,7 @@ func dashFunc(dashFn func([]float64)) BuiltinFunc {
 			segments[i] = arg.(*Num).Val
 		}
 		dashFn(segments)
-		return nil, nil
+		return &None{}, nil
 	}
 }
 
@@ -683,7 +683,7 @@ func xyBuiltin(name string, fn func(x, y float64)) Builtin {
 		x := args[0].(*Num)
 		y := args[1].(*Num)
 		fn(x.Val, y.Val)
-		return nil, nil
+		return &None{}, nil
 	}
 	return result
 }
@@ -725,7 +725,7 @@ func numBuiltin(name string, fn func(n float64)) Builtin {
 	result.Func = func(_ *scope, args []Value) (Value, error) {
 		n := args[0].(*Num)
 		fn(n.Val)
-		return nil, nil
+		return &None{}, nil
 	}
 	return result
 }
@@ -765,7 +765,7 @@ func stringBuiltin(name string, fn func(str string)) Builtin {
 	result.Func = func(_ *scope, args []Value) (Value, error) {
 		str := args[0].(*String)
 		fn(str.Val)
-		return nil, nil
+		return &None{}, nil
 	}
 	return result
 }

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -151,7 +151,7 @@ func (e *Evaluator) Eval(node parser.Node) (Value, error) {
 	case *parser.GroupExpression:
 		return e.Eval(node.Expr)
 	case *parser.FuncDeclStmt, *parser.EventHandlerStmt, *parser.EmptyStmt:
-		return nil, nil
+		return &None{}, nil
 	}
 	return nil, fmt.Errorf("%w: %v", ErrUnknownNode, node)
 }
@@ -292,7 +292,7 @@ func (e *Evaluator) evalFunccall(funcCall *parser.FuncCall) (Value, error) {
 	if returnValue, ok := funcResult.(*ReturnValue); ok {
 		return returnValue.Val, nil
 	}
-	return nil, nil
+	return &None{}, nil
 }
 
 func (e *Evaluator) evalReturn(ret *parser.ReturnStmt) (Value, error) {
@@ -332,7 +332,7 @@ func (e *Evaluator) evalIf(i *parser.IfStmt) (Value, error) {
 		defer e.popScope()
 		return e.Eval(i.Else)
 	}
-	return nil, nil
+	return &None{}, nil
 }
 
 func (e *Evaluator) evalWhile(w *parser.WhileStmt) (Value, error) {
@@ -366,7 +366,7 @@ func (e *Evaluator) evalFor(f *parser.ForStmt) (Value, error) {
 			return val, nil
 		}
 	}
-	return nil, nil
+	return &None{}, nil
 }
 
 func (e *Evaluator) newRange(f *parser.ForStmt) (ranger, error) {

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -217,7 +217,7 @@ func (e *Evaluator) evalDecl(decl *parser.Decl) error {
 	if err != nil {
 		return err
 	}
-	if decl.Type() == parser.ANY_TYPE && val.Type() != ANY {
+	if decl.Type() == parser.ANY_TYPE && val.Type() != parser.ANY_TYPE {
 		val = &Any{Val: val}
 	}
 	e.scope.set(decl.Var.Name, copyOrRef(val))
@@ -242,7 +242,7 @@ func (e *Evaluator) evalArrayLiteral(arr *parser.ArrayLiteral) (Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Array{Elements: &elements}, nil
+	return &Array{Elements: &elements, T: arr.T}, nil
 }
 
 func (e *Evaluator) evalMapLiteral(m *parser.MapLiteral) (Value, error) {
@@ -256,7 +256,7 @@ func (e *Evaluator) evalMapLiteral(m *parser.MapLiteral) (Value, error) {
 	}
 	order := make([]string, len(m.Order))
 	copy(order, m.Order)
-	return &Map{Pairs: pairs, Order: &order}, nil
+	return &Map{Pairs: pairs, Order: &order, T: m.T}, nil
 }
 
 func (e *Evaluator) evalFunccall(funcCall *parser.FuncCall) (Value, error) {
@@ -281,7 +281,7 @@ func (e *Evaluator) evalFunccall(funcCall *parser.FuncCall) (Value, error) {
 		e.scope.set(param.Name, args[i])
 	}
 	if fd.VariadicParam != nil {
-		varArg := &Array{Elements: &args}
+		varArg := &Array{Elements: &args, T: fd.VariadicParam.T}
 		e.scope.set(fd.VariadicParam.Name, varArg)
 	}
 

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -15,6 +15,7 @@ const (
 	BOOL
 	STRING
 	ANY
+	NONE
 	ARRAY
 	MAP
 	RETURN_VALUE
@@ -28,6 +29,7 @@ var valueTypeStrings = map[ValueType]string{
 	BOOL:         "bool",
 	STRING:       "string",
 	ANY:          "any",
+	NONE:         "none",
 	ARRAY:        "array",
 	MAP:          "map",
 	RETURN_VALUE: "return_value",
@@ -84,6 +86,8 @@ type ReturnValue struct {
 }
 
 type Break struct{}
+
+type None struct{}
 
 func (n *Num) Type() ValueType { return NUM }
 func (n *Num) String() string  { return strconv.FormatFloat(n.Val, 'f', -1, 64) }
@@ -188,6 +192,11 @@ func (a *Any) Set(v Value) {
 		a.Val = copyOrRef(v)
 	}
 }
+
+func (n *None) Type() ValueType     { return NONE }
+func (n *None) String() string      { return "" }
+func (n *None) Equals(_ Value) bool { return false }
+func (n *None) Set(_ Value)         { panic("internal error: None.Set called") }
 
 func (r *ReturnValue) Type() ValueType     { return RETURN_VALUE }
 func (r *ReturnValue) String() string      { return r.Val.String() }

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -8,41 +8,8 @@ import (
 	"foxygo.at/evy/pkg/parser"
 )
 
-type ValueType int
-
-const (
-	NUM ValueType = iota
-	BOOL
-	STRING
-	ANY
-	NONE
-	ARRAY
-	MAP
-)
-
-var valueTypeStrings = map[ValueType]string{
-	NUM:    "num",
-	BOOL:   "bool",
-	STRING: "string",
-	ANY:    "any",
-	NONE:   "none",
-	ARRAY:  "array",
-	MAP:    "map",
-}
-
-func (t ValueType) String() string {
-	if s, ok := valueTypeStrings[t]; ok {
-		return s
-	}
-	return "<UNKNOWN>"
-}
-
-func (t ValueType) GoString() string {
-	return t.String()
-}
-
 type Value interface {
-	Type() ValueType
+	Type() *parser.Type
 	Equals(Value) bool
 	String() string
 	Set(Value)
@@ -67,11 +34,13 @@ type Any struct {
 
 type Array struct {
 	Elements *[]Value
+	T        *parser.Type
 }
 
 type Map struct {
 	Pairs map[string]Value
 	Order *[]string
+	T     *parser.Type
 }
 
 type ReturnValue struct {
@@ -82,8 +51,8 @@ type Break struct{}
 
 type None struct{}
 
-func (n *Num) Type() ValueType { return NUM }
-func (n *Num) String() string  { return strconv.FormatFloat(n.Val, 'f', -1, 64) }
+func (n *Num) Type() *parser.Type { return parser.NUM_TYPE }
+func (n *Num) String() string     { return strconv.FormatFloat(n.Val, 'f', -1, 64) }
 func (n *Num) Equals(v Value) bool {
 	n2, ok := v.(*Num)
 	if !ok {
@@ -100,8 +69,8 @@ func (n *Num) Set(v Value) {
 	*n = *n2
 }
 
-func (s *String) Type() ValueType { return STRING }
-func (s *String) String() string  { return s.Val }
+func (s *String) Type() *parser.Type { return parser.STRING_TYPE }
+func (s *String) String() string     { return s.Val }
 func (s *String) Equals(v Value) bool {
 	s2, ok := v.(*String)
 	if !ok {
@@ -144,7 +113,7 @@ func (s *String) Slice(start, end Value) (Value, error) {
 	return &String{Val: string(runes[startIdx:endIdx])}, nil
 }
 
-func (*Bool) Type() ValueType { return BOOL }
+func (*Bool) Type() *parser.Type { return parser.BOOL_TYPE }
 func (b *Bool) String() string {
 	return strconv.FormatBool(b.Val)
 }
@@ -165,7 +134,7 @@ func (b *Bool) Set(v Value) {
 	*b = *b2
 }
 
-func (*Any) Type() ValueType { return ANY }
+func (*Any) Type() *parser.Type { return parser.ANY_TYPE }
 func (a *Any) String() string {
 	return a.Val.String()
 }
@@ -186,22 +155,22 @@ func (a *Any) Set(v Value) {
 	}
 }
 
-func (n *None) Type() ValueType     { return NONE }
+func (n *None) Type() *parser.Type  { return parser.NONE_TYPE }
 func (n *None) String() string      { return "" }
 func (n *None) Equals(_ Value) bool { return false }
 func (n *None) Set(_ Value)         { panic("internal error: None.Set called") }
 
-func (r *ReturnValue) Type() ValueType     { return r.Val.Type() }
+func (r *ReturnValue) Type() *parser.Type  { return r.Val.Type() }
 func (r *ReturnValue) String() string      { return r.Val.String() }
 func (r *ReturnValue) Equals(v Value) bool { return r.Val.Equals(v) }
 func (r *ReturnValue) Set(v Value)         { r.Val.Set(v) }
 
-func (r *Break) Type() ValueType     { return NONE }
+func (r *Break) Type() *parser.Type  { return parser.NONE_TYPE }
 func (r *Break) String() string      { return "" }
 func (r *Break) Equals(_ Value) bool { return false }
 func (r *Break) Set(_ Value)         {}
 
-func (a *Array) Type() ValueType { return ARRAY }
+func (a *Array) Type() *parser.Type { return a.T }
 func (a *Array) String() string {
 	elements := make([]string, len(*a.Elements))
 	for i, e := range *a.Elements {
@@ -250,7 +219,7 @@ func (a *Array) Copy() *Array {
 	for i, v := range *a.Elements {
 		elements[i] = copyOrRef(v)
 	}
-	return &Array{Elements: &elements}
+	return &Array{Elements: &elements, T: a.T}
 }
 
 func (a *Array) Slice(start, end Value) (Value, error) {
@@ -265,7 +234,7 @@ func (a *Array) Slice(start, end Value) (Value, error) {
 		v := (*a.Elements)[i]
 		elements[i-startIdx] = copyOrRef(v)
 	}
-	return &Array{Elements: &elements}, nil
+	return &Array{Elements: &elements, T: a.T}, nil
 }
 
 // copyOrRef is a copy of the input value for basic types and a
@@ -288,7 +257,7 @@ func copyOrRef(val Value) Value {
 	panic("internal error: copyOrRef called with with invalid Value")
 }
 
-func (m *Map) Type() ValueType { return MAP }
+func (m *Map) Type() *parser.Type { return m.T }
 func (m *Map) String() string {
 	pairs := make([]string, 0, len(m.Pairs))
 	for _, key := range *m.Order {
@@ -413,10 +382,10 @@ func zero(t *parser.Type) Value {
 		return &Any{Val: &Bool{}}
 	case t.Name == parser.ARRAY:
 		elements := []Value{}
-		return &Array{Elements: &elements}
+		return &Array{Elements: &elements, T: t}
 	case t.Name == parser.MAP:
 		order := []string{}
-		return &Map{Pairs: map[string]Value{}, Order: &order}
+		return &Map{Pairs: map[string]Value{}, Order: &order, T: t}
 	}
 	panic("cannot create zero value for type " + t.String())
 }

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -18,23 +18,16 @@ const (
 	NONE
 	ARRAY
 	MAP
-	RETURN_VALUE
-	BREAK
-	FUNCTION
-	BUILTIN
 )
 
 var valueTypeStrings = map[ValueType]string{
-	NUM:          "num",
-	BOOL:         "bool",
-	STRING:       "string",
-	ANY:          "any",
-	NONE:         "none",
-	ARRAY:        "array",
-	MAP:          "map",
-	RETURN_VALUE: "return_value",
-	FUNCTION:     "function",
-	BUILTIN:      "builtin",
+	NUM:    "num",
+	BOOL:   "bool",
+	STRING: "string",
+	ANY:    "any",
+	NONE:   "none",
+	ARRAY:  "array",
+	MAP:    "map",
 }
 
 func (t ValueType) String() string {
@@ -198,12 +191,12 @@ func (n *None) String() string      { return "" }
 func (n *None) Equals(_ Value) bool { return false }
 func (n *None) Set(_ Value)         { panic("internal error: None.Set called") }
 
-func (r *ReturnValue) Type() ValueType     { return RETURN_VALUE }
+func (r *ReturnValue) Type() ValueType     { return r.Val.Type() }
 func (r *ReturnValue) String() string      { return r.Val.String() }
 func (r *ReturnValue) Equals(v Value) bool { return r.Val.Equals(v) }
 func (r *ReturnValue) Set(v Value)         { r.Val.Set(v) }
 
-func (r *Break) Type() ValueType     { return BREAK }
+func (r *Break) Type() ValueType     { return NONE }
 func (r *Break) String() string      { return "" }
 func (r *Break) Equals(_ Value) bool { return false }
 func (r *Break) Set(_ Value)         {}
@@ -359,11 +352,13 @@ func (m *Map) Delete(key string) {
 }
 
 func isReturn(val Value) bool {
-	return val != nil && val.Type() == RETURN_VALUE
+	_, ok := val.(*ReturnValue)
+	return ok
 }
 
 func isBreak(val Value) bool {
-	return val != nil && val.Type() == BREAK
+	_, ok := val.(*Break)
+	return ok
 }
 
 func normalizeSliceIndices(start, end Value, length int) (int, int, error) {


### PR DESCRIPTION
Remove the `ValueType` type in favour of `*parser.Type` to enable deeper 
type knowledge of composite types (arrays, maps) that do not have values.
The `ValueType` type only modelled an array or map but not the type of its
contents. If the composite value was empty, it was not possible to tell
what the full composite type was. This makes it impossible to properly do
type assertions.

An `Array` and `Map` now need to store the actual parser type within the 
value. The simple types can just return the parser "constants" for those 
types without needing any extra storage.

This adds a `None` `Value` implementation that is returned instead of
`nil` when an evaluation does not result in a value, making it a little
safer to use everywhere. One place, `evalConditionalBlock` still does
return a `nil` `Value`, but that special case is handled in all the
places that call it and ensure that a real `Value` is returned past
those points.