### PR TITLE
eval: Type empty array and map lit on assignment

### DIFF
--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -1078,8 +1078,10 @@ func TestTypeof(t *testing.T) {
 		"a := [{a:1} {b:2} false]": "[]any",
 		"a := {a:1 b:[2]}":         "{}any",
 		"a := {a:[1 2 3] b:[]}":    "{}[]num",
-		"a := []":                  "[]",
-		"a := {}":                  "{}",
+		"a := []":                  "[]any",
+		"a := {}":                  "{}any",
+		"a:[]num \n a = []":        "[]num",
+		"a:{}num \n a = {}":        "{}num",
 	}
 	for in, want := range tests {
 		in, want := in, want
@@ -1098,6 +1100,79 @@ func TestTypeof(t *testing.T) {
 		in, want := in, want
 		t.Run(in, func(t *testing.T) {
 			in += "\n print (typeof a[0])"
+			got := run(in)
+			assert.Equal(t, want+"\n", got)
+		})
+	}
+
+	tests = map[string]string{
+		`print (typeof [])`: "[]",
+		`print (typeof {})`: "{}",
+	}
+	for in, want := range tests {
+		in, want := in, want
+		t.Run(in, func(t *testing.T) {
+			got := run(in)
+			assert.Equal(t, want+"\n", got)
+		})
+	}
+}
+
+func TestTypeofParam(t *testing.T) {
+	tests := map[string]string{
+		`
+func fn x:[]num
+    print (typeof x)
+end
+fn []
+`: "[]num",
+		`
+func fn x:{}num
+    print (typeof x)
+end
+fn {}
+`: "{}num",
+		`
+func fn x:[][]num
+    print (typeof x)
+end
+fn []
+`: "[][]num",
+		`
+func fn x:{}{}num
+    print (typeof x)
+end
+fn {}
+`: "{}{}num",
+		`
+func fn x:[]{}num
+    print (typeof x)
+end
+fn []
+`: "[]{}num",
+		`
+func fn x:{}[]num
+    print (typeof x)
+end
+fn {}
+`: "{}[]num",
+		`
+func fn x:num...
+    print (typeof x)
+end
+fn
+`: "[]num",
+		`
+func fn x:[]num...
+    print (typeof x)
+end
+fn
+fn []
+`: "[][]num\n[][]num",
+	}
+	for in, want := range tests {
+		in, want := in, want
+		t.Run(in, func(t *testing.T) {
 			got := run(in)
 			assert.Equal(t, want+"\n", got)
 		})

--- a/pkg/evaluator/scope.go
+++ b/pkg/evaluator/scope.go
@@ -1,5 +1,7 @@
 package evaluator
 
+import "foxygo.at/evy/pkg/parser"
+
 type scope struct {
 	values map[string]Value
 	outer  *scope
@@ -23,8 +25,15 @@ func (s *scope) get(name string) (Value, bool) {
 	return s.outer.get(name)
 }
 
-func (s *scope) set(name string, val Value) {
-	if name != "_" {
-		s.values[name] = val
+func (s *scope) set(name string, val Value, t *parser.Type) {
+	if name == "_" {
+		return
 	}
+	switch val.Type() {
+	case parser.GENERIC_ARRAY:
+		val.(*Array).T = t
+	case parser.GENERIC_MAP:
+		val.(*Map).T = t
+	}
+	s.values[name] = val
 }

--- a/pkg/evaluator/value.go
+++ b/pkg/evaluator/value.go
@@ -202,7 +202,9 @@ func (a *Array) Set(v Value) {
 	if !ok {
 		panic("internal error: Array.Set called with with non-Array Value")
 	}
-	*a = *a2
+	// Copy elements but maintain type of assignable `a` as RHS `a2` may be a generic array, e.g. [].
+	// Maintain the type of the assignable as it is specific, e.g. []num.
+	a.Elements = a2.Elements
 }
 
 func (a *Array) Index(idx Value) (Value, error) {
@@ -288,7 +290,10 @@ func (m *Map) Set(v Value) {
 	if !ok {
 		panic("internal error: Map.Set called with with non-Map Value")
 	}
-	*m = *m2
+	// Copy pairs and order but maintain type of assignable `m` as RHS `m2` may be a generic array, e.g. {}.
+	// Maintain the type of the assignable as it is specific, e.g. {}num.
+	m.Pairs = m2.Pairs
+	m.Order = m2.Order
 }
 
 func (m *Map) Get(key string) (Value, error) {

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -124,12 +124,13 @@ func (f *FuncDeclStmt) Token() *lexer.Token {
 }
 
 type FuncDeclStmt struct {
-	token         *lexer.Token // The "func" token
-	Name          string
-	Params        []*Var
-	VariadicParam *Var
-	ReturnType    *Type
-	Body          *BlockStatement
+	token             *lexer.Token // The "func" token
+	Name              string
+	Params            []*Var
+	VariadicParam     *Var
+	ReturnType        *Type
+	VariadicParamType *Type
+	Body              *BlockStatement
 
 	isCalled bool
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -243,11 +243,10 @@ func (p *parser) addParamsToScope(fd *FuncDeclStmt) {
 	if fd.VariadicParam != nil {
 		vParam := fd.VariadicParam
 		p.validateVarDecl(vParam, vParam.token, true /* allowUnderscore */)
-
 		vParamAsArray := &Var{
 			token: vParam.token,
 			Name:  vParam.Name,
-			T:     &Type{Name: ARRAY, Sub: vParam.Type()},
+			T:     fd.VariadicParamType,
 		}
 		p.scope.set(vParam.Name, vParamAsArray)
 	}
@@ -454,6 +453,7 @@ func (p *parser) parseFuncDeclSignature() *FuncDeclStmt {
 		if len(fd.Params) == 1 {
 			fd.VariadicParam = fd.Params[0]
 			fd.Params = nil
+			fd.VariadicParamType = &Type{Name: ARRAY, Sub: fd.VariadicParam.Type()}
 		} else {
 			p.appendError("invalid variadic parameter, must be used with single type")
 		}


### PR DESCRIPTION
Type empty array and map lit on assignment with type of LHS asignable
and as []any or {}any for inferred declaration.

	a := []
	print (typeof a) // before: [] now: []any
	b:[]num
	print (typeof b) // before: []num now: []num
	b = []
	print (typeof b) // before: [] now: []num
	print (typeof []) // before: [] now: []

This seems to be more accurate and expected behaviour.

Fix the same behaviour for parameter passing and including for variadic
parameters.

Throw in a little bug fix for variadic args for good measure.