### PR TITLE
parser: Remove tinygo v0.27.0 map hack

### DIFF
--- a/pkg/parser/multiline.go
+++ b/pkg/parser/multiline.go
@@ -98,7 +98,7 @@ type accumulation struct {
 
 // nlAfter returns a map (set) of statements that need to be
 // followed by a newline.
-func nlAfter(stmts []Node, comments map[uintptr]string) map[int]bool {
+func nlAfter(stmts []Node, comments map[Node]string) map[int]bool {
 	accums := newAccumulations(stmts, comments)
 	indices := map[int]bool{}
 	length := len(accums)
@@ -123,7 +123,7 @@ func nlAfter(stmts []Node, comments map[uintptr]string) map[int]bool {
 	return indices
 }
 
-func newAccumulations(stmts []Node, comments map[uintptr]string) []accumulation {
+func newAccumulations(stmts []Node, comments map[Node]string) []accumulation {
 	lastStmtType := ""
 	var accums []accumulation
 	for i, stmt := range stmts {
@@ -131,7 +131,7 @@ func newAccumulations(stmts []Node, comments map[uintptr]string) []accumulation 
 		switch s := stmt.(type) {
 		case *EmptyStmt:
 			stmtType = "empty"
-			if comments[ptr(s)] != "" {
+			if comments[s] != "" {
 				stmtType = "comment"
 			}
 		case *FuncDeclStmt, *EventHandlerStmt:

--- a/pkg/parser/multiline_test.go
+++ b/pkg/parser/multiline_test.go
@@ -28,7 +28,7 @@ func TestArrayLiteralMultiline(t *testing.T) {
 
 		arrayLit := parser.parseArrayLiteral().(*ArrayLiteral)
 		assertNoParseError(t, parser, input)
-		got := parser.formatting.multiline[ptr(arrayLit)]
+		got := parser.formatting.multiline[arrayLit]
 		assert.Equal(t, want, got)
 	}
 }
@@ -56,7 +56,7 @@ func TestMapLiteralMultiline(t *testing.T) {
 
 		mapLit := parser.parseMapLiteral().(*MapLiteral)
 		assertNoParseError(t, parser, input)
-		got := parser.formatting.multiline[ptr(mapLit)]
+		got := parser.formatting.multiline[mapLit]
 		assert.Equal(t, want, got)
 	}
 }

--- a/pkg/wasm/imports.go
+++ b/pkg/wasm/imports.go
@@ -45,7 +45,7 @@ func (rt *jsRuntime) Dash(segments []float64)          { dash(floatsToString(seg
 func (rt *jsRuntime) Linecap(s string)                 { linecap(s) }
 func (rt *jsRuntime) Text(s string)                    { text(s) }
 func (rt *jsRuntime) Font(props map[string]any) {
-	// encode/json not implemented in tinygo 0.27.0, so do it manually
+	// We don't use encoding/json here as it adds more than 100K to evy.wasm.
 	pairs := make([]string, 0, len(props))
 	for key, value := range props {
 		switch value.(type) {


### PR DESCRIPTION
Remove tinygo v0.27.0 map hack, working around not being able to use
interfaces as map keys. tinygo v0.28.0 has fixed this bug so remove the
workaround.