### PR TITLE
format: Fix misplaced NL before func decl

### DIFF
--- a/pkg/parser/format_test.go
+++ b/pkg/parser/format_test.go
@@ -719,6 +719,54 @@ on down
     print 2
 end
 `,
+		`
+a := 1
+b := 2
+func fn
+    print "fn" a b
+end
+func fn2
+    print "fn2" a b
+end
+fn
+`: `
+a := 1
+b := 2
+
+func fn
+    print "fn" a b
+end
+
+func fn2
+    print "fn2" a b
+end
+
+fn
+`, `
+a := 1
+func fn
+    print "fn" a
+end
+`: `
+a := 1
+
+func fn
+    print "fn" a
+end
+`, `
+a := 1
+b := 2
+func fn
+    print "fn" a b
+end
+`: `
+a := 1
+b := 2
+
+func fn
+    print "fn" a b
+end
+`,
 	}
 	for input, want := range tests {
 		input, want := input, want

--- a/pkg/parser/multiline.go
+++ b/pkg/parser/multiline.go
@@ -113,8 +113,9 @@ func nlAfter(stmts []Node, comments map[Node]string) map[int]bool {
 			// add NL after func decl directly followed by stmt
 			indices[accum.idx] = true
 		case accums[i+1].stmtType == "func":
-			// add NL before func decl (after stmt or other func decl)
-			indices[accum.idx] = true
+			// add NL before func decl (before stmt or other func decl)
+			beforeFuncIdx := accums[i+1].idx - 1
+			indices[beforeFuncIdx] = true
 		case i+2 < length && accums[i+1].stmtType == "comment" && accums[i+2].stmtType == "func":
 			// add NL before comments of func decl (after stmt or other func decl)
 			indices[accum.idx] = true


### PR DESCRIPTION
Fix misplaced NL before function declaration. This is issue became apparent when

	a := 1
	b := 2
	func fn
	    print "fn" a b
	end

was reformatted to

	a := 1

	b := 2
	func fn
	    print "fn" a b
	end

now fixed.