### PR TITLE
eval: Wrap []any and {}any elements

### DIFF
--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -262,6 +262,13 @@ func (e *Evaluator) evalArrayLiteral(arr *parser.ArrayLiteral) (Value, error) {
 	if err != nil {
 		return nil, err
 	}
+	if arr.T.Sub.Name == parser.ANY {
+		for i, e := range elements {
+			if _, ok := e.(*Any); !ok {
+				elements[i] = &Any{Val: e}
+			}
+		}
+	}
 	return &Array{Elements: &elements, T: arr.T}, nil
 }
 
@@ -271,6 +278,11 @@ func (e *Evaluator) evalMapLiteral(m *parser.MapLiteral) (Value, error) {
 		val, err := e.Eval(node)
 		if err != nil {
 			return nil, err
+		}
+		if m.T.Sub.Name == parser.ANY {
+			if _, ok := val.(*Any); !ok {
+				val = &Any{Val: val}
+			}
 		}
 		pairs[key] = copyOrRef(val)
 	}

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -256,6 +256,78 @@ print "6" f4==f1
 	assert.Equal(t, want, got)
 }
 
+func TestAnyArray(t *testing.T) {
+	prog := `
+x:[]any
+x = [1 2 true] // TODO: [true] - still broken
+print x
+x[1] = [3 4 5]
+print x
+`
+	want := "[1 2 true]\n[1 [3 4 5] true]\n"
+	got := run(prog)
+	assert.Equal(t, want, got)
+}
+
+func TestNestedAnyArray(t *testing.T) {
+	prog := `
+x:[][]any
+a:any
+a = 1
+x = [[a 2 true]] // TODO: [[true]] - still broken
+print x
+a = 5
+x[0][1] = [3 4 a]
+print x
+`
+	want := "[[1 2 true]]\n[[1 [3 4 5] true]]\n"
+	got := run(prog)
+	assert.Equal(t, want, got)
+}
+
+func TestAnyMap(t *testing.T) {
+	prog := `
+x:{}any
+x = {a:1 b:2 c:true} // TODO: {a:true} - still broken
+print x
+x.b = [3 4 5]
+print x
+`
+	want := "{a:1 b:2 c:true}\n{a:1 b:[3 4 5] c:true}\n"
+	got := run(prog)
+	assert.Equal(t, want, got)
+}
+
+func TestNestedAnyMap(t *testing.T) {
+	prog := `
+x:{}{}any
+a:any
+a = 1
+x = {A:{A:a B:2 C:true}} // TODO: {A:{A:true}} - still broken
+print x
+a = 5
+x.A.B = [3 4 a]
+print x
+`
+	want := "{A:{A:1 B:2 C:true}}\n{A:{A:1 B:[3 4 5] C:true}}\n"
+	got := run(prog)
+	assert.Equal(t, want, got)
+}
+
+func TestParamTypeof(t *testing.T) {
+	prog := `
+func f a:any
+  print (typeof a)
+end
+f 1
+f [1 2]
+`
+	// TODO: want := "any\nany\n"
+	want := "num\n[]num\n"
+	got := run(prog)
+	assert.Equal(t, want, got)
+}
+
 func TestIf(t *testing.T) {
 	tests := []string{
 		`


### PR DESCRIPTION
Wrap `[]any` and `{}any` elements in an `*Any` value if they aren't already
such a value. Previously the following code caused a panic:

	arr := [1 true]
	arr[0] = "abc"
	print arr
