### PR TITLE
docs: Revise spec contents on types (2/4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ check-evy-fmt:
 doc: doctest toc
 
 DOCTEST_CMD = ./scripts/doctest.awk $(md) > $(O)/out.md && mv $(O)/out.md $(md)
-DOCTESTS = docs/builtins.md
+DOCTESTS = docs/builtins.md docs/spec.md
 doctest: install
 	$(foreach md,$(DOCTESTS),$(DOCTEST_CMD)$(nl))
 

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -426,7 +426,8 @@ Output
 The `del` function takes two arguments: a map and a key. It deletes the
 key-value entry from the map if the key exists. If the key does not
 exist, the function does nothing. The map can have any value type, and
-the key can be any string.
+the key can be any string. It is safe to delete values from the map
+with `del` while iterating with a `for … range` loop.
 
 ## Program control
 

--- a/docs/syntax_by_example.md
+++ b/docs/syntax_by_example.md
@@ -226,8 +226,8 @@ and `circle`, are documented in the[Builtins section](builtins.md).
         print "key pressed"
     end
 
-Evy can only handle a limited set of events, such as key presses, mouse
-movements, or periodic screen redraws.
+Evy can only handle a limited set of events, such as key presses,
+pointer movements, or periodic screen redraws.
 
 ### Event handlers with parameters
 


### PR DESCRIPTION
Revise spec contents on types and use evy and evy:output code fences.
The context of these changes is as follows although there have been
minor reformatting changes added to the later sections too.

✅ Intro
✅ Evy syntax specification
👉 Comments
👉 Types
👉 Variables and Declarations
👉 Zero Values
👉 Assignments
👉 Copy and reference
👉 Scope
👉 Strings
👉 Arrays
👉 Maps
👉 Index and Slice
⬜️ Operators
⬜️ Precedence
⬜️ Whitespace
⬜️ Functions
⬜️ Variadic functions
⬜️ Break and Return
⬜️ Typeof
⬜️ Type assertion
⬜️ Event Handler
⬜️ Errors
⬜️ Runtime

Add doctest for spec.md to Makefile and CI.