### PR TITLE
make: Run prettier format checks on all files

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -2,48 +2,48 @@ name: ci/cd
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
 
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - run: ./bin/make ci
-      env:
-        TERM: vt100
-    - run: ./bin/make firebase-deploy
-      if: ${{ github.event_name == 'pull_request' }} # only run on PR, deploy prod/master in release job
-      env:
-        FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: ./bin/make ci
+        env:
+          TERM: vt100
+      - run: ./bin/make firebase-deploy
+        if: ${{ github.event_name == 'pull_request' }} # only run on PR, deploy prod/master in release job
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     runs-on: ubuntu-latest
-    needs: [ ci ]
+    needs: [ci]
     if: ${{ github.event_name == 'push' }} # only run on push to master
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - run: ./bin/make release
-      env:
-        GITHUB_APP_ID: ${{ secrets.BOXYGOAT_GITHUB_APP_ID }}
-        GITHUB_APP_PEM: ${{ secrets.BOXYGOAT_GITHUB_APP_PEM }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - run: ./bin/make firebase-deploy-prod
-      env:
-        FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG }}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: ./bin/make release
+        env:
+          GITHUB_APP_ID: ${{ secrets.BOXYGOAT_GITHUB_APP_ID }}
+          GITHUB_APP_PEM: ${{ secrets.BOXYGOAT_GITHUB_APP_PEM }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: ./bin/make firebase-deploy-prod
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_EVY_LANG }}
 
   howl-on-fail:
     runs-on: ubuntu-latest
-    needs: [ ci, release ]
+    needs: [ci, release]
     if: ${{ always() && github.event_name == 'push' && ( needs.ci.result == 'failure' ||  needs.release.result == 'failure' ) }}
     steps:
-    - uses: foxygoat/howl@v1
-      env:
-        SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
-        SLACK_TEXT: <!here|here>
+      - uses: foxygoat/howl@v1
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+          SLACK_TEXT: <!here|here>

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,6 @@
 issues:
