### PR TITLE
housekeeping: Reformat with new prettier, adjust UI funcs

### DIFF
--- a/frontend/404.html
+++ b/frontend/404.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -442,7 +442,9 @@ main.view-output {
 .run button#run-mobile {
   color: var(--btn-color);
   background: var(--btn-bg);
-  box-shadow: 0 4px 0 hsl(0deg 0% 42%), 0 16px 12px -8px hsl(0deg 0% 0% / 42%),
+  box-shadow:
+    0 4px 0 hsl(0deg 0% 42%),
+    0 16px 12px -8px hsl(0deg 0% 0% / 42%),
     inset 0 -2px 1px 1px hsl(0deg 0% 42%);
   border-radius: 10px;
   font-weight: 700;
@@ -460,7 +462,9 @@ main.view-output {
 }
 .run button:disabled {
   color: var(--btn-color-disabled);
-  box-shadow: 0 4px 0 hsl(0deg 0% 60%), 0 16px 12px -8px hsl(0deg 0% 0% / 30%),
+  box-shadow:
+    0 4px 0 hsl(0deg 0% 60%),
+    0 16px 12px -8px hsl(0deg 0% 0% / 30%),
     inset 0 -2px 1px 1px hsl(0deg 0% 60%);
   cursor: not-allowed;
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -575,7 +575,7 @@ function ellipse(x, y, radiusX, radiusY, rotation, startAngle, endAngle) {
     transformX(radiusY),
     rotation * rad,
     startAngle * rad,
-    endAngle * rad
+    endAngle * rad,
   )
   fill && ctx.fill()
   stroke && ctx.stroke()

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -436,8 +436,8 @@ function initCanvas() {
 }
 
 function resetCanvas() {
+  clear(0, 0)
   const ctx = canvas.ctx
-  ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
   ctx.fillStyle = "black"
   ctx.strokeStyle = "black"
   ctx.lineWidth = 1
@@ -526,11 +526,10 @@ function circle(r) {
 // clear is exported to evy go/wasm.
 function clear(ptr, len) {
   const ctx = canvas.ctx
-  if (len === 0) {
-    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
-    return
+  let color = "white"
+  if (len !== 0) {
+    color = memToString(ptr, len)
   }
-  const color = memToString(ptr, len)
   const prevColor = ctx.fillStyle
   ctx.fillStyle = color
   ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height)
@@ -622,9 +621,9 @@ function gridn(unit, ptr, len) {
   const restoreStrokeStyle = ctx.strokeStyle
   ctx.strokeStyle = memToString(ptr, len)
   let lineCnt = 0
-  for (let i = unit; i < 100; i += unit) {
-    lineCnt += 1
+  for (let i = 0; i <= 100; i += unit) {
     ctx.lineWidth = lineCnt % 5 === 0 ? 2 : 1
+    lineCnt += 1
     move(i, 0)
     line(i, 100)
     move(0, i)

--- a/frontend/module/yace-editor.js
+++ b/frontend/module/yace-editor.js
@@ -144,7 +144,7 @@ function runPlugins(plugins, event) {
         ...plugin(acc, event),
       }
     },
-    { value, selectionStart, selectionEnd }
+    { value, selectionStart, selectionEnd },
   )
 }
 
@@ -234,7 +234,7 @@ function isKey(string, event) {
         shiftKey: false,
       },
       keyCode: null,
-    }
+    },
   )
 
   const hasModifiers = Object.keys(keys.modifiers).every((key) => {


### PR DESCRIPTION
It seems that prettier 3.0.0 was just released and formats some things
differently by default, so reformat accordingly.

Also, change canvas default background from "transparent" to "white" and
add grid lines at 0 and 100 - as this has been useful in creating docs
and samples.