### PR TITLE
docs: Rework syntax by example

### DIFF
--- a/docs/syntax_by_example.md
+++ b/docs/syntax_by_example.md
@@ -1,13 +1,11 @@
 # Evy Syntax by Example
 
-The following examples give an intuitive understanding of various
-aspects of `evy`'s syntax. For a formal language specification see the
-[syntax grammar](syntax_grammar.md).
-
+The following examples will help you understand the syntax of Evy. For a
+more formal language specification, please see the [syntax grammar](syntax_grammar.md).
 
 ## Comment
 
-    // This is comment
+    // This is a comment
 
 ## Declaration
 
@@ -20,16 +18,16 @@ aspects of `evy`'s syntax. For a formal language specification see the
 
 ## Expression
 
-    x := 5 * (x + z)  - 2 / 7.6           // arithmetic number expression
+    x := 5 * (y + z)  - 2 / 7.6           // arithmetic number expression
     b := !trace and debug or level == ""  // bool expressions
 
 ## Strings
 
-    s1 := "quotation mark : \" " // escaping
-    s2 := "abc" + "🥪123"          // concatenation
+    s1 := "quotation mark : \" "          // escaping
+    s2 := "abc" + "🥪123"                 // concatenation
     s3 := "newline: \n indentation: \t"
-    s4 := s2[0]                  // "a"
-    s5 := s2[1:5]                // "bc🥪1"
+    s4 := s2[0]                           // "a"
+    s5 := s2[1:5]                         // "bc🥪1"
 
 ## `if` statements
 
@@ -50,7 +48,6 @@ aspects of `evy`'s syntax. For a formal language specification see the
             print "nested block 2"
         end
     end
-
 
 ## Loop statements
 
@@ -97,7 +94,7 @@ aspects of `evy`'s syntax. For a formal language specification see the
 
     x := 0
     while true
-        prints "tick..."
+        print "tick... "
         sleep 1
         if x > 9
             print "💥"
@@ -105,7 +102,6 @@ aspects of `evy`'s syntax. For a formal language specification see the
         end
         x = x + 1
     end
-
 
 ## Function definition
 
@@ -121,64 +117,69 @@ aspects of `evy`'s syntax. For a formal language specification see the
 
 ### Variadic
 
-    func my_print args:any...
-        for arg := range args
-            write arg
-            write " "
+    func list args:any...
+        for arg := range args[:-1]
+            printf "%v, " arg
         end
+        printf "%v" args[-1]
     end
+
+### Function calls
+
+    n := add 1 2        // 3
+    foxprint "🐾"       // 🦊 🐾  
+    list 2 true "blue"  // 2, true, blue
 
 ## Array
 
     a1:[]num
     a2:[][]string
-    a1 = [1 2 3 4]             // type: num[]
-    a2 = [["1" "2"]["a" "b"]]  // type: string[][]
-    a3 := [true false]         // type: bool[]
-    a4 := ["s1"                // line break allowed
-           "s2"]               // type: string[]
-    a5 := ["chars" 123]        // type: any[]
-    a6:[]any                   // type: any[]
+    a1 = [1 2 3 4]              // type: num[]
+    a2 = [["1" "2"] ["a" "b"]]  // type: string[][]
+    a3 := [true false]          // type: bool[]
+    a4 := ["s1"                 // line break allowed
+           "s2"]                // type: string[]
+    a5 := ["chars" 123]         // type: any[]
+    a6:[]any                    // type: any[]
 
 ### Array element access
 
     a1 := [1 2 3 4]
-    a2 := [["1" "2"]["a" "b"]]
-    print a1[1]    // 2
-    print a2[1][0] // "a"
+    a2 := [["1" "2"] ["a" "b"]]
+    print a1[1]                  // 2
+    print a2[1][0]               // "a"
+    print a1[-1]                  // 4
 
-### Concatenation, append, prepend
+### Concatenation
 
