### PR TITLE
frontend: Select sharing URL on copy button click

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -964,6 +964,7 @@ async function share() {
   button.className = "copy"
   button.innerHTML = `<svg><use href="#icon-copy" /></svg>`
   button.onclick = () => {
+    input.select()
     navigator.clipboard.writeText(input.value)
     hideModal()
   }


### PR DESCRIPTION
Select sharing URL on copy button click in frontend, so that it will
also be put into the "Primary Selection" on Linux which people commonly
use to copy text.