### PR TITLE
evy: Add `exit` builtin function

### DIFF
--- a/frontend/module/yace-editor.js
+++ b/frontend/module/yace-editor.js
@@ -456,6 +456,7 @@ const builtins = new Set([
   "del",
   "ellipse",
   "endswith",
+  "exit",
   "fill",
   "floor",
   "font",

--- a/main.go
+++ b/main.go
@@ -111,7 +111,12 @@ func (c *runCmd) Run() error {
 	}
 	builtins := evaluator.DefaultBuiltins(newCLIRuntime())
 	eval := evaluator.NewEvaluator(builtins)
-	return eval.Run(string(b))
+	err = eval.Run(string(b))
+	var exitErr evaluator.ExitError
+	if errors.As(err, &exitErr) {
+		os.Exit(int(exitErr))
+	}
+	return err
 }
 
 func (c *fmtCmd) Run() error {

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -66,6 +66,7 @@ func DefaultBuiltins(rt Runtime) Builtins {
 		"del": {Func: BuiltinFunc(delFunc), Decl: delDecl},
 
 		"sleep": {Func: sleepFunc(rt.Sleep), Decl: sleepDecl},
+		"exit":  {Func: BuiltinFunc(exitFunc), Decl: numDecl("exit")},
 
 		"rand":  {Func: BuiltinFunc(randFunc), Decl: randDecl},
 		"rand1": {Func: BuiltinFunc(rand1Func), Decl: rand1Decl},
@@ -494,6 +495,10 @@ func sleepFunc(sleepFn func(time.Duration)) BuiltinFunc {
 		sleepFn(dur)
 		return &None{}, nil
 	}
+}
+
+func exitFunc(_ *scope, args []Value) (Value, error) {
+	return nil, ExitError(args[0].(*Num).Val)
 }
 
 var randDecl = &parser.FuncDeclStmt{

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -40,7 +40,7 @@ type BuiltinFunc func(scope *scope, args []Value) (Value, error)
 func DefaultBuiltins(rt Runtime) Builtins {
 	funcs := map[string]Builtin{
 		"read":   {Func: readFunc(rt.Read), Decl: readDecl},
-		"cls":    {Func: clsFunc(rt.Cls), Decl: clsDecl},
+		"cls":    {Func: clsFunc(rt.Cls), Decl: emptyDecl("cls")},
 		"print":  {Func: printFunc(rt.Print), Decl: printDecl},
 		"printf": {Func: printfFunc(rt.Print), Decl: printDecl},
 
@@ -92,7 +92,7 @@ func DefaultBuiltins(rt Runtime) Builtins {
 		"colour": stringBuiltin("colour", rt.Color),
 
 		"clear": {Func: clearFunc(rt.Clear), Decl: clearDecl},
-		"grid":  {Func: gridFunc(rt.Gridn), Decl: gridDecl},
+		"grid":  {Func: gridFunc(rt.Gridn), Decl: emptyDecl("grid")},
 		"gridn": {Func: gridnFunc(rt.Gridn), Decl: gridnDecl},
 
 		"poly":    {Func: polyFunc(rt.Poly), Decl: polyDecl},
@@ -146,11 +146,6 @@ func readFunc(readFn func() string) BuiltinFunc {
 		s := readFn()
 		return &String{Val: s}, nil
 	}
-}
-
-var clsDecl = &parser.FuncDeclStmt{
-	Name:       "cls",
-	ReturnType: parser.NONE_TYPE,
 }
 
 func clsFunc(clsFn func()) BuiltinFunc {
@@ -563,11 +558,6 @@ func gridnFunc(gridnFn func(float64, string)) BuiltinFunc {
 	}
 }
 
-var gridDecl = &parser.FuncDeclStmt{
-	Name:       "gridn",
-	ReturnType: parser.NONE_TYPE,
-}
-
 func gridFunc(gridnFn func(float64, string)) BuiltinFunc {
 	return func(_ *scope, args []Value) (Value, error) {
 		gridnFn(10, "hsl(0deg 100% 0% / 50%)")
@@ -716,6 +706,13 @@ func fontFunc(fontFn func(map[string]any)) BuiltinFunc {
 		}
 		fontFn(properties)
 		return nil, nil
+	}
+}
+
+func emptyDecl(name string) *parser.FuncDeclStmt {
+	return &parser.FuncDeclStmt{
+		Name:       name,
+		ReturnType: parser.NONE_TYPE,
 	}
 }
 

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -32,6 +32,12 @@ var (
 	ErrAssignmentTarget = fmt.Errorf("%w: bad assignment target", ErrInternal)
 )
 
+type ExitError int
+
+func (e ExitError) Error() string {
+	return fmt.Sprintf("exit %d", int(e))
+}
+
 // Error is an Evy evaluator error.
 type Error struct {
 	err   error
@@ -40,6 +46,10 @@ type Error struct {
 
 func (e *Error) Error() string {
 	return e.token.Location() + ": " + e.err.Error()
+}
+
+func (e *Error) Unwrap() error {
+	return e.err
 }
 
 func newErr(node parser.Node, err error) *Error {

--- a/pkg/parser/format_test.go
+++ b/pkg/parser/format_test.go
@@ -6,11 +6,11 @@ import (
 	"foxygo.at/evy/pkg/assert"
 )
 
-func TestReturnStmtFormat(t *testing.T) {
+func TestFuncCallStmtFormat(t *testing.T) {
 	tests := map[string]string{
-		"return 1":                 "return 1\n",
-		"return    1  ":            "return 1\n",
-		"return  1   // a comment": "return 1 // a comment\n",
+		"print 1":                 "print 1\n",
+		"print    1  ":            "print 1\n",
+		"print  1   // a comment": "print 1 // a comment\n",
 	}
 	for input, want := range tests {
 		input, want := input, want
@@ -53,87 +53,87 @@ end // end comment
 func TestIfStmtFormat(t *testing.T) {
 	tests := map[string]string{
 		`if true
-return 1
+print 1
 else if false
-return 2
+print 2
 else
-return 3
+print 3
 end
 `: `
 if true
-    return 1
+    print 1
 else if false
-    return 2
+    print 2
 else
-    return 3
+    print 3
 end
 `[1:],
 		`if true
   if true
-    return 1
+    print 1
   else
-    return 1.5
+    print 1.5
   end
 else if false
   if true
-    return 2
+    print 2
   end
 else
   if true
-    return 3
+    print 3
   else if true
-    return 4
+    print 4
   end
 end
 `: `
 if true
     if true
-        return 1
+        print 1
     else
-        return 1.5
+        print 1.5
     end
 else if false
     if true
-        return 2
+        print 2
     end
 else
     if true
-        return 3
+        print 3
     else if true
-        return 4
+        print 4
     end
 end
 `[1:],
 		`if true  // if comment
-		return 1 // 1 comment
+		print 1 // 1 comment
 		else if false // else if comment
-		return 2 // 2 comment
+		print 2 // 2 comment
 		else // else comment
-		return 3 // 3 comment
+		print 3 // 3 comment
 		end // end comment
 		`: `
 if true // if comment
-    return 1 // 1 comment
+    print 1 // 1 comment
 else if false // else if comment
-    return 2 // 2 comment
+    print 2 // 2 comment
 else // else comment
-    return 3 // 3 comment
+    print 3 // 3 comment
 end // end comment
 `[1:],
 		`if true
-return 1
+print 1
 end
 `: `
 if true
-    return 1
+    print 1
 end
 `[1:],
 		`if true  // if comment
-		return 1 // 1 comment
+		print 1 // 1 comment
 		end // end comment
 		`: `
 if true // if comment
-    return 1 // 1 comment
+    print 1 // 1 comment
 end // end comment
 `[1:],
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -783,7 +783,9 @@ func (p *parser) parseReturnStatement() Node {
 			p.assertEOL()
 		}
 	}
-	if !p.scope.returnType.Accepts(ret.T) {
+	if p.scope.returnType == nil {
+		p.appendErrorForToken("return statement not allowed here", retValueToken)
+	} else if !p.scope.returnType.Accepts(ret.T) {
 		msg := "expected return value of type " + p.scope.returnType.String() + ", found " + ret.T.String()
 		if p.scope.returnType == NONE_TYPE && ret.T != NONE_TYPE {
 			msg = "expected no return value, found " + ret.T.String()

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -224,7 +224,7 @@ func nums3
 		return
 	end
 end
-return "success"
+print "success"
 func nums4:num
 	a := 5
 	while true
@@ -309,15 +309,17 @@ func nums:num
 end
 `: "line 12 column 2: unreachable code",
 		`
-while true
-	if true
-		return 1
-	else
-		return 2
+func foo
+	while true
+		if true
+			return
+		else
+			return
+		end
+		print "deadcode"
 	end
-	print "deadcode"
 end
-`: "line 8 column 2: unreachable code",
+`: "line 9 column 3: unreachable code",
 		`
 foo
 return false
@@ -325,7 +327,7 @@ func foo
   print "hello"
 end
 print "do i run?"
-`: "line 7 column 1: unreachable code",
+`: "line 3 column 8: return statement not allowed here",
 		`
 func nums:num
 	while true

--- a/pkg/parser/scope.go
+++ b/pkg/parser/scope.go
@@ -4,12 +4,12 @@ type scope struct {
 	vars       map[string]*Var
 	outer      *scope
 	block      Node
-	returnType *Type // TODO: maybe get rid of returnType and look up the scope chain for Func nodes and their return type
+	returnType *Type
 }
 
 func newScope(outer *scope, node Node) *scope {
 	if outer == nil {
-		return newScopeWithReturnType(nil, node, ANY_TYPE)
+		return newScopeWithReturnType(nil, node, nil)
 	}
 	return newScopeWithReturnType(outer, node, outer.returnType)
 }

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -31,15 +31,17 @@ func main() {
 		formattedInput := ast.Format()
 		if formattedInput != input {
 			setEvySource(formattedInput)
+			ast, err = parse(formattedInput, rt)
+			if err != nil {
+				jsError(err.Error())
+				return
+			}
 		}
 	}
 	if actions["ui"] {
 		prepareUI(ast)
 	}
 	if actions["eval"] {
-		// The ast does not correspond to the formatted source code. For
-		// now this is acceptable because evaluator errors don't output
-		// source code locations.
 		err := evaluate(ast, rt)
 		if err != nil && !errors.Is(err, evaluator.ErrStopped) {
 			jsError(err.Error())

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -43,9 +43,14 @@ func main() {
 	}
 	if actions["eval"] {
 		err := evaluate(ast, rt)
-		if err != nil && !errors.Is(err, evaluator.ErrStopped) {
-			jsError(err.Error())
+		if err == nil || errors.Is(err, evaluator.ErrStopped) {
+			return
 		}
+		var exitErr evaluator.ExitError
+		if errors.As(err, &exitErr) && exitErr == 0 {
+			return
+		}
+		jsError(err.Error())
 	}
 }
 


### PR DESCRIPTION
Add `exit N` builtin function calling os.Exit(N) on the evy CLI and
terminating the wasm interpreter on the web. On the web for exit status
greater 0 a runtime error type output is generated pointing to the line
that caused the exit.

In preparation remove top level return statements which where a bit
weird to start with. And sneak in a re-parse for correct token location
after formatting and a builtin emptyDecl refactor.