-    z = z + [ 100 ]    // z: [1 2 3 4 5 6 100]; optional extra whitespace 
-    z = z + [101]      // z: [1 2 3 4 5 6 100 101]
-    append z 102       // z: [1 2 3 4 5 6 100 101 102]
-    prepend z 0        // z: [0 1 2 3 4 5 6 100 101 102]
+    a := [1 2 3 4]
+    a = a + [ 100 ]          // [1 2 3 4 100]; optional extra whitespace 
+    a = [0] + a + [101 102]  // [0 1 2 3 4 100 101 102]
 
 ### Slicing
 
-    x := [1 2 3]
-    x1 := x[:2] // [1 2]
-    x2 = x[2]   // [3]
-    x2 = x[1:2] // [2]
-    x2 = x[-1]  // [3]
-    x2 = x[-2:] // [2 3]
+    a := [1 2 3]
+    b := a[:2]         // [1 2]
+    b = a[1:2]         // [2]
+    b = a[-2:]         // [2 3]
 
 ## Map
 
-    m1:{}any          // keys can only be identifiers, any value allowed
-    m2.name = "fox"
-    m2.age = 42
-
-    m3 := {letters:"abc" name:"Jill"}   // type: {}string
-    m4 := {}                            // type: {}any
-    m5 := {
-            letters:"abc"               // line break allowed
-            nums:123
-          }                             // type: {}any
-    m6:{}[]num                          // map of array of numbers
-    m6.digits = [1 2 3]
-    m7:{}num
-    m7.x = "y"                          // invalid, only num values allows
+    m1:{}any // keys used in literals or with `.` must be identifiers.
+    m1.name = "fox"
+    m1.age = 42
+    m1["key with space"] = "🔑🪐"
+    
+    m2 := {letters:"abc" name:"Jill"} // type: {}string
+    m3 := {}                          // type: {}any
+    m4 := {
+        letters:"abc"                 // line break allowed
+        nums:123
+    }                                 // type: {}any
+    m5:{}[]num                        // map of array of numbers
+    m5.digits = [1 2 3]
+    m6:{}num
+    //m6.x = "y"                      // invalid, only num values allowed
 
 ### Map value access
 
@@ -188,201 +189,47 @@ aspects of `evy`'s syntax. For a formal language specification see the
     print m[s]         // abc
     print m["letters"] // abc
 
-### Map value existence
+## `any`
 
-    p := { name: "Le Petit Prince", pet: "sheep" }
-    if has p "age" {
-        print "age" p.age
-    } 
-
-## Any
-
-    x:any     // any type
+    x:any     // any type, default value: false
     m1:{}any  // map with any value type
     m2 := { letter:"a" number:1 }
     arr1:[]any
     arr2 := [ "b" 2 ]
    
-## Type reflection
-
-    reflect "abc"         // {type: "string"}
-    reflect true          // {type: "bool"}
-    reflect [ 1 2 ]       // {type: "array",
-                          //  sub:  {type: "num"}
-                          // }
-    reflect [[1 2] [3 4]] // {
-                          //   type: "array",
-                          //   sub:  {
-                          //     type: "array"
-                          //     sub: {
-                          //       type: "num"
-                          //     }
-                          //   }
-                          // }
-
-### Type reflection Usage Example
-
-    v:any
-    v = "asdf"
-    if (reflect v) == {type: "string"}
-        print "v is a string:" v
-    end
-
-## Type conversion
-
-    b := str2bool "true" // true
-    n := str2num "123"   // 123
-    s1 := bool2str true  // "true"
-    s2 := num2str 42     // "42"
-
 ## Type assertion
 
     x:any
     x = [ 1 2 3 4 ]  // concrete type num[]
     s := x.([]num)
 
-## Variadic functions
+## Type reflection
 
-    func addmany:num arr:num...
-        result := 0
-        for x := range arr
-            result = result + x
-        end
-        return result
+    typeof "abc"          // "string"
+    typeof true           // "bool"
+    typeof [ 1 2 ]        // "[]num"
+    typeof [[1 2] [3 4]]  // "[][]num"
+
+    v:any
+    v = "🐐"
+    if (typeof v) == "string"
+        print "v is a string:" v
+        s := v.(string) // type assertion        
+        print s+s       // 🐐🐐 
     end
