### PR TITLE
ci: Support auto-versioning of major/minor versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,10 +148,13 @@ nexttag:
 .PHONY: nexttag release
 
 define NEXTTAG_CMD
-{ git tag --list --merged HEAD --sort=-v:refname; echo v0.0.0; }
-| grep -E "^v?[0-9]+.[0-9]+.[0-9]+$$"
-| head -n1
-| awk -F . '{ print $$1 "." $$2 "." $$3 + 1 }'
+{
+  { git tag --list --merged HEAD --sort=-v:refname; echo v0.0.0; }
+  | grep -E "^v?[0-9]+\.[0-9]+\.[0-9]+$$"
+  | head -n 1
+  | awk -F . '{ print $$1 "." $$2 "." $$3 + 1 }';
+  git diff --name-only @^ | sed -E -n 's|^docs/release-notes/(v[0-9]+\.[0-9]+\.[0-9]+)\.md$$|\1|p';
+} | sort --reverse --version-sort | head -n 1
 endef
 
 # --- Utilities ----------------------------------------------------------------


### PR DESCRIPTION
Update the `NEXTTAG_CMD` command to identify when a release note has
been added in the latest master commit in `docs/release-notes/v*.md` and
extract the version from the filename. If that version is later than
what `NEXTTAG_CMD` would have used by default, use that version number
for the tag instead.

This allows creating a commit/PR with a new release note and have that
version get auto-tagged and released when merged to master.
