### PR TITLE
builtins: Add `panic` function 

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -171,8 +171,8 @@ function jsError(ptr, len) {
     msgs += `line ${g.line}: ${g.msg}\n`
   }
   const output = document.querySelector("#console")
-  output.textContent = msgs
-  output.scrollTo({ behavior: "smooth", left: 0, top: 0 })
+  output.textContent += msgs
+  output.scrollTo({ behavior: "smooth", left: 0, top: output.scrollHeight })
   editor.update({ errorLines })
 }
 

--- a/main.go
+++ b/main.go
@@ -118,11 +118,20 @@ func (c *runCmd) Run() error {
 	builtins := evaluator.DefaultBuiltins(rt)
 	eval := evaluator.NewEvaluator(builtins)
 	err = eval.Run(string(b))
+	handlEvyErr(err)
+	return nil
+}
+
+func handlEvyErr(err error) {
+	if err == nil {
+		return
+	}
 	var exitErr evaluator.ExitError
 	if errors.As(err, &exitErr) {
 		os.Exit(int(exitErr))
 	}
-	return err
+	fmt.Fprintln(os.Stderr, err.Error())
+	os.Exit(1)
 }
 
 func (c *fmtCmd) Run() error {

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -67,6 +67,7 @@ func DefaultBuiltins(rt Runtime) Builtins {
 
 		"sleep": {Func: sleepFunc(rt.Sleep), Decl: sleepDecl},
 		"exit":  {Func: BuiltinFunc(exitFunc), Decl: numDecl("exit")},
+		"panic": {Func: BuiltinFunc(panicFunc), Decl: stringDecl("panic")},
 
 		"rand":  {Func: BuiltinFunc(randFunc), Decl: randDecl},
 		"rand1": {Func: BuiltinFunc(rand1Func), Decl: rand1Decl},
@@ -501,6 +502,11 @@ func sleepFunc(sleepFn func(time.Duration)) BuiltinFunc {
 
 func exitFunc(_ *scope, args []Value) (Value, error) {
 	return nil, ExitError(args[0].(*Num).Val)
+}
+
+func panicFunc(_ *scope, args []Value) (Value, error) {
+	s := args[0].(*String).Val
+	return nil, PanicError("panic: " + s)
 }
 
 var randDecl = &parser.FuncDeclStmt{

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -38,6 +38,12 @@ func (e ExitError) Error() string {
 	return fmt.Sprintf("exit %d", int(e))
 }
 
+type PanicError string
+
+func (e PanicError) Error() string {
+	return string(e)
+}
+
 // Error is an Evy evaluator error.
 type Error struct {
 	err   error


### PR DESCRIPTION
Add `panic` function that interrupts evaluations with a `PanicError`
which contains the panic message. It is up to the runtime to decide
what to do with it.

---

Here's an evy program to play with:

```
print "before panic"
panic "🙀"
print "after panic"
```

Link: https://evy-lang--178-2e7co2tu.web.app/#content=H4sIAAAAAAAAEysoyswrUVBKSk3LL0pVKEjMy0xW4gJTCkof5s9sAHIgKhLTSlKLYAq4AGoqMzw3AAAA
