### PR TITLE
docs: Fix and improve doctest error handling

### DIFF
--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -474,7 +474,7 @@ fraction of a second, e.g. `sleep 0.1`.
 
 #### Example
 
-```evy
+```evy expect_err
 input := "not a number"
 n := str2num input
 

--- a/scripts/doctest.awk
+++ b/scripts/doctest.awk
@@ -36,6 +36,7 @@ BEGIN {
 function reset() {
 	code = input = output = ""
 	in_code = in_input = in_output = 0
+	delete(flags)
 }
 
 # accumulate lines in a buffer, leaving off the final newline
@@ -62,7 +63,7 @@ function execute(cmd, input) {
 	close(tempfile)
 	system("rm " tempfile)
 
-	if (rv != 0) {
+	if (rv != 0 && !flags["expect_err"]) {
 		split(cmd, args)
 		print "Error running 'evy " args[2] "' for:", builtin > "/dev/stderr"
 		print o > "/dev/stderr"
@@ -84,9 +85,12 @@ function execute(cmd, input) {
 # we get to the end of the code block. If `evy fmt` returns an error,
 # just print out the original code and send the error to stderr. Otherwise
 # output the formatted code in the place of the code.
-/^```evy$/ {
+/^```evy( .*)?$/ {
 	reset()
 	in_code = 1
+	for (i = 2; i <= NF; i++) {
+		flags[$i]=1
+	}
 	print; next
 }
 /^```$/ && in_code {

--- a/scripts/doctest.awk
+++ b/scripts/doctest.awk
@@ -52,14 +52,8 @@ function accumulate_line(line, buffer) {
 # instead.
 function execute(cmd, input) {
 	tempfile = "/tmp/doctest.tmp"
-	print input | (cmd ">" tempfile)
-
-	rv = close(cmd ">" tempfile)
-	if (rv != 0) {
-		print "Error running:", cmd, "for:", builtin > "/dev/stderr"
-		print o > "/dev/stderr"
-		return -1
-	}
+	print input | (cmd ">" tempfile " 2>&1")
+	rv = close(cmd ">" tempfile " 2>&1")
 
 	o = ""
 	while (getline line < tempfile) {
@@ -67,6 +61,14 @@ function execute(cmd, input) {
 	}
 	close(tempfile)
 	system("rm " tempfile)
+
+	if (rv != 0) {
+		split(cmd, args)
+		print "Error running 'evy " args[2] "' for:", builtin > "/dev/stderr"
+		print o > "/dev/stderr"
+		close("/dev/stderr")
+		return -1
+	}
 	return o
 }
 


### PR DESCRIPTION
Fix the error handling of `doctest.awk` when running evy to output the 
error captured instead of the previous output captured. While fixing this,
capture stderr err from the command executed as that is often where error
output goes. And then close `/dev/stderr` for good measure.

Add an `expect_err` flag to go after the `evy` language marker used by 
doctest to denote that the evy program is expected to exit with an error.
In these cases, we do not report the error and instead capture the error
output to put in the `evy:output` block.

Update `docs/builtins.md` to add this `expect_err` flag to the `exit` 
builtin which exits with an error. This cleans up the output of
`make doctest` so it no longer reports an expected error.