### PR TITLE
parser: Enable late typing of composite literals

### DIFF
--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -730,3 +730,9 @@ func zeroValue(t *Type, tt *lexer.Token) Node {
 	}
 	return nil
 }
+
+func isCompositeLit(n Node) bool {
+	_, aok := n.(*ArrayLiteral)
+	_, mok := n.(*MapLiteral)
+	return aok || mok
+}

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -455,10 +455,10 @@ func (p *parser) parseExprWSS() Node {
 func (p *parser) combineTypes(types []*Type) *Type {
 	combinedT := types[0]
 	for _, t := range types[1:] {
-		if combinedT.Accepts(t) {
+		if combinedT.Accepts(t, false) {
 			continue
 		}
-		if t.Accepts(combinedT) {
+		if t.Accepts(combinedT, false) {
 			combinedT = t
 			continue
 		}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -384,7 +384,7 @@ func (p *parser) parseAssignmentStatement() Node {
 		p.advancePastNL()
 		return nil
 	}
-	if !target.Type().Accepts(value.Type()) {
+	if !target.Type().Accepts(value.Type(), isCompositeLit(value)) {
 		msg := fmt.Sprintf("%q accepts values of type %s, found %s", target.String(), target.Type().String(), value.Type().String())
 		p.appendErrorForToken(msg, tok)
 	}
@@ -575,7 +575,7 @@ func (p *parser) assertArgTypes(decl *FuncDeclStmt, args []Node) {
 		paramType := decl.VariadicParam.Type()
 		for _, arg := range args {
 			argType := arg.Type()
-			if !paramType.Accepts(argType) && !paramType.Matches(argType) {
+			if !paramType.Accepts(argType, isCompositeLit(arg)) && !paramType.Matches(argType) {
 				msg := fmt.Sprintf("%q takes variadic arguments of type %s, found %s", funcName, paramType.String(), argType.String())
 				p.appendErrorForToken(msg, arg.Token())
 			}
@@ -594,7 +594,7 @@ func (p *parser) assertArgTypes(decl *FuncDeclStmt, args []Node) {
 	for i, arg := range args {
 		paramType := decl.Params[i].Type()
 		argType := arg.Type()
-		if !paramType.Accepts(argType) && !paramType.Matches(argType) {
+		if !paramType.Accepts(argType, isCompositeLit(arg)) && !paramType.Matches(argType) {
 			msg := fmt.Sprintf("%q takes %s argument of type %s, found %s", funcName, ordinalize(i+1), paramType.String(), argType.String())
 			p.appendErrorForToken(msg, arg.Token())
 		}
@@ -786,7 +786,7 @@ func (p *parser) parseReturnStatement() Node {
 	}
 	if p.scope.returnType == nil {
 		p.appendErrorForToken("return statement not allowed here", retValueToken)
-	} else if !p.scope.returnType.Accepts(ret.T) {
+	} else if !p.scope.returnType.Accepts(ret.T, isCompositeLit(ret.Value)) {
 		msg := "expected return value of type " + p.scope.returnType.String() + ", found " + ret.T.String()
 		if p.scope.returnType == NONE_TYPE && ret.T != NONE_TYPE {
 			msg = "expected no return value, found " + ret.T.String()

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1330,6 +1330,98 @@ print a.([]num)[1]
 	}
 }
 
+func TestLateCompositeLiteralTyping(t *testing.T) {
+	inputs := []string{
+		`
+a:[]any
+m:{}any
+a = [1 2 3]
+m = {a:true b:false}
+print a m
+`, `
+func fn m:{}any a:[]any
+	 print m a
+end
+fn {} []
+fn {a:1} [true] // {}num []bool`,
+		`has {} "b"`,
+		`has {x:2} "b"`,
+		`
+func fn a:[]any...
+	 print a
+end
+fn []
+fn [1 2]
+fn [] []
+fn [1] [true]
+`, `
+func fn m:{}any...
+	 print m
+end
+fn {}
+fn {a:1 b:2}
+fn {} {}
+fn {a:1} {b:true}
+`, `
+func fnm:{}any
+	 return {a:1}
+end
+`, `
+func fna:[]any
+	 return [true]
+end
+`,
+	}
+	for _, input := range inputs {
+		parser := newParser(input, testBuiltins())
+		_ = parser.parse()
+		assertNoParseError(t, parser, input)
+	}
+}
+
+func TestLateCompositeLiteralTypingErr(t *testing.T) {
+	inputs := map[string]string{
+		`
+has ["a"] "a"`: `line 2 column 5: "has" takes 1st argument of type {}, found []string`,
+		`
+a:[]any
+b := [1 2]
+a = [1 2]
+a = b
+`: `line 5 column 1: "a" accepts values of type []any, found []num`,
+		`
+b := [1 2]
+b = [] + b + [true]
+`: `line 3 column 12: mismatched type for +: []num, []bool`,
+		`
+a:[]any
+b:[]num
+b = [1 2 3]
+a = [] + b
+`: `line 5 column 1: "a" accepts values of type []any, found []num`,
+		`
+func fn m:{}any...
+	 print m
+end
+m:{}num
+fn m
+`: `line 5 column 1: "fn" takes variadic arguments of type {}any, found {}num`,
+		`
+func fn:{}any
+	m := {a:1}
+	return m
+end
+`: `line 4 column 9: expected return value of type {}any, found {}num`,
+	}
+	for input, wantErr := range inputs {
+		parser := newParser(input, testBuiltins())
+		_ = parser.parse()
+		assertParseError(t, parser, input)
+		gotErr := parser.errors.Truncate(1)
+		assert.Equal(t, wantErr, gotErr.Error())
+	}
+}
+
 func TestDemo(t *testing.T) {
 	input := `
 move 10 10
@@ -1378,6 +1470,14 @@ func testBuiltins() Builtins {
 			Name:       "len",
 			Params:     []*Var{{Name: "a", T: ANY_TYPE}},
 			ReturnType: NUM_TYPE,
+		},
+		"has": {
+			Name: "has",
+			Params: []*Var{
+				{Name: "map", T: GENERIC_MAP},
+				{Name: "key", T: STRING_TYPE},
+			},
+			ReturnType: NONE_TYPE,
 		},
 	}
 	eventHandlers := map[string]*EventHandlerStmt{

--- a/pkg/parser/type.go
+++ b/pkg/parser/type.go
@@ -78,7 +78,10 @@ func (t *Type) String() string {
 	return t.Name.String() + t.Sub.String()
 }
 
-func (t *Type) Accepts(t2 *Type) bool {
+func (t *Type) Accepts(t2 *Type, isLiteral bool) bool {
+	if isLiteral {
+		return t.acceptsLiteral(t2)
+	}
 	if t.acceptsStrict(t2) {
 		return true
 	}
@@ -89,6 +92,29 @@ func (t *Type) Accepts(t2 *Type) bool {
 	// empty Array none array accepted by all arrays.
 	// empty Map of none_type accepted by all maps
 	return false
+}
+
+func (t *Type) acceptsLiteral(t2 *Type) bool {
+	n, n2 := t.Name, t2.Name
+	if n == ILLEGAL || n2 == ILLEGAL || n2 == NONE {
+		return false
+	}
+	if n == ANY {
+		return true
+	}
+	if n != n2 {
+		return false
+	}
+	if t.Sub == nil || t2.Sub == nil {
+		return t.Sub == nil && t2.Sub == nil
+	}
+	if n == ARRAY && t2 == GENERIC_ARRAY {
+		return true
+	}
+	if n == MAP && t2 == GENERIC_MAP {
+		return true
+	}
+	return t.Sub.acceptsLiteral(t2.Sub)
 }
 
 func (t *Type) Matches(t2 *Type) bool {


### PR DESCRIPTION
Enable late typing of composite literals, such that `[1]` can be `
[]num` or an `[]any` depending on what is required by the assigned
variable, parameter or return type.

This finally allows for an evy implementation of a function like `font`
which accepts and `{}any` to call as: `font {size: 4}`.