### PR TITLE
evaluator: Rename runtime error to panic

### DIFF
--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -506,7 +506,7 @@ func exitFunc(_ *scope, args []Value) (Value, error) {
 
 func panicFunc(_ *scope, args []Value) (Value, error) {
 	s := args[0].(*String).Val
-	return nil, PanicError("panic: " + s)
+	return nil, PanicError(s)
 }
 
 var randDecl = &parser.FuncDeclStmt{

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -15,13 +15,13 @@ import (
 var (
 	ErrStopped = errors.New("stopped")
 
-	ErrRuntime       = errors.New("runtime error")
-	ErrBounds        = fmt.Errorf("%w: index out of bounds", ErrRuntime)
-	ErrRangeValue    = fmt.Errorf("%w: bad range value", ErrRuntime)
-	ErrMapKey        = fmt.Errorf("%w: no value for map key", ErrRuntime)
-	ErrSlice         = fmt.Errorf("%w: bad slice", ErrRuntime)
-	ErrBadArguments  = fmt.Errorf("%w: bad arguments", ErrRuntime)
-	ErrAnyConversion = fmt.Errorf("%w: error converting any to type", ErrRuntime)
+	ErrPanic         = errors.New("panic")
+	ErrBounds        = fmt.Errorf("%w: index out of bounds", ErrPanic)
+	ErrRangeValue    = fmt.Errorf("%w: bad range value", ErrPanic)
+	ErrMapKey        = fmt.Errorf("%w: no value for map key", ErrPanic)
+	ErrSlice         = fmt.Errorf("%w: bad slice", ErrPanic)
+	ErrBadArguments  = fmt.Errorf("%w: bad arguments", ErrPanic)
+	ErrAnyConversion = fmt.Errorf("%w: error converting any to type", ErrPanic)
 
 	ErrInternal         = errors.New("internal error")
 	ErrUnknownNode      = fmt.Errorf("%w: unknown AST node", ErrInternal)
@@ -42,6 +42,10 @@ type PanicError string
 
 func (e PanicError) Error() string {
 	return string(e)
+}
+
+func (e *PanicError) Unwrap() error {
+	return ErrPanic
 }
 
 // Error is an Evy evaluator error.

--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -469,10 +469,10 @@ func TestDoubleIndex(t *testing.T) {
 func TestIndexErr(t *testing.T) {
 	tests := map[string]string{
 		// x := ["a","b","c"]; x = "abc"
-		"print x[3]":  "line 2 column 8: runtime error: index out of bounds: 3",
-		"print x[-4]": "line 2 column 8: runtime error: index out of bounds: -4",
+		"print x[3]":  "line 2 column 8: panic: index out of bounds: 3",
+		"print x[-4]": "line 2 column 8: panic: index out of bounds: -4",
 		`m := {}
-		print m[x[1]]`: `line 3 column 10: runtime error: no value for map key: "b"`,
+		print m[x[1]]`: `line 3 column 10: panic: no value for map key: "b"`,
 	}
 	for in, want := range tests {
 		in, want := in, want
@@ -534,7 +534,7 @@ func TestDotErr(t *testing.T) {
 m := {a:1}
 print m.missing_index
 `
-	want := `line 3 column 8: runtime error: no value for map key: "missing_index"`
+	want := `line 3 column 8: panic: no value for map key: "missing_index"`
 	got := run(in)
 	assert.Equal(t, want, got)
 }
@@ -1053,7 +1053,7 @@ func TestTypeAssertionErr(t *testing.T) {
 a:any
 b := a.(num)
 print b`
-	want := "line 3 column 7: runtime error: error converting any to type: expected num, found bool"
+	want := "line 3 column 7: panic: error converting any to type: expected num, found bool"
 	got := run(prog)
 	assert.Equal(t, want, got)
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -110,8 +110,8 @@ func (p *parser) consumeTokens(l *lexer.Lexer) []int {
 	var token *lexer.Token
 	for token = l.Next(); token.Type != lexer.EOF; token = l.Next() {
 		if token.Type == lexer.ILLEGAL {
-			if token.Literal == `"` {
-				p.appendErrorForToken(`unterminated string, missing "`, token)
+			if token.Literal == "invalid string" {
+				p.appendErrorForToken("invalid string", token)
 			} else {
 				msg := fmt.Sprintf("illegal character %q", token.Literal)
 				p.appendErrorForToken(msg, token)


### PR DESCRIPTION
Rename runtime error to panic so that index out of bounds and similar
runtime errors appear like a panic. Then all unrecoverable runtime
errors are panics or internal errors (which should never occur). While
at it, fix the error message for missing closing quote of string
literals and improve on the error section in builtins.md. 
Add a section on using the `panic` builtin.

This is precursory work to finish off the last part of the spec revision,
including errors.