### PR TITLE
lexer: Rework godocs

### DIFF
--- a/main.go
+++ b/main.go
@@ -228,8 +228,13 @@ func (c *tokenizeCmd) Run() error {
 	if err != nil {
 		return err
 	}
-	result := lexer.Run(string(b))
-	fmt.Println(result)
+	l := lexer.New(string(b))
+	tok := l.Next()
+	for ; tok.Type != lexer.EOF; tok = l.Next() {
+		fmt.Println(tok)
+	}
+	fmt.Println(tok)
+	fmt.Println()
 	return nil
 }
 

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -6,20 +6,8 @@ package lexer
 
 import (
 	"strconv"
-	"strings"
 	"unicode"
 )
-
-func Run(input string) string {
-	l := New(input)
-	tok := l.Next()
-	var sb strings.Builder
-	for ; tok.Type != EOF; tok = l.Next() {
-		sb.WriteString(tok.String() + "\n")
-	}
-	sb.WriteString(tok.String() + "\n")
-	return sb.String()
-}
 
 type Lexer struct {
 	input []rune

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -44,94 +44,94 @@ func (l *Lexer) Next() *Token {
 	switch l.cur {
 	case ' ', '\t':
 		l.consumeHorizontalWhitespace()
-		return tok.SetType(WS)
+		return tok.setType(WS)
 	case '=':
 		if l.peekRune() == '=' {
 			l.advance()
-			return tok.SetType(EQ)
+			return tok.setType(EQ)
 		}
-		return tok.SetType(ASSIGN)
+		return tok.setType(ASSIGN)
 	case '+':
-		return tok.SetType(PLUS)
+		return tok.setType(PLUS)
 	case '-':
-		return tok.SetType(MINUS)
+		return tok.setType(MINUS)
 	case '!':
 		if l.peekRune() == '=' {
 			l.advance()
-			return tok.SetType(NOT_EQ)
+			return tok.setType(NOT_EQ)
 		}
-		return tok.SetType(BANG)
+		return tok.setType(BANG)
 	case '/':
 		if l.peekRune() == '/' {
-			return tok.SetType(COMMENT).SetLiteral(l.readComment())
+			return tok.setType(COMMENT).setLiteral(l.readComment())
 		}
-		return tok.SetType(SLASH)
+		return tok.setType(SLASH)
 	case '*':
-		return tok.SetType(ASTERISK)
+		return tok.setType(ASTERISK)
 	case '%':
-		return tok.SetType(PERCENT)
+		return tok.setType(PERCENT)
 	case '<':
 		if l.peekRune() == '=' {
 			l.advance()
-			return tok.SetType(LTEQ)
+			return tok.setType(LTEQ)
 		}
-		return tok.SetType(LT)
+		return tok.setType(LT)
 	case '>':
 		if l.peekRune() == '=' {
 			l.advance()
-			return tok.SetType(GTEQ)
+			return tok.setType(GTEQ)
 		}
-		return tok.SetType(GT)
+		return tok.setType(GT)
 	case ':':
 		if l.peekRune() == '=' {
 			l.advance()
-			return tok.SetType(DECLARE)
+			return tok.setType(DECLARE)
 		}
-		return tok.SetType(COLON)
+		return tok.setType(COLON)
 	case '{':
-		return tok.SetType(LCURLY)
+		return tok.setType(LCURLY)
 	case '}':
-		return tok.SetType(RCURLY)
+		return tok.setType(RCURLY)
 	case '(':
-		return tok.SetType(LPAREN)
+		return tok.setType(LPAREN)
 	case ')':
-		return tok.SetType(RPAREN)
+		return tok.setType(RPAREN)
 	case '[':
-		return tok.SetType(LBRACKET)
+		return tok.setType(LBRACKET)
 	case ']':
-		return tok.SetType(RBRACKET)
+		return tok.setType(RBRACKET)
 	case '\n':
-		return tok.SetType(NL)
+		return tok.setType(NL)
 	case '.':
 		if l.peekRune() == '.' && l.peekRune2() == '.' {
 			l.advance()
 			l.advance()
-			return tok.SetType(DOT3)
+			return tok.setType(DOT3)
 		}
-		return tok.SetType(DOT)
+		return tok.setType(DOT)
 	case '"':
 		literal, err := l.readString()
 		// strconv.Unquote error
 		if err != nil {
-			return tok.SetType(ILLEGAL).SetLiteral("invalid string")
+			return tok.setType(ILLEGAL).setLiteral("invalid string")
 		}
-		return tok.SetType(STRING_LIT).SetLiteral(literal)
+		return tok.setType(STRING_LIT).setLiteral(literal)
 	case 0:
-		return tok.SetType(EOF)
+		return tok.setType(EOF)
 	}
 	if isLetter(l.cur) {
 		literal := l.readIdent()
-		tokenType := LookupKeyword(literal)
+		tokenType := lookupKeyword(literal)
 		if tokenType == IDENT {
-			return tok.SetType(IDENT).SetLiteral(literal)
+			return tok.setType(IDENT).setLiteral(literal)
 		}
-		return tok.SetType(tokenType)
+		return tok.setType(tokenType)
 	}
 	if isDigit(l.cur) {
-		return tok.SetType(NUM_LIT).SetLiteral(l.readNum())
+		return tok.setType(NUM_LIT).setLiteral(l.readNum())
 	}
 
-	return tok.SetType(ILLEGAL).SetLiteral(string(l.cur))
+	return tok.setType(ILLEGAL).setLiteral(string(l.cur))
 }
 
 func (l *Lexer) advance() {

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -1,7 +1,21 @@
-// Package lexer tokenizes input and lets follow up phases in compiler,
-// such as parser, iterate over tokens via Lexer.Next() function. The
-// lexer package also exposes a Run method for debugging the lexing
-// phase only.
+// Package lexer tokenizes the input.
+//
+// The first step in the Evy compilation process is tokenization. This
+// involves breaking the Evy input code into individual tokens, such as
+// keywords, operators, and identifiers.  The lexer package is
+// responsible for this task. It provides a [Lexer] type, which can be
+// initialized using the [New] function. The [Lexer.Next] method
+// returns the next Token in the input string. A [Token] is a data
+// structure that represents a single token in the input code. The
+// [EOF] token is a special token that indicates the end of the input
+// code.
+//
+// The [parser] then takes these tokens and creates an Abstract Syntax
+// Tree(AST), which is a representation of the Evy code's structure.
+// Finally, the [evaluator] walks the AST and executes the program.
+//
+// [parser]: https://pkg.go.dev/foxygo.at/evy/pkg/parser
+// [evaluator]: https://pkg.go.dev/foxygo.at/evy/pkg/evaluator
 package lexer
 
 import (
@@ -9,6 +23,7 @@ import (
 	"unicode"
 )
 
+// Lexer is a lexical analyzer for Evy source code.
 type Lexer struct {
 	input []rune
 	cur   rune // current rune under examination
@@ -17,10 +32,13 @@ type Lexer struct {
 	col   int
 }
 
+// New creates a new Lexer for the given input string.
 func New(input string) *Lexer {
 	return &Lexer{input: []rune(input), pos: -1, line: 1}
 }
 
+// Next returns the next [Token] in the input string. When the end of
+// the input string is reached Next returns a Token with type [EOF].
 func (l *Lexer) Next() *Token {
 	l.advance()
 

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -1,6 +1,7 @@
 package lexer
 
 import (
+	"strings"
 	"testing"
 
 	"foxygo.at/evy/pkg/assert"
@@ -306,7 +307,7 @@ func TestRun(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.in, func(t *testing.T) {
-			got := Run(tt.in)
+			got := run(tt.in)
 			want := tt.want + "EOF\n"
 			assert.Equal(t, want, got)
 		})
@@ -326,7 +327,7 @@ func TestRunWS(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.in, func(t *testing.T) {
-			got := Run(tt.in)
+			got := run(tt.in)
 			want := tt.want + "WS\nEOF\n"
 			assert.Equal(t, want, got)
 		})
@@ -347,7 +348,7 @@ func TestString(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.in, func(t *testing.T) {
-			got := Run(tt.in)
+			got := run(tt.in)
 			want := tt.want + "\nWS\nEOF\n"
 			assert.Equal(t, want, got)
 		})
@@ -386,4 +387,15 @@ func TestStringLitErr(t *testing.T) {
 		got := l.Next()
 		assert.Equal(t, want, got)
 	}
+}
+
+func run(input string) string {
+	l := New(input)
+	tok := l.Next()
+	var sb strings.Builder
+	for ; tok.Type != EOF; tok = l.Next() {
+		sb.WriteString(tok.String() + "\n")
+	}
+	sb.WriteString(tok.String() + "\n")
+	return sb.String()
 }

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -61,7 +61,7 @@ func TestSingleToken(t *testing.T) {
 			want := &Token{Type: tt.want, Literal: "", Offset: 0, Line: 1, Col: 1}
 			assert.Equal(t, want, got)
 
-			wantFormat := tt.in
+			wantFormat := `"` + tt.in + `"`
 			gotFormat := got.Format()
 			assert.Equal(t, wantFormat, gotFormat)
 

--- a/pkg/lexer/token.go
+++ b/pkg/lexer/token.go
@@ -80,7 +80,7 @@ const (
 	END    // end
 )
 
-func LookupKeyword(s string) TokenType {
+func lookupKeyword(s string) TokenType {
 	if tok, ok := keywords[s]; ok {
 		return tok
 	}
@@ -198,7 +198,7 @@ func (t TokenType) FormatDetails() string {
 	return fmt.Sprintf("%q", t.Format())
 }
 
-func (t *Token) SetType(tokenType TokenType) *Token {
+func (t *Token) setType(tokenType TokenType) *Token {
 	t.Type = tokenType
 	return t
 }
@@ -207,7 +207,7 @@ func (t *Token) TokenType() TokenType {
 	return t.Type
 }
 
-func (t *Token) SetLiteral(literal string) *Token {
+func (t *Token) setLiteral(literal string) *Token {
 	t.Literal = literal
 	return t
 }

--- a/pkg/lexer/token.go
+++ b/pkg/lexer/token.go
@@ -5,6 +5,11 @@ import (
 	"strconv"
 )
 
+// Token contains
+//   - type of the token, such as [IDENT], [PLUS] or [NUM_LIT]
+//   - start location of the token in the input string
+//   - literal value of the token, used only for number literals, string
+//     literals and comments.
 type Token struct {
 	Literal string
 
@@ -14,6 +19,8 @@ type Token struct {
 	Type   TokenType
 }
 
+// TokenType represents the type of token, such as identifier [IDENT],
+// operator [PLUS] or literal [NUM_LIT].
 type TokenType int
 
 const (
@@ -23,7 +30,7 @@ const (
 
 	// Identifiers and Literals.
 	IDENT      // some_identifier
-	NUM_LIT    // 123 456.78
+	NUM_LIT    // 123 or 456.78
 	STRING_LIT // "a string 🧵"
 
 	// Operators.
@@ -167,6 +174,7 @@ var tokenStrings = map[TokenType]tokenString{
 	END:        {string: "END", format: "end"},
 }
 
+// String implements the [fmt.Stringer] interface for [TokenType].
 func (t TokenType) String() string {
 	if ts, ok := tokenStrings[t]; ok {
 		return ts.string
@@ -174,10 +182,16 @@ func (t TokenType) String() string {
 	return "UNKNOWN"
 }
 
+// GoString implements the [fmt.GoStringer] interface for
+// [TokenType]. Its return value is more useful than the iota value
+// when debugging failed tests.
 func (t TokenType) GoString() string {
 	return t.String()
 }
 
+// Format returns a string representation of the token type that is
+// useful in error messages. The string representation is more
+// descriptive than the string returned by the String() method.
 func (t TokenType) Format() string {
 	if t == EOF {
 		return "end of input"
@@ -196,6 +210,8 @@ func (t *Token) setType(tokenType TokenType) *Token {
 	return t
 }
 
+// TokenType returns the type of the token as represented by the
+// [TokenType] type.
 func (t *Token) TokenType() TokenType {
 	return t.Type
 }
@@ -205,6 +221,7 @@ func (t *Token) setLiteral(literal string) *Token {
 	return t
 }
 
+// String implements the [fmt.Stringer] interface for [Token].
 func (t *Token) String() string {
 	switch t.Type {
 	case COMMENT, IDENT, NUM_LIT, STRING_LIT:
@@ -215,6 +232,10 @@ func (t *Token) String() string {
 	return t.Type.String()
 }
 
+// Format returns a string representation of the token that is useful in
+// error messages. If the token has a relevant literal value, the
+// literal is returned. Otherwise, the format of the token type is
+// returned.
 func (t *Token) Format() string {
 	switch t.Type {
 	case COMMENT, IDENT, NUM_LIT:
@@ -225,6 +246,8 @@ func (t *Token) Format() string {
 	return t.Type.Format()
 }
 
+// Location returns a string representation of a token's start location
+// in the form of: "line <line number> column <column number>".
 func (t *Token) Location() string {
 	return "line " + strconv.Itoa(t.Line) + " column " + strconv.Itoa(t.Col)
 }

--- a/pkg/lexer/token.go
+++ b/pkg/lexer/token.go
@@ -167,13 +167,6 @@ var tokenStrings = map[TokenType]tokenString{
 	END:        {string: "END", format: "end"},
 }
 
-func (t TokenType) Format() string {
-	if ts, ok := tokenStrings[t]; ok {
-		return ts.format
-	}
-	return "<unknown>"
-}
-
 func (t TokenType) String() string {
 	if ts, ok := tokenStrings[t]; ok {
 		return ts.string
@@ -185,7 +178,7 @@ func (t TokenType) GoString() string {
 	return t.String()
 }
 
-func (t TokenType) FormatDetails() string {
+func (t TokenType) Format() string {
 	if t == EOF {
 		return "end of input"
 	}
@@ -195,7 +188,7 @@ func (t TokenType) FormatDetails() string {
 	if t == IDENT {
 		return "identifier"
 	}
-	return fmt.Sprintf("%q", t.Format())
+	return fmt.Sprintf("%q", tokenStrings[t].format)
 }
 
 func (t *Token) setType(tokenType TokenType) *Token {
@@ -230,16 +223,6 @@ func (t *Token) Format() string {
 		return `"` + t.Literal + `"`
 	}
 	return t.Type.Format()
-}
-
-func (t *Token) FormatDetails() string {
-	switch t.Type {
-	case COMMENT, IDENT, NUM_LIT:
-		return t.Literal
-	case STRING_LIT:
-		return `"` + t.Literal + `"`
-	}
-	return t.Type.FormatDetails()
 }
 
 func (t *Token) Location() string {

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -103,16 +103,16 @@ func (p *parser) unexpectedLeftTokenError() {
 		tt := p.cur.Type
 		prevTT := p.lookAt(p.pos - 1).Type
 		if isBinaryOp(tt) && prevTT == lexer.WS {
-			p.appendError("unexpected whitespace before " + p.cur.FormatDetails())
+			p.appendError("unexpected whitespace before " + p.cur.Format())
 			return
 		}
 		if tt == lexer.WS && isBinaryOp(prevTT) {
 			prevToken := p.lookAt(p.pos - 1)
-			p.appendErrorForToken("unexpected whitespace after "+prevToken.FormatDetails(), prevToken)
+			p.appendErrorForToken("unexpected whitespace after "+prevToken.Format(), prevToken)
 			return
 		}
 	}
-	p.appendError("unexpected " + p.cur.FormatDetails())
+	p.appendError("unexpected " + p.cur.Format())
 }
 
 func (p *parser) isAtExprEnd() bool {
@@ -502,7 +502,7 @@ func (p *parser) parseMapPairs(mapLit *MapLiteral) bool {
 
 	for tt != lexer.RCURLY && tt != lexer.EOF {
 		if tt != lexer.IDENT {
-			p.appendError("expected map key, found " + p.cur.FormatDetails())
+			p.appendError("expected map key, found " + p.cur.Format())
 		}
 		key := p.cur.Literal
 		p.advance() // advance past key IDENT

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -344,7 +344,7 @@ func (p *parser) parseStatement() Node {
 	case lexer.IF:
 		return p.parseIfStatement()
 	}
-	p.appendError("unexpected input " + p.cur.FormatDetails())
+	p.appendError("unexpected input " + p.cur.Format())
 	p.advancePastNL()
 	return nil
 }
@@ -440,7 +440,7 @@ func (p *parser) parseFuncDeclSignature() *FuncDeclStmt {
 		p.advance() // advance past `:` of return type declaration, e.g. in `func rand:num`
 		fd.ReturnType = p.parseType()
 		if fd.ReturnType.Name == ILLEGAL {
-			p.appendErrorForToken("invalid return type: "+p.cur.FormatDetails(), fd.token)
+			p.appendErrorForToken("invalid return type: "+p.cur.Format(), fd.token)
 		}
 	}
 	for !p.isAtEOL() && p.cur.TokenType() != lexer.DOT3 {
@@ -622,7 +622,7 @@ func isEOL(tt lexer.TokenType) bool {
 
 func (p *parser) assertToken(tt lexer.TokenType) bool {
 	if p.cur.TokenType() != tt {
-		p.appendError("expected " + tt.FormatDetails() + ", got " + p.cur.TokenType().FormatDetails())
+		p.appendError("expected " + tt.Format() + ", got " + p.cur.TokenType().Format())
 		return false
 	}
 	return true
@@ -630,7 +630,7 @@ func (p *parser) assertToken(tt lexer.TokenType) bool {
 
 func (p *parser) assertEOL() {
 	if !p.isAtEOL() {
-		p.appendError("expected end of line, found " + p.cur.FormatDetails())
+		p.appendError("expected end of line, found " + p.cur.Format())
 	}
 }
 


### PR DESCRIPTION
Rework package, public type and function godocs for lexer package
according to new guidelines. While writing docs it became obvious that
we could remove several bits of this package make others private - less
documentation effort and commitment to maintain compatibility.

---

To view docs locally pull branch and run

    go run golang.org/x/pkgsite/cmd/pkgsite@latest -open .