### PR TITLE
docs: Use POSIX syntax for deleting array in awk

### DIFF
--- a/scripts/doctest.awk
+++ b/scripts/doctest.awk
@@ -36,7 +36,8 @@ BEGIN {
 function reset() {
 	code = input = output = ""
 	in_code = in_input = in_output = 0
-	delete(flags)
+	for (i in flags)
+		delete flags[i]
 }
 
 # accumulate lines in a buffer, leaving off the final newline


### PR DESCRIPTION
Use the POSIX awk syntax for deleting an array in doctest.awk instead of
the gawk syntax. Whoops.