-   exclude-use-default: false
-   exclude:
+  exclude-use-default: false
+  exclude:
     - "^don't use ALL_CAPS"
     - "^ST1003: should not use ALL_CAPS"
     - "^G304: Potential file inclusion via variable"

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,20 +1,20 @@
 {
-	"semi": false,
-	"singleQuote": false,
-	"htmlWhitespaceSensitivity": "ignore",
-	"printWidth": 100,
-	"overrides": [
-	{
-		"files": "*.svg",
-		"options": {
-			"parser": "html"
-		}
-	},
-	{
-		"files": "*.html",
-		"options": {
-			"printWidth": 115
-		}
-	}
+  "semi": false,
+  "singleQuote": false,
+  "htmlWhitespaceSensitivity": "ignore",
+  "printWidth": 100,
+  "overrides": [
+    {
+      "files": "*.svg",
+      "options": {
+        "parser": "html"
+      }
+    },
+    {
+      "files": "*.html",
+      "options": {
+        "printWidth": 115
+      }
+    }
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ all: build test lint tiny test-tiny check-coverage sh-lint check-prettier check-
 ci: clean check-uptodate all ## Full clean build and up-to-date checks as run on CI
 
 check-uptodate: tidy fmt doctest
-	test -z "$$(git status --porcelain -- go.mod go.sum $(GOFILES) $(DOCTESTS))" || { git status; false; }
+	test -z "$$(git status --porcelain)" || { git status; false; }
 
 clean:: ## Remove generated files
 	-rm -rf $(O)
@@ -101,11 +101,11 @@ frontend: tiny | $(O) ## Build frontend, typically iterate with npm and inside f
 frontend-serve: frontend ## Build frontend and serve on free port
 	servedir $(O)/public
 
-prettier: | $(NODELIB) ## Format frontend code with prettier
-	npx -y prettier --write frontend
+prettier: | $(NODELIB) ## Format code with prettier
+	npx -y prettier --write .
 
-check-prettier: | $(NODELIB)  ## Ensure frontend code is formatted with prettier
-	npx -y prettier --check frontend
+check-prettier: | $(NODELIB)  ## Ensure code is formatted with prettier
+	npx -y prettier --check .
 
 $(NODELIB):
 	@mkdir -p $@

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -15,7 +15,7 @@ key.
 `print` prints the arguments given to it to the output area. It separates them by
 a single space and outputs a newline character at the end.
 
-#### Example 
+#### Example
 
 ```evy
 print "Hello"
@@ -23,7 +23,9 @@ print 2 true "blue"
 print "array:" [1 2 3]
 print "map:" {name:"Scholl" age:21}
 ```
+
 Output
+
 ```evy:output
 Hello
 2 true blue
@@ -37,20 +39,21 @@ map: {name:Scholl age:21}
 
 The `print` function prints its arguments to the output area, each
 separated by a single space and terminated by a newline character. If
-no arguments are provided it only prints the newline character. 
+no arguments are provided it only prints the newline character.
 
 The backslash character `\` can be used to represent special characters
 in strings. For example, the `\t` escape sequence represents a tab
 character, and the `\n` escape sequence represents a newline character.
 Quotes in string literals must also be escaped with backslashes,
 otherwise they will be interpreted as the end of the string literal.
-For example: 
+For example:
 
 ```evy
 print "Here's a tab: 👉\t👈\nShe said: \"Thank you!\""
 ```
 
 Output
+
 ```evy:output
 Here's a tab: 👉	👈
 She said: "Thank you!"
@@ -61,22 +64,25 @@ running Evy from the command line interface, `print` prints to standard
 out.
 
 ### `read`
- 
+
 `read` reads a line of input from the user and returns it as a
 string. The newline character is not included in the returned string.
 
 #### Example
+
 ```evy
 name := read
 print "Hello, "+name+"!"
 ```
 
 Input
+
 ```evy:input
 Mary Jackson
 ```
 
 Output
+
 ```evy:output
 Hello, Mary Jackson!
 ```
@@ -99,6 +105,7 @@ in.
 `cls` clears the output area of all printed text.
 
 #### Example
+
 ```evy
 print "Hello"
 sleep 1
@@ -107,6 +114,7 @@ print "Bye"
 ```
 
 Output
+
 ```evy:output
 Bye
 ```
@@ -129,15 +137,15 @@ string. The format string is the first argument, and it
 contains _specifiers_. Specifiers start with a percent sign `%`. They
 tell the `printf` function how and where to print the remaining
 arguments inside the format string. The rest of the format string is
-printed to the output area without changes. 
+printed to the output area without changes.
 
 Here are some valid specifiers in Evy:
 
-| Specifier | Description |
-| --------- | ------------- |
-| `%v`      | the argument in its default format  |
-| `%q`      | a double-quoted string |
-| `%%`      | a percent sign `%`  |
+| Specifier | Description                        |
+| --------- | ---------------------------------- |
+| `%v`      | the argument in its default format |
+| `%q`      | a double-quoted string             |
+| `%%`      | a percent sign `%`                 |
 
 #### Example
 
@@ -158,6 +166,7 @@ printf "Map: %v\n" {a:1 b:2}
 ```
 
 Output
+
 ```evy:output
 The tank is 100% full.
 
@@ -183,15 +192,15 @@ A, second: B`.
 
 Full list of valid specifiers in Evy:
 
-| Specifier | Description |
-| --------- | ------------- |
-| `%v`      | the argument in a default format  |
-| `%t`      | the word `true` or `false` |
+| Specifier | Description                                            |
+| --------- | ------------------------------------------------------ |
+| `%v`      | the argument in a default format                       |
+| `%t`      | the word `true` or `false`                             |
 | `%f`      | decimal point (floating-point) number, e.g. 123.456000 |
-| `%e`      | scientific notation, e.g. -1.234456e+78 |
-| `%s`      | string value |
-| `%q`      | a double-quoted string |
-| `%%`      | a literal percent sign `%`; consumes no value  |
+| `%e`      | scientific notation, e.g. -1.234456e+78                |
+| `%s`      | string value                                           |
+| `%q`      | a double-quoted string                                 |
+| `%%`      | a literal percent sign `%`; consumes no value          |
 
 If the arguments for the `%s`, `%q`, `%f`, `%e`, and `%t` specifiers do
 not match the required type, a fatal runtime error will occur.
@@ -204,18 +213,18 @@ with the `%f` and `%v` format specifiers.
   the size of the number. It can be useful for padding and aligned
   output.
 - Precision is the number of decimal places that will be displayed. If
-  the precision is not specified, it will be set to 6 for `%f`. 
+  the precision is not specified, it will be set to 6 for `%f`.
 
 Here is a table that shows the different ways to specify the width and
 precision of a floating-point number:
 
-| Verb    | Description |
-| ------- | ------------- |
+| Verb    | Description                      |
+| ------- | -------------------------------- |
 | `%f`    | default width, default precision |
-| `%7f`   | width 7, default precision |
-| `%.2f`  | default width, precision 2 |
-| `%7.2f` | width 7, precision 2 |
-| `%7.f`  | width 7, precision 0 |
+| `%7f`   | width 7, default precision       |
+| `%.2f`  | default width, precision 2       |
+| `%7.2f` | width 7, precision 2             |
+| `%7.f`  | width 7, precision 0             |
 
 If the width/precision is preceded by a `-`, the value is padded with
 spaces on the right rather than the left. If it is preceded by a 0, the
@@ -229,7 +238,9 @@ printf "right:  |%7.2f|\n" 1
 printf "left:   |%-7.2v|\n" "abcd"
 printf "zeropad:|%07.2f|\n" 1.2345
 ```
+
 Output
+
 ```evy:output
 right:  |   1.00|
 left:   |ab     |
@@ -257,6 +268,7 @@ print "len {a:3 b:4 c:5}:" l
 ```
 
 Output
+
 ```evy:output
 len "abcd": 4
 len [1 2]: 2
@@ -299,6 +311,7 @@ print "typeof []:" (typeof [])
 ```
 
 Output
+
 ```evy:output
 typeof "abcd": string
 typeof {kind:true strong:true}: {}bool
@@ -334,6 +347,7 @@ printf "has %v %q: %t\n" map "X" (has map "X")
 ```
 
 Output
+
 ```evy:output
 has {a:1} "a": true
 has {a:1} "X": false
@@ -361,6 +375,7 @@ print map
 ```
 
 Output
+
 ```evy:output
 {a:1}
 ```
@@ -392,6 +407,7 @@ print "1"
 ```
 
 Output
+
 ```evy:output
 2
 1
@@ -424,6 +440,7 @@ print n
 ```
 
 Output
+
 ```evy:output
 str2num: cannot parse "not a number"
 ```
@@ -457,6 +474,7 @@ print "n:" n "err:" err
 ```
 
 Output
+
 ```evy:output
 n: 1 err: false
 n: 0 err: true
@@ -489,6 +507,7 @@ print "b:" b "err:" err
 ```
 
 Output
+
 ```evy:output
 b: true err: false
 b: false err: true
@@ -500,7 +519,7 @@ b: false err: true
 
 The `str2bool` function converts a string to a bool. It takes a single
 argument, which is the string to convert. The function returns `true`
-if the string is equal to `"true"`, `"True"`, `"TRUE"`,  or `"1"`, and
+if the string is equal to `"true"`, `"True"`, `"TRUE"`, or `"1"`, and
 `false` if the string is equal to `"false"`, `"False"`, `"FALSE"`, or
 `"0"`. The function returns `false` and sets the global `err` variable
 to `true` if the string is not a valid boolean. For more information
@@ -520,7 +539,7 @@ message. They typically occur when the program encounters a situation
 that it cannot handle, such as trying to access an element of an array
 that is out of bounds. Fatal errors cannot be intercepted by the
 program, so it is important to take steps to prevent them from
-occurring in the first place. 
+occurring in the first place.
 
 One way to do this is to use _guarding code_, which is code that checks
 for potential errors and takes steps to prevent them from occurring.
@@ -539,7 +558,7 @@ print "This line will not be executed"
 ```
 
 This code will cause a fatal error because the index 5 is out of bounds
-for the array `arr`. The program will exit with the error message 
+for the array `arr`. The program will exit with the error message
 
 ```
 line 3: index out of bounds: 5
@@ -559,7 +578,7 @@ no error, `err` is set to `false`.
 
 The global `errmsg` variable stores a detailed message about the error
 which is set alongside `err`. `errmsg` is set to the empty string `""`
-if no error has occurred.  If an error does occur, `errmsg` is set to a
+if no error has occurred. If an error does occur, `errmsg` is set to a
 message that describes the error.
 
 When a function that could potentially cause an error finishes executing
@@ -579,6 +598,7 @@ print "errmsg:" errmsg
 ```
 
 Output
+
 ```evy:output
 num: 0
 err: true

--- a/docs/syntax_by_example.md
+++ b/docs/syntax_by_example.md
@@ -75,7 +75,7 @@ Builtin functions, such as `print` and `circle`, are documented in the
         print x           // 1 3 5 7 9
     end
 
-    for x := range -10 
+    for x := range -10
         print x        // nothing. step is 1 by default.
     end
 
@@ -129,7 +129,7 @@ Builtin functions, such as `print` and `circle`, are documented in the
 ### Function calls
 
     n := add 1 2        // 3
-    foxprint "🐾"       // 🦊 🐾  
+    foxprint "🐾"       // 🦊 🐾
     list 2 true "blue"  // 2, true, blue
 
 ## Array
@@ -155,7 +155,7 @@ Builtin functions, such as `print` and `circle`, are documented in the
 ### Concatenation
 
     a := [1 2 3 4]
-    a = a + [ 100 ]          // [1 2 3 4 100]; optional extra whitespace 
+    a = a + [ 100 ]          // [1 2 3 4 100]; optional extra whitespace
     a = [0] + a + [101 102]  // [0 1 2 3 4 100 101 102]
 
 ### Slicing
@@ -171,7 +171,7 @@ Builtin functions, such as `print` and `circle`, are documented in the
     m1.name = "fox"
     m1.age = 42
     m1["key with space"] = "🔑🪐"
-    
+
     m2 := {letters:"abc" name:"Jill"} // type: {}string
     m3 := {}                          // type: {}any
     m4 := {
@@ -185,7 +185,7 @@ Builtin functions, such as `print` and `circle`, are documented in the
 
 ### Map value access
 
-    m := {letters:"abc" name:"Jill"}   
+    m := {letters:"abc" name:"Jill"}
     s := "letters"
     print m.letters    // abc
     print m[s]         // abc
@@ -198,7 +198,7 @@ Builtin functions, such as `print` and `circle`, are documented in the
     m2 := { letter:"a" number:1 }
     arr1:[]any
     arr2 := [ "b" 2 ]
-   
+
 ## Type assertion
 
     x:any
@@ -216,11 +216,11 @@ Builtin functions, such as `print` and `circle`, are documented in the
     v = "🐐"
     if (typeof v) == "string"
         print "v is a string:" v
-        s := v.(string) // type assertion        
-        print s+s       // 🐐🐐 
+        s := v.(string) // type assertion
+        print s+s       // 🐐🐐
     end
 
-## Event handling 
+## Event handling
 
     on key
         print "key pressed"
@@ -234,4 +234,3 @@ movements, or periodic screen redraws.
     on key k:string
         printf "%q pressed\n" k
     end
-

--- a/docs/syntax_grammar.md
+++ b/docs/syntax_grammar.md
@@ -63,7 +63,7 @@ horizontal whitespace, `<-` … `->` and `<+` … `+>`. `<-` … `->` means
 no horizontal whitespace is allowed between the terminals of the
 enclosed expression, e.g. `3+5` inside `<-` … `->` is allowed, but
 `3 + 5` is not. The fencing tokens `<+` … `+>` are the default and mean
-horizontal whitespace is allowed (again) between terminals. 
+horizontal whitespace is allowed (again) between terminals.
 
 See section [whitespace](#whitespace) for further details.
 
@@ -75,8 +75,8 @@ not allowed.
     program    = { statement | func | event_handler | NL } .
     statements = statement { statement } .
     statement  = typed_decl_stmt | inferred_decl_stmt |
-                 assign_stmt | 
-                 func_call_stmt | 
+                 assign_stmt |
+                 func_call_stmt |
                  return_stmt | break_stmt |
                  if_stmt | for_stmt | while_stmt .
 
@@ -146,7 +146,7 @@ not allowed.
     operand    = literal | assignable | slice | type_assertion | group_expr .
     group_expr = "(" <+ toplevel_expr +> ")" . /* WS can be used freely within `(…)` */
     type_assertion = <- assignable "." "(" type ")" -> .
-    
+
     unary_expr = <- UNARY_OP -> expr .  /* WS not allowed after UNARY_OP */
     UNARY_OP   = "-" | "!" .
 
@@ -178,7 +178,6 @@ not allowed.
     NL             = "\n" {"\n"} .
     WS             = " " | "\t" {" " | "\t"} .
 
-
 ## Comments
 
 There is only one type of comment, the line comment which starts with
@@ -192,7 +191,7 @@ composite types: [arrays](#arrays) `[]` and [maps](#maps) `{}`.
 The _dynamic_ type `any` can hold any of the previously listed
 types.
 
-Composite types can nest further composite types, for example 
+Composite types can nest further composite types, for example
 `[]{}string` is an array of maps with string values.
 
 A `bool` value is either `true` or `false`.
@@ -213,7 +212,7 @@ declaration_. With the inferred declaration the type is not given but
 inferred from the value. With typed declaration the type is explicitly
 specified and the variable is initialised to its type's zero value.
 
-    a1 := 1 // inferred declaration of variable 'a1' 
+    a1 := 1 // inferred declaration of variable 'a1'
             // with type 'num' and value 1.
     a2:num  // typed declaration of variable 'a2'
             // with type 'num' and zero value 0.
@@ -245,8 +244,8 @@ value of their type:
 ## Assignments
 
 Assignments are defined by an equal sign `=`. The left hand side of the
-`=` must contain an _assignable_, a variable, an indexed array 
-(`arr[1] = "abc"`) or a map field (`person.age = 42`), see [Arrays](#Arrays) 
+`=` must contain an _assignable_, a variable, an indexed array
+(`arr[1] = "abc"`) or a map field (`person.age = 42`), see [Arrays](#Arrays)
 and [Maps](#Maps) for further details. Before the assignment
 the variable must be declared via inferred (`:=`)or typed declaration
 (`:TYPE`). Only values of the correct type can be assigned to a
@@ -299,7 +298,7 @@ calling `b` and `func b` calling func `a`.
 Variables by contrast must be declared and given an unchangeable type
 before they can be used. Variables can be declared at the top level of
 the program, at _global scope_, or within a block-statement, at _block
-scope_. 
+scope_.
 
 A _block-statement_ is a block of statements that ends with the keyword
 `end`. A function body following the line starting with `func` is a
@@ -308,7 +307,7 @@ block-statement. The statements between `if` and `else` are a block
 a block. Blocks can be nested within other blocks.
 
 A variable declared inside a block only exists until the end of the
-block and may not be used outside the block. 
+block and may not be used outside the block.
 
 Variable names in an inner block can shadow or override the same
 variable name from an outer block, which makes the variable of the
@@ -325,7 +324,7 @@ unchanged:
     print "3" x
 
 This program will print
-    
+
     1 outer
     2 true
     3 outer
@@ -418,7 +417,7 @@ in the iteration.
 `len m` returns the number of values in the map.
 
 The empty map literal becomes `{}any` in inferred declarations,
-otherwise the empty map literal assumes the type required. 
+otherwise the empty map literal assumes the type required.
 `m:{}any` and `m := {}` are equivalent.
 
 The dot expression `.` and the index expression `[ "key" ]` must not be
@@ -470,13 +469,13 @@ have a `bool` result.
 
 `+` `-` `*` `/` `%` stand for addition, subtraction, multiplication,
 division and the [modulo operator]. `+` may also be used as
-concatenation operator for `string` and `array` types. 
+concatenation operator for `string` and `array` types.
 
 Boolean operators `and`, `or` stand for [logical conjunction (AND)] and
 [logical disjunction (OR)]. They perform [short-circuit evaluation]
 where the right-hand side of the operator is not evaluated if the result
 of the operation can be determined from the left-hand side alone.
-Comparison operators `<`  `<=`  `>`  `>=` stand for less, less or equal,
+Comparison operators `<` `<=` `>` `>=` stand for less, less or equal,
 greater, greater or equal. Their operands may be `num` or `string`
 values. For `string` types [lexicographical comparison] is used.
 
@@ -511,7 +510,7 @@ Finally, binary operators have the following order of precedence:
         6             *  /  %
         5             +  -
         4             <  <=  >  >=
-        3             ==  !=  
+        3             ==  !=
         2             and
         1             or
 
@@ -539,24 +538,23 @@ More formally, `WS` between tokens or terminals as defined in the
 grammar is ignored except for the following cases:
 
 1. `WS` is not allowed in assignables, around `DOT`, or before array or
-map index. Invalid: `person .name`, `person. name`, `array [1] = 2`.
-Valid: `person.name`, `array[1] = 2`.
+   map index. Invalid: `person .name`, `person. name`, `array [1] = 2`.
+   Valid: `person.name`, `array[1] = 2`.
 
 2. `WS` is not allowed following the unary operators `-` and `!`.
 
 3. `WS` is used as the separator in expression lists in function call
-arguments and array elements. `WS` is therefore _not_ allowed within
-the expressions of an expression list, including the values of map
-literal definitions.
+   arguments and array elements. `WS` is therefore _not_ allowed within
+   the expressions of an expression list, including the values of map
+   literal definitions.
 
 4. `WS` is allowed within the expression of an expression list if the
-expression is surrounded by `()`, `[]` or `{}`, `e.g. [ ( 2 + 3 ) ]`,
-not `WS` directly after `[` and within `( … )`
+   expression is surrounded by `()`, `[]` or `{}`, `e.g. [ ( 2 + 3 ) ]`,
+   not `WS` directly after `[` and within `( … )`
 
 5. `WS` can be freely used in single expressions for assignments,
-inferred declarations, return statements, `if` conditions and `while`
-conditions, as well as within parentheses `(…)`
-
+   inferred declarations, return statements, `if` conditions and `while`
+   conditions, as well as within parentheses `(…)`
 
 Examples:
 
@@ -571,7 +569,7 @@ Examples:
     print arr[1]        // b
     print arr [1]       // [a b] [1]
     arr [0] = "A"       // invalid
-    arr2 :=[ 1   ]      // valid 
+    arr2 :=[ 1   ]      // valid
     arr3 := [[1][2]]    // valid
     arr3 := [[1] [ 2] ] // valid
     arr3 := [1 + 1 ]    // invalid
@@ -618,7 +616,6 @@ Bare returns in functions without result types are allowed
         end
         // further validation
     end
-
 
 ## Variadic functions
 
@@ -676,7 +673,7 @@ A type assertion `ident.(type)` asserts that the value of the variable
 [run-time panic](#run-time-panics-and-recoverable-errors) occurs.
 
     x:any
-    x = [ 1 2 3 4 ]  
+    x = [ 1 2 3 4 ]
     num_array := x.([]num)
     x = "abc"
     str := x.(string)
@@ -692,7 +689,7 @@ or other concrete type:
     x[0].(num)    // valid
     x[0].(string) // run time panic
 
-However, the elements of `x` can be type assert, e.g. `x[0].(num)`, 
+However, the elements of `x` can be type assert, e.g. `x[0].(num)`,
 `x[1].([]num)`.
 
 ## Event Handler

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -5,11 +5,7 @@
   },
   "hosting": {
     "public": "public",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ]
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
   },
   "emulators": {
     "auth": {


### PR DESCRIPTION
Run prettier format checks on all file formats that prettier can format:
.js, .html, .css, .md, .json, .yaml. Simply update the prettier check
and format commands to run on the repo root rather than the frontend
directory (Makefile changes). Update all relevant files with

 	make prettier

Ensure checks are passing again with `make check-prettier`.

---

This is a mechanical PR using prettier in more places and fixing
formatting accordingly.