### PR TITLE
parser/eval: Implement type assertions and typeof builtin

### DIFF
--- a/docs/syntax_grammar.md
+++ b/docs/syntax_grammar.md
@@ -654,16 +654,20 @@ by an expression whose value is returned by the function call.
 ## Typeof
 
 `typeof` returns the concrete type of a value held by a variable as a
-string. It returns one of `"num"`, `"string"`, `"bool"`, `"array"`, or
-`"map"`.
+string. It returns a string the same as the type in an evy program,
+e.g. `num`, `bool`, `string`, `[]num`, `{}[]any`, etc. For an empty
+composite literal , `typeof` returns `[]` or `{}` as it can be matched
+to any subtype. e.g. `[]` can be passed to a function that takes an
+argument of `[]num`, or `[]string`, etc.
 
     typeof "abc"        // string
     typeof true         // bool
     arr := [ "abc" 1 ]
-    typeof arr          // array
+    typeof arr          // []any
     typeof arr[0]       // string
     typeof arr[1]       // num
-    typeof {}           // map
+    typeof {}           // {}
+    typeof []           // []
 
 ## Type assertion
 

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -58,6 +58,8 @@ func DefaultBuiltins(rt Runtime) Builtins {
 		"str2num":  {Func: BuiltinFunc(str2numFunc), Decl: str2numDecl},
 		"str2bool": {Func: BuiltinFunc(str2boolFunc), Decl: str2boolDecl},
 
+		"typeof": {Func: BuiltinFunc(typeofFunc), Decl: typeofDecl},
+
 		"len": {Func: BuiltinFunc(lenFunc), Decl: lenDecl},
 		"has": {Func: BuiltinFunc(hasFunc), Decl: hasDecl},
 		"del": {Func: BuiltinFunc(delFunc), Decl: delDecl},
@@ -405,6 +407,20 @@ func globalErr(scope *scope, isErr bool, msg string) {
 		panic("cannot find global errmsg")
 	}
 	val.Set(&String{Val: msg})
+}
+
+var typeofDecl = &parser.FuncDeclStmt{
+	Name:       "typeof",
+	Params:     []*parser.Var{{Name: "a", T: parser.ANY_TYPE}},
+	ReturnType: parser.STRING_TYPE,
+}
+
+func typeofFunc(_ *scope, args []Value) (Value, error) {
+	t := args[0].Type()
+	if a, ok := args[0].(*Any); ok {
+		t = a.Val.Type()
+	}
+	return &String{Val: t.String()}, nil
 }
 
 var lenDecl = &parser.FuncDeclStmt{

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -1035,6 +1035,29 @@ print n a m`
 	assert.Equal(t, want, got)
 }
 
+func TestTypeAssertion(t *testing.T) {
+	prog := `
+a := {v:[1 2 3]}
+b:any
+b = a
+c := b.({}[]num)
+print c`
+	want := "{v:[1 2 3]}\n"
+	got := run(prog)
+	assert.Equal(t, want, got)
+}
+
+func TestTypeAssertionErr(t *testing.T) {
+	// Note the zero value for any is a false bool
+	prog := `
+a:any
+b := a.(num)
+print b`
+	want := "line 3 column 7: runtime error: error converting any to type: expected num, found bool"
+	got := run(prog)
+	assert.Equal(t, want, got)
+}
+
 func TestStr2BoolNum(t *testing.T) {
 	prog := `
 print 1 (str2bool "1") err

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -1058,6 +1058,52 @@ print b`
 	assert.Equal(t, want, got)
 }
 
+func TestTypeof(t *testing.T) {
+	tests := map[string]string{
+		"a:bool":                   "bool",
+		"a:num":                    "num",
+		"a:string":                 "string",
+		"a:any":                    "bool", // zero value for any is bool false
+		"a:[]num":                  "[]num",
+		"a:{}string":               "{}string",
+		"a:[]{}[]{}bool":           "[]{}[]{}bool",
+		"a := 1":                   "num",
+		"a := true":                "bool",
+		`a := "hello"`:             "string",
+		"a := [1 2 3]":             "[]num",
+		"a := [{a:1}]":             "[]{}num",
+		"a := [{a:1} {b:true}]":    "[]{}any",
+		"a := [{a:1} {b:true} {}]": "[]{}any",
+		"a := [{a:1} {b:2} {}]":    "[]{}num",
+		"a := [{a:1} {b:2} false]": "[]any",
+		"a := {a:1 b:[2]}":         "{}any",
+		"a := {a:[1 2 3] b:[]}":    "{}[]num",
+		"a := []":                  "[]",
+		"a := {}":                  "{}",
+	}
+	for in, want := range tests {
+		in, want := in, want
+		t.Run(in, func(t *testing.T) {
+			in += "\n print (typeof a)"
+			got := run(in)
+			assert.Equal(t, want+"\n", got)
+		})
+	}
+
+	tests = map[string]string{
+		`a := [ "abc" 1 ]`: "string",
+		`a := [ 1 "abc" ]`: "num",
+	}
+	for in, want := range tests {
+		in, want := in, want
+		t.Run(in, func(t *testing.T) {
+			in += "\n print (typeof a[0])"
+			got := run(in)
+			assert.Equal(t, want+"\n", got)
+		})
+	}
+}
+
 func TestStr2BoolNum(t *testing.T) {
 	prog := `
 print 1 (str2bool "1") err

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -712,20 +712,20 @@ func newlineList(nodes []Node) string {
 	return strings.Join(lines, "\n") + "\n"
 }
 
-func zeroValue(t TypeName) Node {
-	switch t {
+func zeroValue(t *Type, tt *lexer.Token) Node {
+	switch t.Name {
 	case NUM:
-		return &NumLiteral{Value: 0}
+		return &NumLiteral{Value: 0, token: tt}
 	case STRING:
-		return &StringLiteral{Value: ""}
+		return &StringLiteral{Value: "", token: tt}
 	case BOOL:
-		return &Bool{Value: false}
+		return &Bool{Value: false, token: tt}
 	case ANY:
-		return &Bool{Value: false}
+		return &Bool{Value: false, token: tt}
 	case ARRAY:
-		return &ArrayLiteral{}
+		return &ArrayLiteral{T: t, token: tt}
 	case MAP:
-		return &MapLiteral{}
+		return &MapLiteral{T: t, token: tt}
 	}
 	return nil
 }

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -76,6 +76,12 @@ type DotExpression struct {
 	Key   string // m := { age: 42}; m.age => key: "age"
 }
 
+type TypeAssertion struct {
+	T     *Type
+	token *lexer.Token
+	Left  Node
+}
+
 type GroupExpression struct {
 	token *lexer.Token
 	Expr  Node
@@ -393,6 +399,18 @@ func (d *DotExpression) String() string {
 
 func (d *DotExpression) Type() *Type {
 	return d.T
+}
+
+func (t *TypeAssertion) Token() *lexer.Token {
+	return t.token
+}
+
+func (t *TypeAssertion) String() string {
+	return "(" + t.Left.String() + "." + "(" + t.T.String() + ")" + ")"
+}
+
+func (t *TypeAssertion) Type() *Type {
+	return t.T
 }
 
 func (d *GroupExpression) Token() *lexer.Token {

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -457,6 +457,10 @@ func (p *parser) combineTypes(types []*Type) *Type {
 			combinedT = t
 			continue
 		}
+		if t.sameComposite(combinedT) {
+			combinedT = &Type{Name: t.Name, Sub: ANY_TYPE}
+			continue
+		}
 		return ANY_TYPE
 	}
 	return combinedT

--- a/pkg/parser/expression_test.go
+++ b/pkg/parser/expression_test.go
@@ -95,6 +95,13 @@ func TestParseTopLevelExpression(t *testing.T) {
 		"list[n1][s]":      "((list[n1])[s])",
 		"map2[s]":          "(map2[s])",
 
+		// Type assertions
+		"a.(num)":     "(a.(num))",
+		"a.(string)":  "(a.(string))",
+		"a.(bool)":    "(a.(bool))",
+		"a.([]num)":   "(a.([]num))",
+		"a.({}[]num)": "(a.({}[]num))",
+
 		// Array literals
 		"[]":          "[]",
 		"[1]":         "[1]",
@@ -182,6 +189,7 @@ func TestParseTopLevelExpression(t *testing.T) {
 		parser.scope.set("n2", &Var{Name: "n2", T: NUM_TYPE})
 		parser.scope.set("s", &Var{Name: "s", T: STRING_TYPE})
 		parser.scope.set("b", &Var{Name: "b", T: BOOL_TYPE})
+		parser.scope.set("a", &Var{Name: "a", T: ANY_TYPE})
 		arrType := &Type{Name: ARRAY, Sub: BOOL_TYPE}
 		parser.scope.set("arr", &Var{Name: "arr", T: arrType})
 		arrType2 := &Type{Name: ARRAY, Sub: arrType}
@@ -233,8 +241,15 @@ func TestParseTopLevelExpressionErr(t *testing.T) {
 
 		"[1] + [false]": "line 1 column 5: mismatched type for +: []num, []bool",
 
-		"a. b":        `line 1 column 2: unexpected whitespace after "."`,
-		"a .b":        `line 1 column 3: unexpected whitespace before "."`,
+		"n1.(num)": "line 1 column 3: value of type assertion must be of type any, not num",
+		"a.(any)":  "line 1 column 2: cannot type assert to type any",
+		"a.(x)":    `line 1 column 2: invalid type in type assertion of "a"`,
+		"a.([]x)":  `line 1 column 2: invalid type in type assertion of "a"`,
+
+		"a. (num)":    `line 1 column 2: unexpected whitespace after "."`,
+		"a .(num)":    `line 1 column 3: unexpected whitespace before "."`,
+		"map. b":      `line 1 column 4: unexpected whitespace after "."`,
+		"map .b":      `line 1 column 5: unexpected whitespace before "."`,
 		"- 5":         `line 1 column 1: unexpected whitespace after "-"`,
 		"- n1":        `line 1 column 1: unexpected whitespace after "-"`,
 		"[3 +5]":      `line 1 column 4: unexpected whitespace before "+"`,
@@ -261,7 +276,8 @@ func TestParseTopLevelExpressionErr(t *testing.T) {
 		parser.scope = newScope(nil, &Program{})
 		parser.scope.set("n1", &Var{Name: "n1", T: NUM_TYPE})
 		mapType := &Type{Name: MAP, Sub: NUM_TYPE}
-		parser.scope.set("a", &Var{Name: "a", T: mapType})
+		parser.scope.set("map", &Var{Name: "map", T: mapType})
+		parser.scope.set("a", &Var{Name: "a", T: ANY_TYPE})
 
 		_ = parser.parseTopLevelExpr()
 		assertParseError(t, parser, input)

--- a/pkg/parser/format.go
+++ b/pkg/parser/format.go
@@ -125,6 +125,11 @@ func (f *formatting) format(n Node) {
 	case *DotExpression:
 		f.format(n.Left)
 		f.writes(".", n.Key)
+	case *TypeAssertion:
+		f.format(n.Left)
+		f.write(".(")
+		f.formatType(n.T)
+		f.write(")")
 	case *GroupExpression:
 		f.write("(")
 		f.format(n.Expr)

--- a/pkg/parser/format_test.go
+++ b/pkg/parser/format_test.go
@@ -325,6 +325,7 @@ func TestExpressionFormat(t *testing.T) {
 		"x := arr[1:n+3]":     "x := arr[1:n + 3]",
 		"x := arr[ :n+3]":     "x := arr[:n + 3]",
 		"x := arr[ n+3: ]":    "x := arr[n + 3:]",
+		"x := a.( num )":      "x := a.(num)",
 	}
 	for input, want := range tests {
 		before := `
@@ -332,8 +333,9 @@ n := 1
 arr := [1 2 3]
 m := {a:1 b:2}
 s := "a"
+a:any
 `[1:]
-		after := "\nprint n arr m s x\n"
+		after := "\nprint n arr m s a x\n"
 		input := before + input + after
 		want := before + want + after
 		t.Run(input, func(t *testing.T) {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -490,7 +490,7 @@ func (p *parser) parseTypedDecl() *Decl {
 	p.advance() // advance past `:`
 	v := p.parseType()
 	decl.Var.T = v
-	decl.Value = zeroValue(v.Name)
+	decl.Value = zeroValue(v, p.cur)
 	if v == ILLEGAL_TYPE {
 		msg := fmt.Sprintf("invalid type declaration for %q", varName)
 		p.appendErrorForToken(msg, decl.token)

--- a/pkg/parser/type.go
+++ b/pkg/parser/type.go
@@ -145,3 +145,13 @@ func (t *Type) acceptsStrict(t2 *Type) bool {
 	}
 	return t.Sub.acceptsStrict(t2.Sub)
 }
+
+func (t *Type) sameComposite(t2 *Type) bool {
+	if t.Name == ARRAY && t2.Name == ARRAY {
+		return true
+	}
+	if t.Name == MAP && t2.Name == MAP {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Implement type assertions as defined in the spec in the parser as a new
AST node type and in the evaluator to evaluate that AST node. Implement
the `typeof` builtin so that type assertions can be used safely and robustly
over a range of types.

Update the spec to make `typeof` more specified in the value returned for
arrays and maps, and cover the special case of empty array and map
literals that do not yet have a subtype.

A couple of small bugs have been fixed were AST nodes for literals were
not fully constructed, and where types were not inferred deeply enough
in the case of array and map elements of arrays and maps.