### PR TITLE
docs: Fix builtin typo for linecap

### DIFF
--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -1826,9 +1826,9 @@ Output
 
     linecap style:string
 
-The `linecap` sets the shape of the ends of lines to the `style` string
-argument. Valid styles are `"round"`, `"butt"` or `"square"`. An
-invalid style takes no effect.
+The `linecap` function sets the shape of the ends of lines to the
+`style` string argument. Valid styles are `"round"`, `"butt"` or
+`"square"`. An invalid style takes no effect.
 
 | Style      | Description                                                                                                           |
 | ---------- | --------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Fix builtin typo for `linecap` to be consistent with other `Reference`
sections. This was due to a premature merge.