### PR TITLE
docs: Add builtin docs for conversion functions and errors

### DIFF
--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -438,3 +438,149 @@ number, but it is typically used to indicate whether the program
 terminated successfully or with an error. A status code of 0 means that
 the program terminated successfully, while any other status code is
 considered an error.
+
+## Conversion
+
+### `str2num`
+
+`str2num` converts a string to a number. If the string is not a valid
+number, it returns `0` and sets the global `err` variable to `true`.
+
+#### Example
+
+```evy
+n:num
+n = str2num "1"
+print "n:" n "err:" err
+n = str2num "NOT-A-NUMBER"
+print "n:" n "err:" err
+```
+
+Output
+```evy:output
+n: 1 err: false
+n: 0 err: true
+```
+
+#### Reference
+
+    str2num:num s:string
+
+The `str2num` function converts a string to a number. It takes a single
+argument, which is the string to convert. If the string is a valid
+number, the function returns the number. Otherwise, the function
+returns 0 and sets the global `err` variable to `true`. For more
+information on `err`, see the [Non-fatal Error section](#non-fatal-errors).
+
+### `str2bool`
+
+`str2bool` converts a string to a boolean. If the string is not a valid
+boolean, it returns `false` and sets the global `err` variable to
+`true`.
+
+#### Example
+
+```evy
+b:bool
+b = str2bool "true"
+print "b:" b "err:" err
+b = str2bool "NOT-A-BOOL"
+print "b:" b "err:" err
+```
+
+Output
+```evy:output
+b: true err: false
+b: false err: true
+```
+
+#### Reference
+
+    str2bool:bool s:string
+
+The `str2bool` function converts a string to a bool. It takes a single
+argument, which is the string to convert. The function returns `true`
+if the string is equal to `"true"`, `"True"`, `"TRUE"`,  or `"1"`, and
+`false` if the string is equal to `"false"`, `"False"`, `"FALSE"`, or
+`"0"`. The function returns `false` and sets the global `err` variable
+to `true` if the string is not a valid boolean. For more information
+on `err`, see the [Non-fatal Error section](#non-fatal-errors).
+
+## Error
+
+Evy programs in execution can report two types of errors:
+
+- Fatal errors
+- Non-fatal errors
+
+### Fatal Errors
+
+Fatal errors cause the program to exit immediately with an error
+message. They typically occur when the program encounters a situation
+that it cannot handle, such as trying to access an element of an array
+that is out of bounds. Fatal errors cannot be intercepted by the
+program, so it is important to take steps to prevent them from
+occurring in the first place. 
+
+One way to do this is to use _guarding code_, which is code that checks
+for potential errors and takes steps to prevent them from occurring.
+For example, guarding code could be used to check the length of an
+array before trying to access an element to avoid an out of bounds
+error. If the access index is out of bounds, the guarding code could
+report the error.
+
+Here is an example of a fatal error:
+
+```evy
+arr := [0 1 2]
+i := 5 // e.g. user input
+print arr[i] // out of bounds
+print "This line will not be executed"
+```
+
+This code will cause a fatal error because the index 5 is out of bounds
+for the array `arr`. The program will exit with the error message 
+
+```
+line 3: index out of bounds: 5
+```
+
+### Non-fatal Errors
+
+The global `err` variable is used to indicate whether a non-fatal
+error has occurred. The global `errmsg` variable stores a detailed
+message about the error that occurred.
+
+Non-fatal errors are caused by code that could not be prevented from
+running, such as converting a user input string to a number if the
+string is not a number. Non-fatal errors will set the global `err`
+variable to `true` and the program will continue executing. If there is
+no error, `err` is set to `false`.
+
+The global `errmsg` variable stores a detailed message about the error
+which is set alongside `err`. `errmsg` is set to the empty string `""`
+if no error has occurred.  If an error does occur, `errmsg` is set to a
+message that describes the error.
+
+When a function that could potentially cause an error finishes executing
+without an error, the `err` variable is reset to `false` and the
+`errmsg` variable is set to the empty string. This is done even if the
+`err` variable was previously set to `true` or the `errmsg` variable
+was not empty. Therefore, it is up to the program to check the `err`
+variable after any possible error occurrence.
+
+Here is an example of a non-fatal error:
+
+```evy
+n := str2num "NOT A NUM"
+print "num:" n
+print "err:" err
+print "errmsg:" errmsg
+```
+
+Output
+```evy:output
+num: 0
+err: true
+errmsg: str2num: cannot parse "NOT A NUM"
+```

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -31,7 +31,7 @@ array: [1 2 3]
 map: {name:Scholl age:21}
 ```
 
-#### Reference 
+#### Reference
 
     print a:any...
 
@@ -81,7 +81,7 @@ Output
 Hello, Mary Jackson!
 ```
 
-#### Reference 
+#### Reference
 
     read:string
 
@@ -111,7 +111,7 @@ Output
 Bye
 ```
 
-#### Reference 
+#### Reference
 
     cls
 
@@ -170,7 +170,7 @@ Array: [1 2 3]
 Map: {a:1 b:2}
 ```
 
-#### Reference 
+#### Reference
 
     printf format:string a:any...
 
@@ -263,7 +263,7 @@ len [1 2]: 2
 len {a:3 b:4 c:5}: 3
 ```
 
-#### Reference 
+#### Reference
 
     len:num a:any
 
@@ -307,7 +307,7 @@ typeof [1 2 true]: []any
 typeof []: []
 ```
 
-#### Reference 
+#### Reference
 
     typeof:string a:any
 
@@ -339,7 +339,7 @@ has {a:1} "a": true
 has {a:1} "X": false
 ```
 
-#### Reference 
+#### Reference
 
     has:bool map:{} key:string
 
@@ -365,7 +365,7 @@ Output
 {a:1}
 ```
 
-#### Reference 
+#### Reference
 
     del map:{} key:string
 
@@ -397,7 +397,7 @@ Output
 1
 ```
 
-#### Reference 
+#### Reference
 
     sleep seconds:num
 
@@ -428,7 +428,7 @@ Output
 str2num: cannot parse "not a number"
 ```
 
-#### Reference 
+#### Reference
 
     exit status:num
 


### PR DESCRIPTION
Add builtin documentation for sections: conversion and errors.
The following list shows the new sections in context.

- ✅ I/O
- ✅ Types
- ✅ Map
- ✅ Program Control
- 👉 Conversion
- 👉 Error
- ⬜️ String
- ⬜️ Random
- ⬜️ Math
- ⬜️ UI
- ⬜️ Event Handlers

Fix a couple of accidentally left of over whitespace in previous PRs.

---

Rendered markdown:
https://github.com/foxygoat/evy/blob/builtin-strings/docs/builtins.md#conversion

Current WIP:
https://github.com/foxygoat/evy/blob/builtin-wip/docs/builtins.md
