### PR TITLE
docs: Tweak docs and add redirects from evy.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,13 @@
 
 Evy is a simple programming language, made to learn coding.
 
-Evy has a minimalist syntax with fewer special characters and advanced
-concepts than most programming languages. It also has a small set of
+Evy bridges the gap between block-based languages like [Scratch] and
+conventional languages like Python or JavaScript. It has a minimalist
+syntax with fewer special characters and advanced concepts than most
+programming languages. Evy has a small set of
 [built-in functions](docs/builtins.md) that are easy to understand and
 remember, but it still is powerful enough for user interaction, games,
-and animations. Evy bridges the gap between block-based languages like
-[Scratch] and conventional languages like Python or JavaScript.
+and animations.
 
 [Scratch]: https://scratch.mit.edu/
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Here is a "hello world" program in Evy
 <details>
   <summary>Screencast: How to code a simple animation in Evy.</summary>
 
-[![Coding evy](docs/img/purple-dot.gif)](https://evy.dev)
+![Coding evy](docs/img/purple-dot.gif)
 
 [Animation source code]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Evy
 
-[![Slack Chat](https://img.shields.io/badge/slack-gophers-660066?style=flat-square&logo=slack)](https://gophers.slack.com/messages/foxygoat)
+[![Discord Chat](https://img.shields.io/badge/discord-chat-414eed?style=flat-square&logo=discord&logoColor=white)](https://evy.dev/discord)
 [![GitHub Build](https://img.shields.io/github/actions/workflow/status/foxygoat/evy/cicd.yaml?style=flat-square&branch=master&logo=github)](https://github.com/foxygoat/evy/actions/workflows/cicd.yaml?query=branch%3Amaster)
 [![Go Reference](https://pkg.go.dev/badge/foxygo.at/evy.svg)](https://pkg.go.dev/foxygo.at/evy)
 
@@ -45,6 +45,10 @@ Here are some resources for learning more about Evy:
 - [Syntax by Example](docs/syntax_by_example.md): A collection of examples that illustrate the Evy syntax.
 - [Built-in Documentation](docs/builtins.md): Details on built-in functions and events in Evy.
 - [Language Specification](docs/spec.md): A formal definition of the Evy syntax and language.
+
+For questions and discussions, join the [Evy community] on Discord.
+
+[Evy community]: https://evy.dev/discord
 
 ## 📦 Installation
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and animations. Evy bridges the gap between block-based languages like
 
 ## 🌱 Getting Started
 
-You can try Evy online at [evy.dev] and browse the examples.
+You can try Evy online at [evy.dev/play] and browse the examples.
 Alternatively you can [install](#-installation) the `evy` toolchain
 locally.
 
@@ -34,8 +34,8 @@ Here is a "hello world" program in Evy
 
 </details>
 
-[evy.dev]: https://evy.dev
-[Animation source code]: https://evy.dev/#content=H4sIAAAAAAAAEzWLwQqAIBBE7/sVg/fSiC6BHyO2B0FXWazvz4qGGXjMMKVejM09thaRpbNSrLkqTDu1ZTak2D1WRzFpzAwlqoIgqYTOhKHRBn1J4UcmuHn5lv/CctAN/HT8mWwAAAA=
+[evy.dev/play]: https://evy.dev/play
+[Animation source code]: https://evy.dev/play#content=H4sIAAAAAAAAEzWLwQqAIBBE7/sVg/fSiC6BHyO2B0FXWazvz4qGGXjMMKVejM09thaRpbNSrLkqTDu1ZTak2D1WRzFpzAwlqoIgqYTOhKHRBn1J4UcmuHn5lv/CctAN/HT8mWwAAAA=
 
 ## 📖 Documentation
 
@@ -140,7 +140,7 @@ Evy would not be here today without the help of many people.
 [@ckaser]: https://github.com/ckaser
 [easylang]: https://easylang.online/
 [@fcostin]: https://github.com/fcostin
-[Splash of Trig]: https://evy.dev/#splashtrig
+[Splash of Trig]: https://evy.dev/play#splashtrig
 [@starkcoffee]: https://github.com/starkcoffee
 [@loislambeth]: https://github.com/loislambeth
 [@alecthomas]: https://github.com/alecthomas

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# Documentation
+
+Learn more about Evy
+
+- [Syntax by Example](syntax_by_example.md): Learn the Evy syntax with a collection of examples.
+- [Built-in Documentation](builtins.md): Get details on built-in functions and events in Evy.
+- [Language Specification](spec.md): Read a formal definition of the Evy syntax and language.
+- [`evy` Usage](usage.md): Learn how to use the `evy` command line tool.
+
+Learn programming with Evy
+
+- Check out the [Learn and Practise] resources.
+- Explore the samples on the [Playground] or the [Gallery].
+- Ask questions or discuss Evy in the [Evy community] on Discord.
+
+[Learn and Practise]: https://github.com/foxygoat/evy/wiki
+[Playground]: https://evy.dev/play
+[Gallery]: https://github.com/foxygoat/evy/wiki/gallery
+[Evy community]: https://evy.dev/discord

--- a/docs/builtins.md
+++ b/docs/builtins.md
@@ -1438,7 +1438,7 @@ create shapes on the canvas. Other graphics functions such as
 `color`, `width`, and `font` set the style of the pen for subsequent
 drawing commands.
 
-[Evy source: coordinates]: https://evy.dev/#content=H4sIAAAAAAAAE0WRwW6EIBCG7/MUE86NAV1w8dqkL7HxYJFtSVE2rmnXNn33DgL2NDMfA///h7fFjWCCDwuyVz+YDwZfblzfkVcnAO9mixwF5zCFz9jyxIhQC7fgN7zsQ48XfUZRydTEOfG8tL8SYSVRn/sIcokc4BrmFX/u7tt2J7wOk/Nbx17cMuBzGO0TTmEO99tgLPtNXrREAat9rMgeLCFBMKPtQGWJM0ioOVJQp3gJqY48hKUma7VG2VJtRK47z0t0qGKeus3LLSrRF56laomqzvq72OFBYK2L1e6fC5JQJVXXRJ4/Z7EjO/yTV+MW4+kC/AGSFdVbwgEAAA==
+[Evy source: coordinates]: https://evy.dev/play#content=H4sIAAAAAAAAE0WRwW6EIBCG7/MUE86NAV1w8dqkL7HxYJFtSVE2rmnXNn33DgL2NDMfA///h7fFjWCCDwuyVz+YDwZfblzfkVcnAO9mixwF5zCFz9jyxIhQC7fgN7zsQ48XfUZRydTEOfG8tL8SYSVRn/sIcokc4BrmFX/u7tt2J7wOk/Nbx17cMuBzGO0TTmEO99tgLPtNXrREAat9rMgeLCFBMKPtQGWJM0ioOVJQp3gJqY48hKUma7VG2VJtRK47z0t0qGKeus3LLSrRF56laomqzvq72OFBYK2L1e6fC5JQJVXXRJ4/Z7EjO/yTV+MW4+kC/AGSFdVbwgEAAA==
 
 ---
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1398,7 +1398,7 @@ For more information on individual event handlers, see the
 
 Evy has two runtimes: the **terminal runtime** and the **browser runtime**.
 
-The browser runtime can be tried at [evy.dev](https://evy.dev). It fully
+The browser runtime can be tried at [evy.dev/play]. It fully
 supports all built-in functions and event handlers as described in the
 [built-in documentation](builtin.md).
 
@@ -1414,3 +1414,5 @@ with
 
 For more details, run `evy run --help` or `evy fmt --help`. The terminal
 runtime does not support event handlers or graphics functions.
+
+[evy.dev/play](https://evy.dev/play)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,7 +4,7 @@ The `evy` toolchain is a set of tools that can be used to compile, run,
 and format Evy source code. You can [install] the Evy toolchain locally
 and run it from your command line. The command-line interface for Evy
 supports all built-in functions except for graphics functions and event
-handlers. Only the web interface on [evy.dev] supports graphics and
+handlers. Only the web interface on [evy.dev/play] supports graphics and
 events.
 
 The Evy toolchain has two subcommands:
@@ -16,7 +16,7 @@ You can also get help for each subcommand by running it with the
 `--help` flag.
 
 [install]: ../README.md#-installation
-[evy.dev]: https://evy.dev
+[evy.dev/play]: https://evy.dev/play
 
 #### evy --help
 

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -18,6 +18,11 @@
         "type": 301
       },
       {
+        "source": "/docs",
+        "destination": "https://github.com/foxygoat/evy/blob/master/docs/README.md",
+        "type": 301
+      },
+      {
         "source": "/play",
         "destination": "/",
         "type": 301

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -5,7 +5,19 @@
   },
   "hosting": {
     "public": "public",
-    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "redirects": [
+      {
+        "source": "/discord",
+        "destination": "https://discord.gg/XHHXf6y29n",
+        "type": 301
+      },
+      {
+        "source": "/discord-server",
+        "destination": "https://discord.com/channels/1008553546058313738",
+        "type": 301
+      }
+    ]
   },
   "emulators": {
     "auth": {

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -16,6 +16,11 @@
         "source": "/discord-server",
         "destination": "https://discord.com/channels/1008553546058313738",
         "type": 301
+      },
+      {
+        "source": "/play",
+        "destination": "/",
+        "type": 301
       }
     ]
   },


### PR DESCRIPTION
Tweak docs and add redirects from evy.dev:

- change chat on Slack to chat on Discord
- add a redirect to for evy.dev/play
- add a docs/README.md landing page