-
-    print addmany 1 2 3
-    arr := [ 4 5 6 ]
-    print (addmany arr...)
 
 ## Event handling 
 
-    on frame
-        draw
+    on key
+        print "key pressed"
     end
 
-    on key_press 
-        print key
+Evy can only handle a limited set of events, such as key presses, mouse
+movements, or periodic screen redraws.
+
+### Event handlers with parameters
+
+    on key k:string
+        printf "%q pressed\n" k
     end
-
-    on mouse_down
-        print mouse_x mouse_y
-    end
-
-## Builtin
-
-### Print
-    
-    print  "abc" 123 // abc 123\n
-    prints "abc" 123 // print string: abc123
-    printq "abc" 123  // print quoted, reuse as value: "abc"
-
-Returning a string:
-
-    sprint  "abc" 123 // returns "abc 123\n"
-    sprints "abc" 123 // returns "abc123"
-    sprintq "abc"     // returns "\"abc\""
-
-### Strings
-    
-    "Hello"[2]                // "l"
-    "Hello world"[1:5]        // "ello"
-    join [ "one" "two" ] ", " // "one, two"
-    split "hi there"          // [ "hi" "there" ]
-
-### Length
- 
-    len for strings, arrays and maps
-
-### Arrays
-
-    append x 100   // [ 1 2 3 100 ]
-    prepend x -100 // [ -100 1 2 3 100 ]
-
-### Maps
- 
-    m := {name: "abc"}
-    has m "abc" // true
-    del m "abc"
-    has m "abc" // false
-
-### Conversion
-
-    str2bool "true" // true
-    str2num "123"   // 123
-    num2str 123     // "123"
-    bool2str false  // "false"
-
-### Error
-
-    error  // global string error message of last error
-    errnum // error num to check for error type 0 ... 10 reserved 
-           // conversion error, index out of bounds, assertion error,
-    panic "error message" // terminates the program and prints "error message"
-
-### Time
-    
-    now                                 // return unix time in seconds
-    format_time now                     // "2022-08-28T23:59:05Z" Z is time zone zero
-    format_timef now "06/01/02 15:04"   // "22/01/02 15:04" 
-    parse_time "2022-08-28T23:59:05Z"   // internal representation as unix seconds
-    parse_timef value format
-    sleep 10                            // sleep 10 seconds
-
-See Go's [time.Layout] for further details on formatting and parsing.
-
-[time.Layout]: https://pkg.go.dev/time#pkg-constants
-
-### Events
-    
-    mouse_down mouse_up mouse_move
-    key_press
-
-Used in event handlers, e.g. `on mouse_down`.
-No support for custom events.
-
-### UI
-
-    move x y
-
-    circle radius
-    line end_x end_y
-    rect width height
-    curve // TBD
-    polygon [x1 y2] [x2 y2] [x3 y3]
-    polyline [x1 y1] [x2 y2] [x3 y3]
-
-    color  900   // CSS    #ff0000
-    colors "red" // CSS color keywords:     #ff0000
-    linewidth 1
-
-    text "some text"
-    textsize 12
-
-### Math
-   
-    div 7 3 // integer division
-    pow 2 3 // exponentiation
-    sqrt 2
-    logn 10
-    sin 45
-    asin 0.707
-    cos 45
-    acos 0.707
-    tan 45
-    atan 1
-    atan 100
-    atan2 100 0
-    pi
-    abs -21.34
-    floor 2.15
-    number "114.2"
-    random 10
-    randomf // [0 1.0)
-
-### Read
-
-    str := read
-    str := readln
-    str := readid query_selector // event.target.value
 


### PR DESCRIPTION
Rework syntax by example to match the current state of evy. Remove
references to builtin functions which will be treated in a separate
document.

---

There will be a bunch of follow up commits, next probably builtins,
then spec and README.md. I'm trying to keep things digestible here and just do one file at a time. Diff is probably a bit useless, 💰 

Maybe easiest reviewed on branch:
https://github.com/foxygoat/evy/blob/docs/docs/syntax_by_example.md