### PR TITLE
parser: Fix function calls with indexed arguments

### DIFF
--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -1276,6 +1276,46 @@ fox3 [1 2] true
 	}
 }
 
+func TestIndexing(t *testing.T) {
+	tests := map[string]string{
+		"print [1 2] [1]":          "[1 2] [1]",
+		"print [1 2][1]":           "2",
+		"print {} []":              "{} []",
+		"print [] []":              "[] []",
+		"print [] {}":              "[] {}",
+		"print {} {}":              "{} {}",
+		`print {a:1}["a"]`:         "1",
+		`print {a:1} ["a"]`:        "{a:1} [a]",
+		`print ( sin ( sin 0 ) ) `: "0",
+		`
+func fn:{}num
+	return {a:1}
+end
+print (fn)["a"]
+print (fn) ["a"]
+`: "1\n{a:1} [a]",
+		`
+func fn:string
+	return "abc"
+end
+print (fn)[1]
+print (fn) [1]
+`: "b\nabc [1]",
+		`a:any
+a = [1 2]
+print a.([]num)[1]
+print a.([]num) [1]
+`: "2\n[1 2] [1]",
+	}
+	for in, want := range tests {
+		in, want := in, want
+		t.Run(in, func(t *testing.T) {
+			got := run(in)
+			assert.Equal(t, want+"\n", got)
+		})
+	}
+}
+
 func TestDemo(t *testing.T) {
 	prog := `
 move 10 10

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -171,7 +171,7 @@ func (p *parser) parseGroupedExpr() Node {
 	if !p.assertToken(lexer.RPAREN) || exp == nil {
 		return nil
 	}
-	p.advance() // advance past )
+	p.advanceWSS() // advance past )
 	return &GroupExpression{token: tok, Expr: exp}
 }
 
@@ -205,7 +205,7 @@ func (p *parser) parseIndexOrSliceExpr(left Node, allowSlice bool) Node {
 	if !p.validateIndex(tok, leftType, index.Type()) {
 		return nil
 	}
-	p.advance() // advance past ]
+	p.advanceWSS() // advance past ]
 	t := left.Type().Sub
 	if leftType == STRING {
 		t = STRING_TYPE
@@ -299,7 +299,7 @@ func (p *parser) parseTypeAssertion(left Node) Node {
 		p.appendErrorForToken("cannot type assert to type any", tok)
 	}
 	if p.assertToken(lexer.RPAREN) {
-		p.advance() // advance past )
+		p.advanceWSS() // advance past )
 	}
 	if left.Type() != ANY_TYPE {
 		p.appendErrorForToken("value of type assertion must be of type any, not "+left.Type().String(), tok)
@@ -484,7 +484,7 @@ func (p *parser) parseMapLiteral() Node {
 	if !p.assertToken(lexer.RCURLY) {
 		return nil
 	}
-	p.advance() // advance past }
+	p.advanceWSS() // advance past }
 	if len(mapLit.Pairs) == 0 {
 		return mapLit
 	}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1,7 +1,6 @@
 package parser
 
 import (
-	"fmt"
 	"sort"
 	"strings"
 	"testing"
@@ -1270,7 +1269,7 @@ print a.( num ) // whitespaces added`,
 	}
 }
 
-func TestArrayConcatTyping(t *testing.T) {
+func TestArrayConcatTypingErr(t *testing.T) {
 	inputs := map[string]string{
 		`
 b:[]num
@@ -1287,7 +1286,6 @@ b = [] + [true]
 	}
 	for input, wantErr := range inputs {
 		parser := newParser(input, testBuiltins())
-		fmt.Println(input)
 		_ = parser.parse()
 		assertParseError(t, parser, input)
 		gotErr := parser.errors.Truncate(1)

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1293,6 +1293,43 @@ b = [] + [true]
 	}
 }
 
+func TestArgsWithIndex(t *testing.T) {
+	inputs := []string{
+		"print [1 2] [1]",
+		"print [1 2][1]",
+		"print {} []",
+		"print [] []",
+		"print [] {}",
+		"print {} {}",
+		`print {a:1}["a"]`,
+		`print {a:1} ["a"]`,
+		`
+func fn:{}num
+	return {a:1}
+end
+print (fn)["a"]
+print (fn) ["a"]
+`,
+		`
+func fn:string
+	return "abc"
+end
+print (fn)[1]
+print (fn) [1]
+`,
+		`a:any
+a = [1 2]
+print a.([]num) [1]
+print a.([]num)[1]
+`,
+	}
+	for _, input := range inputs {
+		parser := newParser(input, testBuiltins())
+		_ = parser.parse()
+		assertNoParseError(t, parser, input)
+	}
+}
+
 func TestDemo(t *testing.T) {
 	input := `
 move 10 10


### PR DESCRIPTION
Fix function call parsing for arguments with index - maps, type assertions,
grouped expressions and arrays. We're here at a finicky bit of evy. Prior
to this PR we'd get a compile error for:

	print {} []

error message:

	line 1: unexpected whitespace before "["

Remove debug print in tests from previous PR.