### PR TITLE
parser: Fix bad unreachable code error on comments

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -678,8 +678,10 @@ func (p *parser) parseBlockWithEndTokens(endTokens map[lexer.TokenType]bool) *Bl
 			continue
 		}
 		if block.AlwaysTerminates() {
-			p.appendErrorForToken("unreachable code", tok)
-			continue
+			if _, ok := stmt.(*EmptyStmt); !ok {
+				p.appendErrorForToken("unreachable code", tok)
+				continue
+			}
 		}
 		if alwaysTerminates(stmt) {
 			block.alwaysTerminates = true

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -276,6 +276,23 @@ fox 1 2 3`,
 	}
 }
 
+func TestReturn(t *testing.T) {
+	inputs := []string{
+		`
+func fn
+    print 1
+    return
+    // unreachable code!?
+end
+`,
+	}
+	for _, input := range inputs {
+		parser := newParser(input, testBuiltins())
+		_ = parser.parse()
+		assertNoParseError(t, parser, input)
+	}
+}
+
 func TestReturnErr(t *testing.T) {
 	inputs := map[string]string{
 		`


### PR DESCRIPTION
Fix bad unreachable code error on comments by only issuing the error if
the statement is not a comment (or an empty line).