### PR TITLE
parser: Fix typing of array concatenation expressions

### DIFF
--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -639,6 +639,9 @@ func evalBinaryArrayExpr(op parser.Operator, left, right *Array) (Value, error) 
 		return nil, fmt.Errorf("%w (array): %v", ErrOperation, op.String())
 	}
 	result := left.Copy()
+	if result.T == parser.GENERIC_ARRAY {
+		result.T = right.T
+	}
 	rightElemnts := *right.Copy().Elements
 	*result.Elements = append(*result.Elements, rightElemnts...)
 	return result, nil

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -1082,6 +1082,7 @@ func TestTypeof(t *testing.T) {
 		"a := {}":                  "{}any",
 		"a:[]num \n a = []":        "[]num",
 		"a:{}num \n a = {}":        "{}num",
+		"a := [] + [true]":         "[]bool",
 	}
 	for in, want := range tests {
 		in, want := in, want
@@ -1106,8 +1107,11 @@ func TestTypeof(t *testing.T) {
 	}
 
 	tests = map[string]string{
-		`print (typeof [])`: "[]",
-		`print (typeof {})`: "{}",
+		`print (typeof [])`:        "[]",
+		`print (typeof {})`:        "{}",
+		`print (typeof []+[true])`: "[]bool",
+		`print (typeof [true]+[])`: "[]bool",
+		`print (typeof []+[])`:     "[]",
 	}
 	for in, want := range tests {
 		in, want := in, want

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -151,6 +151,9 @@ func (p *parser) parseBinaryExpr(left Node) Node {
 	if binaryExp.Right == nil {
 		return nil // previous error
 	}
+	if expType == GENERIC_ARRAY {
+		binaryExp.T = binaryExp.Right.Type() // array concatenation e.g. [] + [1 2]
+	}
 	p.validateBinaryType(binaryExp)
 	if p.isWSS() {
 		p.formatting.recordWSS(binaryExp)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 	"testing"
@@ -1266,6 +1267,31 @@ print a.( num ) // whitespaces added`,
 		parser := newParser(input, testBuiltins())
 		_ = parser.parse()
 		assertNoParseError(t, parser, input)
+	}
+}
+
+func TestArrayConcatTyping(t *testing.T) {
+	inputs := map[string]string{
+		`
+b:[]num
+b = [true]
+`: `line 3 column 1: "b" accepts values of type []num, found []bool`,
+		`
+b:[]num
+b = [true] + []
+`: `line 3 column 1: "b" accepts values of type []num, found []bool`,
+		`
+b:[]num
+b = [] + [true]
+`: `line 3 column 1: "b" accepts values of type []num, found []bool`,
+	}
+	for input, wantErr := range inputs {
+		parser := newParser(input, testBuiltins())
+		fmt.Println(input)
+		_ = parser.parse()
+		assertParseError(t, parser, input)
+		gotErr := parser.errors.Truncate(1)
+		assert.Equal(t, wantErr, gotErr.Error())
 	}
 }
 

--- a/pkg/parser/type.go
+++ b/pkg/parser/type.go
@@ -104,6 +104,7 @@ func (t *Type) Matches(t2 *Type) bool {
 	if t.Sub == nil || t2.Sub == nil {
 		return false
 	}
+
 	if t == GENERIC_ARRAY || t == GENERIC_MAP || t2 == GENERIC_ARRAY || t2 == GENERIC_MAP {
 		return true
 	}


### PR DESCRIPTION
Fix typing of array concatenation expressions so that `[]+[true]` now
returns the correct `[]bool` type.

Before:
`print (typeof []+[true])` -> `[]`

Now:
`print (typeof []+[true])` -> `[]bool`

