### PR TITLE
docs: Prepare for parser godoc revision

### DIFF
--- a/main.go
+++ b/main.go
@@ -63,10 +63,12 @@ func newCLIRuntime() *cliRuntime {
 	return &cliRuntime{reader: bufio.NewReader(os.Stdin)}
 }
 
+// Print prints s to stdout.
 func (*cliRuntime) Print(s string) {
 	fmt.Print(s)
 }
 
+// Cls clears the screen.
 func (*cliRuntime) Cls() {
 	cmd := exec.Command("clear")
 	if runtime.GOOS == "windows" {
@@ -78,6 +80,7 @@ func (*cliRuntime) Cls() {
 	}
 }
 
+// Read reads a line of input from stdin and strips trailing newline.
 func (rt *cliRuntime) Read() string {
 	s, err := rt.reader.ReadString('\n')
 	if err != nil {
@@ -86,12 +89,16 @@ func (rt *cliRuntime) Read() string {
 	return s[:len(s)-1] // strip trailing newline
 }
 
+// Sleep sleeps for dur. If the --skip-sleep flag is used, it does nothing.
 func (rt *cliRuntime) Sleep(dur time.Duration) {
 	if !rt.skipSleep {
 		time.Sleep(dur)
 	}
 }
 
+// Yielder returns a no-op yielder for CLI evy as it is not needed. By
+// contrast, browser Evy needs to explicitly hand over control to JS
+// host with Yielder.
 func (*cliRuntime) Yielder() evaluator.Yielder { return nil }
 
 const description = `
@@ -135,6 +142,7 @@ type parseCmd struct {
 	Source string `arg:"" help:"Source file. Default stdin" default:"-"`
 }
 
+// Run implements the `evy run` CLI command, called by the Kong API.
 func (c *runCmd) Run() error {
 	b, err := fileBytes(c.Source)
 	if err != nil {
@@ -161,6 +169,7 @@ func handlEvyErr(err error) {
 	os.Exit(1)
 }
 
+// Run implements the `evy fmt` CLI command, called by the Kong API.
 func (c *fmtCmd) Run() error {
 	if len(c.Files) == 0 {
 		if c.Write {
@@ -223,6 +232,8 @@ func format(r io.Reader, w io.StringWriter, checkOnly bool) error {
 	return nil
 }
 
+// Run implements the hidden `evy tokenize` CLI command, called by the
+// Kong API.
 func (c *tokenizeCmd) Run() error {
 	b, err := fileBytes(c.Source)
 	if err != nil {
@@ -238,6 +249,8 @@ func (c *tokenizeCmd) Run() error {
 	return nil
 }
 
+// Run implements the hidden `evy parse` CLI command, called by the
+// Kong API.
 func (c *parseCmd) Run() error {
 	b, err := fileBytes(c.Source)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -217,7 +217,7 @@ func format(r io.Reader, w io.StringWriter, checkOnly bool) error {
 	parserBuiltins := evaluator.DefaultBuiltins(newCLIRuntime()).ParserBuiltins()
 	prog, err := parser.Parse(in, parserBuiltins)
 	if err != nil {
-		return fmt.Errorf("%w: %w", errParse, parser.TruncateError(err, 8))
+		return fmt.Errorf("%w: %w", errParse, truncateError(err))
 	}
 	out := prog.Format()
 	if checkOnly {
@@ -259,7 +259,7 @@ func (c *parseCmd) Run() error {
 	builtinDecls := evaluator.DefaultBuiltins(newCLIRuntime()).ParserBuiltins()
 	ast, err := parser.Parse(string(b), builtinDecls)
 	if err != nil {
-		return fmt.Errorf("%w: %w", errParse, parser.TruncateError(err, 8))
+		return fmt.Errorf("%w: %w", errParse, truncateError(err))
 	}
 	fmt.Println(ast.String())
 	return nil
@@ -270,4 +270,12 @@ func fileBytes(filename string) ([]byte, error) {
 		return io.ReadAll(os.Stdin)
 	}
 	return os.ReadFile(filename)
+}
+
+func truncateError(err error) error {
+	var parseErrors parser.Errors
+	if errors.As(err, &parseErrors) {
+		return parseErrors.Truncate(8)
+	}
+	return err
 }

--- a/pkg/evaluator/builtin.go
+++ b/pkg/evaluator/builtin.go
@@ -13,7 +13,7 @@ import (
 
 type Builtin struct {
 	Func BuiltinFunc
-	Decl *parser.FuncDeclStmt
+	Decl *parser.FuncDefStmt
 }
 
 type Builtins struct {
@@ -24,7 +24,7 @@ type Builtins struct {
 }
 
 func (b Builtins) ParserBuiltins() parser.Builtins {
-	funcs := make(map[string]*parser.FuncDeclStmt, len(b.Funcs))
+	funcs := make(map[string]*parser.FuncDefStmt, len(b.Funcs))
 	for name, builtin := range b.Funcs {
 		funcs[name] = builtin.Decl
 	}
@@ -138,7 +138,7 @@ func DefaultBuiltins(rt Runtime) Builtins {
 	}
 }
 
-var readDecl = &parser.FuncDeclStmt{
+var readDecl = &parser.FuncDefStmt{
 	Name:       "read",
 	ReturnType: parser.STRING_TYPE,
 }
@@ -157,7 +157,7 @@ func clsFunc(clsFn func()) BuiltinFunc {
 	}
 }
 
-var printDecl = &parser.FuncDeclStmt{
+var printDecl = &parser.FuncDefStmt{
 	Name:          "print",
 	VariadicParam: &parser.Var{Name: "a", T: parser.ANY_TYPE},
 	ReturnType:    parser.NONE_TYPE,
@@ -185,7 +185,7 @@ func printfFunc(printFn func(string)) BuiltinFunc {
 	}
 }
 
-var sprintDecl = &parser.FuncDeclStmt{
+var sprintDecl = &parser.FuncDefStmt{
 	Name:          "sprint",
 	VariadicParam: &parser.Var{Name: "a", T: parser.ANY_TYPE},
 	ReturnType:    parser.STRING_TYPE,
@@ -214,7 +214,7 @@ func sprintf(s string, vals []Value) string {
 	return fmt.Sprintf(s, args...)
 }
 
-var joinDecl = &parser.FuncDeclStmt{
+var joinDecl = &parser.FuncDefStmt{
 	Name: "join",
 	Params: []*parser.Var{
 		{Name: "arr", T: parser.GENERIC_ARRAY},
@@ -243,7 +243,7 @@ var stringArrayType *parser.Type = &parser.Type{
 	Sub:  parser.STRING_TYPE,
 }
 
-var splitDecl = &parser.FuncDeclStmt{
+var splitDecl = &parser.FuncDefStmt{
 	Name: "split",
 	Params: []*parser.Var{
 		{Name: "s", T: parser.STRING_TYPE},
@@ -263,7 +263,7 @@ func splitFunc(_ *scope, args []Value) (Value, error) {
 	return &Array{Elements: &elements, T: stringArrayType}, nil
 }
 
-var upperDecl = &parser.FuncDeclStmt{
+var upperDecl = &parser.FuncDefStmt{
 	Name: "upper",
 	Params: []*parser.Var{
 		{Name: "s", T: parser.STRING_TYPE},
@@ -276,7 +276,7 @@ func upperFunc(_ *scope, args []Value) (Value, error) {
 	return &String{Val: strings.ToUpper(s)}, nil
 }
 
-var lowerDecl = &parser.FuncDeclStmt{
+var lowerDecl = &parser.FuncDefStmt{
 	Name: "lower",
 	Params: []*parser.Var{
 		{Name: "s", T: parser.STRING_TYPE},
@@ -289,7 +289,7 @@ func lowerFunc(_ *scope, args []Value) (Value, error) {
 	return &String{Val: strings.ToLower(s)}, nil
 }
 
-var indexDecl = &parser.FuncDeclStmt{
+var indexDecl = &parser.FuncDefStmt{
 	Name: "index",
 	Params: []*parser.Var{
 		{Name: "s", T: parser.STRING_TYPE},
@@ -304,7 +304,7 @@ func indexFunc(_ *scope, args []Value) (Value, error) {
 	return &Num{Val: float64(strings.Index(s, substr))}, nil
 }
 
-var startswithDecl = &parser.FuncDeclStmt{
+var startswithDecl = &parser.FuncDefStmt{
 	Name: "startswith",
 	Params: []*parser.Var{
 		{Name: "s", T: parser.STRING_TYPE},
@@ -319,7 +319,7 @@ func startswithFunc(_ *scope, args []Value) (Value, error) {
 	return &Bool{Val: strings.HasPrefix(s, prefix)}, nil
 }
 
-var endswithDecl = &parser.FuncDeclStmt{
+var endswithDecl = &parser.FuncDefStmt{
 	Name: "endswith",
 	Params: []*parser.Var{
 		{Name: "s", T: parser.STRING_TYPE},
@@ -334,7 +334,7 @@ func endswithFunc(_ *scope, args []Value) (Value, error) {
 	return &Bool{Val: strings.HasSuffix(s, suffix)}, nil
 }
 
-var trimDecl = &parser.FuncDeclStmt{
+var trimDecl = &parser.FuncDefStmt{
 	Name: "trim",
 	Params: []*parser.Var{
 		{Name: "s", T: parser.STRING_TYPE},
@@ -349,7 +349,7 @@ func trimFunc(_ *scope, args []Value) (Value, error) {
 	return &String{Val: strings.Trim(s, cutset)}, nil
 }
 
-var replaceDecl = &parser.FuncDeclStmt{
+var replaceDecl = &parser.FuncDefStmt{
 	Name: "replace",
 	Params: []*parser.Var{
 		{Name: "s", T: parser.STRING_TYPE},
@@ -366,7 +366,7 @@ func replaceFunc(_ *scope, args []Value) (Value, error) {
 	return &String{Val: strings.ReplaceAll(s, oldStr, newStr)}, nil
 }
 
-var str2numDecl = &parser.FuncDeclStmt{
+var str2numDecl = &parser.FuncDefStmt{
 	Name:       "str2num",
 	Params:     []*parser.Var{{Name: "s", T: parser.STRING_TYPE}},
 	ReturnType: parser.NUM_TYPE,
@@ -383,7 +383,7 @@ func str2numFunc(scope *scope, args []Value) (Value, error) {
 	return &Num{Val: n}, nil
 }
 
-var str2boolDecl = &parser.FuncDeclStmt{
+var str2boolDecl = &parser.FuncDefStmt{
 	Name:       "str2bool",
 	Params:     []*parser.Var{{Name: "s", T: parser.STRING_TYPE}},
 	ReturnType: parser.BOOL_TYPE,
@@ -421,7 +421,7 @@ func globalErr(scope *scope, isErr bool, msg string) {
 	val.Set(&String{Val: msg})
 }
 
-var typeofDecl = &parser.FuncDeclStmt{
+var typeofDecl = &parser.FuncDefStmt{
 	Name:       "typeof",
 	Params:     []*parser.Var{{Name: "a", T: parser.ANY_TYPE}},
 	ReturnType: parser.STRING_TYPE,
@@ -435,7 +435,7 @@ func typeofFunc(_ *scope, args []Value) (Value, error) {
 	return &String{Val: t.String()}, nil
 }
 
-var lenDecl = &parser.FuncDeclStmt{
+var lenDecl = &parser.FuncDefStmt{
 	Name:       "len",
 	Params:     []*parser.Var{{Name: "a", T: parser.ANY_TYPE}},
 	ReturnType: parser.NUM_TYPE,
@@ -453,7 +453,7 @@ func lenFunc(_ *scope, args []Value) (Value, error) {
 	return nil, fmt.Errorf(`%w: "len" takes 1 argument of type "string", array "[]" or map "{}" not %s`, ErrBadArguments, args[0].Type())
 }
 
-var hasDecl = &parser.FuncDeclStmt{
+var hasDecl = &parser.FuncDefStmt{
 	Name: "has",
 	Params: []*parser.Var{
 		{Name: "m", T: parser.GENERIC_MAP},
@@ -469,7 +469,7 @@ func hasFunc(_ *scope, args []Value) (Value, error) {
 	return &Bool{Val: ok}, nil
 }
 
-var delDecl = &parser.FuncDeclStmt{
+var delDecl = &parser.FuncDefStmt{
 	Name: "del",
 	Params: []*parser.Var{
 		{Name: "m", T: parser.GENERIC_MAP},
@@ -485,7 +485,7 @@ func delFunc(_ *scope, args []Value) (Value, error) {
 	return &None{}, nil
 }
 
-var sleepDecl = &parser.FuncDeclStmt{
+var sleepDecl = &parser.FuncDefStmt{
 	Name:       "sleep",
 	Params:     []*parser.Var{{Name: "seconds", T: parser.NUM_TYPE}},
 	ReturnType: parser.NONE_TYPE,
@@ -509,7 +509,7 @@ func panicFunc(_ *scope, args []Value) (Value, error) {
 	return nil, PanicError(s)
 }
 
-var randDecl = &parser.FuncDeclStmt{
+var randDecl = &parser.FuncDefStmt{
 	Name:       "rand",
 	Params:     []*parser.Var{{Name: "upper", T: parser.NUM_TYPE}},
 	ReturnType: parser.NUM_TYPE,
@@ -526,7 +526,7 @@ func randFunc(_ *scope, args []Value) (Value, error) {
 	return &Num{Val: float64(randsource.Int31n(int32(upper)))}, nil
 }
 
-var rand1Decl = &parser.FuncDeclStmt{
+var rand1Decl = &parser.FuncDefStmt{
 	Name:       "rand",
 	Params:     []*parser.Var{},
 	ReturnType: parser.NUM_TYPE,
@@ -536,7 +536,7 @@ func rand1Func(_ *scope, args []Value) (Value, error) {
 	return &Num{Val: randsource.Float64()}, nil
 }
 
-var clearDecl = &parser.FuncDeclStmt{
+var clearDecl = &parser.FuncDefStmt{
 	Name:          "clear",
 	VariadicParam: &parser.Var{Name: "s", T: parser.STRING_TYPE},
 	ReturnType:    parser.NONE_TYPE,
@@ -556,7 +556,7 @@ func clearFunc(clearFn func(string)) BuiltinFunc {
 	}
 }
 
-var gridnDecl = &parser.FuncDeclStmt{
+var gridnDecl = &parser.FuncDefStmt{
 	Name: "gridn",
 	Params: []*parser.Var{
 		{Name: "unit", T: parser.NUM_TYPE},
@@ -586,7 +586,7 @@ var numArrayType *parser.Type = &parser.Type{
 	Sub:  parser.NUM_TYPE,
 }
 
-var polyDecl = &parser.FuncDeclStmt{
+var polyDecl = &parser.FuncDefStmt{
 	Name:          "poly",
 	VariadicParam: &parser.Var{Name: "vertices", T: numArrayType},
 	ReturnType:    parser.NONE_TYPE,
@@ -610,7 +610,7 @@ func polyFunc(polyFn func([][]float64)) BuiltinFunc {
 	}
 }
 
-var ellipseDecl = &parser.FuncDeclStmt{
+var ellipseDecl = &parser.FuncDefStmt{
 	Name:          "ellipse",
 	VariadicParam: &parser.Var{Name: "n", T: parser.NUM_TYPE},
 	ReturnType:    parser.NONE_TYPE,
@@ -644,7 +644,7 @@ func ellipseFunc(ellipseFn func(x, y, radiusX, radiusY, rotation, startAngle, en
 	}
 }
 
-var dashDecl = &parser.FuncDeclStmt{
+var dashDecl = &parser.FuncDefStmt{
 	Name:          "dash",
 	VariadicParam: &parser.Var{Name: "segments", T: parser.NUM_TYPE},
 	ReturnType:    parser.NONE_TYPE,
@@ -661,7 +661,7 @@ func dashFunc(dashFn func([]float64)) BuiltinFunc {
 	}
 }
 
-var fontDecl = &parser.FuncDeclStmt{
+var fontDecl = &parser.FuncDefStmt{
 	Name:       "font",
 	Params:     []*parser.Var{{Name: "properties", T: parser.GENERIC_MAP}},
 	ReturnType: parser.NONE_TYPE,
@@ -725,15 +725,15 @@ func fontFunc(fontFn func(map[string]any)) BuiltinFunc {
 	}
 }
 
-func emptyDecl(name string) *parser.FuncDeclStmt {
-	return &parser.FuncDeclStmt{
+func emptyDecl(name string) *parser.FuncDefStmt {
+	return &parser.FuncDefStmt{
 		Name:       name,
 		ReturnType: parser.NONE_TYPE,
 	}
 }
 
-func xyDecl(name string) *parser.FuncDeclStmt {
-	return &parser.FuncDeclStmt{
+func xyDecl(name string) *parser.FuncDefStmt {
+	return &parser.FuncDefStmt{
 		Name: name,
 		Params: []*parser.Var{
 			{Name: "x", T: parser.NUM_TYPE},
@@ -754,8 +754,8 @@ func xyBuiltin(name string, fn func(x, y float64)) Builtin {
 	return result
 }
 
-func xyRetDecl(name string) *parser.FuncDeclStmt {
-	return &parser.FuncDeclStmt{
+func xyRetDecl(name string) *parser.FuncDefStmt {
+	return &parser.FuncDefStmt{
 		Name: name,
 		Params: []*parser.Var{
 			{Name: "x", T: parser.NUM_TYPE},
@@ -776,8 +776,8 @@ func xyRetBuiltin(name string, fn func(x, y float64) float64) Builtin {
 	return result
 }
 
-func numDecl(name string) *parser.FuncDeclStmt {
-	return &parser.FuncDeclStmt{
+func numDecl(name string) *parser.FuncDefStmt {
+	return &parser.FuncDefStmt{
 		Name: name,
 		Params: []*parser.Var{
 			{Name: "n", T: parser.NUM_TYPE},
@@ -796,8 +796,8 @@ func numBuiltin(name string, fn func(n float64)) Builtin {
 	return result
 }
 
-func numRetDecl(name string) *parser.FuncDeclStmt {
-	return &parser.FuncDeclStmt{
+func numRetDecl(name string) *parser.FuncDefStmt {
+	return &parser.FuncDefStmt{
 		Name: name,
 		Params: []*parser.Var{
 			{Name: "n", T: parser.NUM_TYPE},
@@ -816,8 +816,8 @@ func numRetBuiltin(name string, fn func(n float64) float64) Builtin {
 	return result
 }
 
-func stringDecl(name string) *parser.FuncDeclStmt {
-	return &parser.FuncDeclStmt{
+func stringDecl(name string) *parser.FuncDefStmt {
+	return &parser.FuncDefStmt{
 		Name: name,
 		Params: []*parser.Var{
 			{Name: "str", T: parser.STRING_TYPE},

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -82,7 +82,9 @@ func NewEvaluator(builtins Builtins) *Evaluator {
 }
 
 type Evaluator struct {
-	Stopped       bool
+	Stopped           bool
+	EventHandlerNames []string
+
 	yielder       Yielder // Yield to give JavaScript/browser events a chance to run.
 	builtins      Builtins
 	eventHandlers map[string]*parser.EventHandlerStmt
@@ -176,10 +178,6 @@ func (e *Evaluator) Eval(node parser.Node) (Value, error) {
 	return nil, fmt.Errorf("%w: %v", ErrUnknownNode, node)
 }
 
-func (e *Evaluator) EventHandlerNames() []string {
-	return parser.EventHandlerNames(e.eventHandlers)
-}
-
 func (e *Evaluator) HandleEvent(ev Event) error {
 	eh := e.eventHandlers[ev.Name]
 	if eh == nil {
@@ -210,6 +208,10 @@ func (e *Evaluator) yield() {
 
 func (e *Evaluator) evalProgram(program *parser.Program) (Value, error) {
 	e.eventHandlers = program.EventHandlers
+	e.EventHandlerNames = make([]string, 0, len(e.eventHandlers))
+	for name := range e.eventHandlers {
+		e.EventHandlerNames = append(e.EventHandlerNames, name)
+	}
 	return e.evalStatments(program.Statements)
 }
 

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -170,7 +170,7 @@ func (e *Evaluator) Eval(node parser.Node) (Value, error) {
 		return e.Eval(node.Expr)
 	case *parser.TypeAssertion:
 		return e.evalTypeAssertion(node)
-	case *parser.FuncDeclStmt, *parser.EventHandlerStmt, *parser.EmptyStmt:
+	case *parser.FuncDefStmt, *parser.EventHandlerStmt, *parser.EmptyStmt:
 		return &None{}, nil
 	}
 	return nil, fmt.Errorf("%w: %v", ErrUnknownNode, node)
@@ -296,7 +296,7 @@ func (e *Evaluator) evalFunccall(funcCall *parser.FuncCall) (Value, error) {
 	defer restoreScope()
 
 	// Add func args to scope
-	fd := funcCall.FuncDecl
+	fd := funcCall.FuncDef
 	for i, param := range fd.Params {
 		e.scope.set(param.Name, args[i], param.Type())
 	}

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -134,7 +134,7 @@ func (e *Evaluator) Eval(node parser.Node) (Value, error) {
 		return &Num{Val: node.Value}, nil
 	case *parser.StringLiteral:
 		return &String{Val: node.Value}, nil
-	case *parser.Bool:
+	case *parser.BoolLiteral:
 		return e.evalBool(node), nil
 	case *parser.ArrayLiteral:
 		return e.evalArrayLiteral(node)
@@ -228,7 +228,7 @@ func (e *Evaluator) evalStatments(statements []parser.Node) (Value, error) {
 	return result, nil
 }
 
-func (e *Evaluator) evalBool(b *parser.Bool) Value {
+func (e *Evaluator) evalBool(b *parser.BoolLiteral) Value {
 	return &Bool{Val: b.Value}
 }
 

--- a/pkg/lexer/token.go
+++ b/pkg/lexer/token.go
@@ -23,6 +23,8 @@ type Token struct {
 // operator [PLUS] or literal [NUM_LIT].
 type TokenType int
 
+// Token types are represented as constants and are the core field of
+// the [Token] struct type.
 const (
 	ILLEGAL TokenType = iota
 	EOF

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -221,11 +221,11 @@ type BlockStatement struct {
 	alwaysTerminates bool
 }
 
-func (b *Bool) Token() *lexer.Token {
+func (b *BoolLiteral) Token() *lexer.Token {
 	return b.token
 }
 
-type Bool struct {
+type BoolLiteral struct {
 	token *lexer.Token
 	Value bool
 }
@@ -656,11 +656,11 @@ func (c *ConditionalBlock) AlwaysTerminates() bool {
 	return c.Block.AlwaysTerminates()
 }
 
-func (b *Bool) String() string {
+func (b *BoolLiteral) String() string {
 	return strconv.FormatBool(b.Value)
 }
 
-func (b *Bool) Type() *Type {
+func (b *BoolLiteral) Type() *Type {
 	return BOOL_TYPE
 }
 
@@ -720,9 +720,9 @@ func zeroValue(t *Type, tt *lexer.Token) Node {
 	case STRING:
 		return &StringLiteral{Value: "", token: tt}
 	case BOOL:
-		return &Bool{Value: false, token: tt}
+		return &BoolLiteral{Value: false, token: tt}
 	case ANY:
-		return &Bool{Value: false, token: tt}
+		return &BoolLiteral{Value: false, token: tt}
 	case ARRAY:
 		return &ArrayLiteral{T: t, token: tt}
 	case MAP:

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -37,7 +37,7 @@ type FuncCall struct {
 	token     *lexer.Token // The IDENT of the function
 	Name      string
 	Arguments []Node
-	FuncDecl  *FuncDeclStmt
+	FuncDef   *FuncDefStmt
 }
 
 type UnaryExpression struct {
@@ -119,11 +119,11 @@ type BreakStmt struct {
 	token *lexer.Token
 }
 
-func (f *FuncDeclStmt) Token() *lexer.Token {
+func (f *FuncDefStmt) Token() *lexer.Token {
 	return f.token
 }
 
-type FuncDeclStmt struct {
+type FuncDefStmt struct {
 	token             *lexer.Token // The "func" token
 	Name              string
 	Params            []*Var
@@ -316,7 +316,7 @@ func (f *FuncCall) String() string {
 }
 
 func (f *FuncCall) Type() *Type {
-	return f.FuncDecl.ReturnType
+	return f.FuncDef.ReturnType
 }
 
 func (f *FuncCallStmt) Token() *lexer.Token {
@@ -328,7 +328,7 @@ func (f *FuncCallStmt) String() string {
 }
 
 func (f *FuncCallStmt) Type() *Type {
-	return f.FuncCall.FuncDecl.ReturnType
+	return f.FuncCall.FuncDef.ReturnType
 }
 
 func (u *UnaryExpression) Token() *lexer.Token {
@@ -512,7 +512,7 @@ func (a *AssignmentStmt) Type() *Type {
 	return a.Target.Type()
 }
 
-func (f *FuncDeclStmt) String() string {
+func (f *FuncDefStmt) String() string {
 	s := make([]string, len(f.Params))
 	for i, param := range f.Params {
 		s[i] = param.String()
@@ -529,7 +529,7 @@ func (f *FuncDeclStmt) String() string {
 	return signature + "{\n" + body + "}\n"
 }
 
-func (f *FuncDeclStmt) Type() *Type {
+func (f *FuncDefStmt) Type() *Type {
 	return f.ReturnType
 }
 

--- a/pkg/parser/ast.go
+++ b/pkg/parser/ast.go
@@ -20,8 +20,8 @@ type Program struct {
 	EventHandlers      map[string]*EventHandlerStmt
 	CalledBuiltinFuncs []string
 
-	alwaysTerminates bool
-	formatting       *formatting
+	alwaysTerms bool
+	formatting  *formatting
 }
 
 type EmptyStmt struct {
@@ -216,9 +216,9 @@ func (b *BlockStatement) Token() *lexer.Token {
 }
 
 type BlockStatement struct {
-	token            *lexer.Token // the NL before the first statement
-	Statements       []Node
-	alwaysTerminates bool
+	token       *lexer.Token // the NL before the first statement
+	Statements  []Node
+	alwaysTerms bool
 }
 
 func (b *BoolLiteral) Token() *lexer.Token {
@@ -288,8 +288,8 @@ func (*Program) Type() *Type {
 	return NONE_TYPE
 }
 
-func (p *Program) AlwaysTerminates() bool {
-	return p.alwaysTerminates
+func (p *Program) alwaysTerminates() bool {
+	return p.alwaysTerms
 }
 
 func (e *EmptyStmt) Token() *lexer.Token {
@@ -480,7 +480,7 @@ func (r *ReturnStmt) Type() *Type {
 	return r.T
 }
 
-func (*ReturnStmt) AlwaysTerminates() bool {
+func (*ReturnStmt) alwaysTerminates() bool {
 	return true
 }
 
@@ -496,7 +496,7 @@ func (*BreakStmt) Type() *Type {
 	return NONE_TYPE
 }
 
-func (b *BreakStmt) AlwaysTerminates() bool {
+func (b *BreakStmt) alwaysTerminates() bool {
 	return true
 }
 
@@ -548,15 +548,15 @@ func (i *IfStmt) Type() *Type {
 	return NONE_TYPE
 }
 
-func (i *IfStmt) AlwaysTerminates() bool {
-	if i.Else == nil || !i.Else.AlwaysTerminates() {
+func (i *IfStmt) alwaysTerminates() bool {
+	if i.Else == nil || !i.Else.alwaysTerminates() {
 		return false
 	}
-	if !i.IfBlock.AlwaysTerminates() {
+	if !i.IfBlock.alwaysTerminates() {
 		return false
 	}
 	for _, b := range i.ElseIfBlocks {
-		if !b.AlwaysTerminates() {
+		if !b.alwaysTerminates() {
 			return false
 		}
 	}
@@ -588,13 +588,13 @@ func (b *BlockStatement) Type() *Type {
 	return NONE_TYPE
 }
 
-func (b *BlockStatement) AlwaysTerminates() bool {
-	return b.alwaysTerminates
+func (b *BlockStatement) alwaysTerminates() bool {
+	return b.alwaysTerms
 }
 
-func alwaysTerminates(n Node) bool {
-	r, ok := n.(interface{ AlwaysTerminates() bool })
-	return ok && r.AlwaysTerminates()
+func alwaysTerms(n Node) bool {
+	r, ok := n.(interface{ alwaysTerminates() bool })
+	return ok && r.alwaysTerminates()
 }
 
 func (w *WhileStmt) String() string {
@@ -605,7 +605,7 @@ func (w *WhileStmt) Type() *Type {
 	return w.ConditionalBlock.Type()
 }
 
-func (*WhileStmt) AlwaysTerminates() bool {
+func (*WhileStmt) alwaysTerminates() bool {
 	return false
 }
 
@@ -639,7 +639,7 @@ func (s *StepRange) Type() *Type {
 	return NUM_TYPE
 }
 
-func (*ForStmt) AlwaysTerminates() bool {
+func (*ForStmt) alwaysTerminates() bool {
 	return false
 }
 
@@ -652,8 +652,8 @@ func (c *ConditionalBlock) Type() *Type {
 	return NONE_TYPE
 }
 
-func (c *ConditionalBlock) AlwaysTerminates() bool {
-	return c.Block.AlwaysTerminates()
+func (c *ConditionalBlock) alwaysTerminates() bool {
+	return c.Block.alwaysTerminates()
 }
 
 func (b *BoolLiteral) String() string {

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -18,33 +18,33 @@ import (
 type precedence int
 
 const (
-	LOWEST      precedence = iota
-	OR                     // or
-	AND                    // and
-	EQUALS                 // ==
-	LESSGREATER            // > or <
-	SUM                    // +
-	PRODUCT                // *
-	UNARY                  // -x  !x
-	INDEX                  // array[i]
+	lowestPrec      precedence = iota
+	orPrec                     // or
+	andPrec                    // and
+	equalsPrec                 // ==
+	lessgreaterPrec            // > or <
+	sumPrec                    // +
+	productPrec                // *
+	unaryPrec                  // -x  !x
+	indexPrec                  // array[i]
 )
 
 var precedences = map[lexer.TokenType]precedence{
-	lexer.EQ:       EQUALS,
-	lexer.NOT_EQ:   EQUALS,
-	lexer.LT:       LESSGREATER,
-	lexer.GT:       LESSGREATER,
-	lexer.LTEQ:     LESSGREATER,
-	lexer.GTEQ:     LESSGREATER,
-	lexer.PLUS:     SUM,
-	lexer.MINUS:    SUM,
-	lexer.OR:       OR,
-	lexer.SLASH:    PRODUCT,
-	lexer.ASTERISK: PRODUCT,
-	lexer.PERCENT:  PRODUCT,
-	lexer.AND:      AND,
-	lexer.LBRACKET: INDEX,
-	lexer.DOT:      INDEX,
+	lexer.EQ:       equalsPrec,
+	lexer.NOT_EQ:   equalsPrec,
+	lexer.LT:       lessgreaterPrec,
+	lexer.GT:       lessgreaterPrec,
+	lexer.LTEQ:     lessgreaterPrec,
+	lexer.GTEQ:     lessgreaterPrec,
+	lexer.PLUS:     sumPrec,
+	lexer.MINUS:    sumPrec,
+	lexer.OR:       orPrec,
+	lexer.SLASH:    productPrec,
+	lexer.ASTERISK: productPrec,
+	lexer.PERCENT:  productPrec,
+	lexer.AND:      andPrec,
+	lexer.LBRACKET: indexPrec,
+	lexer.DOT:      indexPrec,
 }
 
 func (p *parser) parseTopLevelExpr() Node {
@@ -52,7 +52,7 @@ func (p *parser) parseTopLevelExpr() Node {
 	if tok.Type == lexer.IDENT && p.funcs[tok.Literal] != nil {
 		return p.parseFuncCall()
 	}
-	return p.parseExpr(LOWEST)
+	return p.parseExpr(lowestPrec)
 }
 
 func (p *parser) parseFuncCall() Node {
@@ -130,7 +130,7 @@ func (p *parser) parseUnaryExpr() Node {
 		msg := fmt.Sprintf("unexpected whitespace after %q", unaryExp.Op.String())
 		p.appendErrorForToken(msg, tok)
 	}
-	unaryExp.Right = p.parseExpr(UNARY)
+	unaryExp.Right = p.parseExpr(unaryPrec)
 	if unaryExp.Right == nil {
 		return nil // previous error
 	}
@@ -449,7 +449,7 @@ func (p *parser) parseExprList() []Node {
 func (p *parser) parseExprWSS() Node {
 	p.pushWSS(true)
 	defer p.popWSS()
-	return p.parseExpr(LOWEST)
+	return p.parseExpr(lowestPrec)
 }
 
 func (p *parser) combineTypes(types []*Type) *Type {

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -218,7 +218,7 @@ func (p *parser) validateIndex(tok *lexer.Token, leftType TypeName, indexType *T
 		return false
 	}
 	if (leftType == ARRAY || leftType == STRING) && indexType != NUM_TYPE {
-		p.appendErrorForToken(leftType.Name()+" index expects num, found "+indexType.String(), tok)
+		p.appendErrorForToken(leftType.name()+" index expects num, found "+indexType.String(), tok)
 		return false
 	}
 	if leftType == MAP && indexType != STRING_TYPE {
@@ -455,10 +455,10 @@ func (p *parser) parseExprWSS() Node {
 func (p *parser) combineTypes(types []*Type) *Type {
 	combinedT := types[0]
 	for _, t := range types[1:] {
-		if combinedT.Accepts(t) {
+		if combinedT.accepts(t) {
 			continue
 		}
-		if t.Accepts(combinedT) {
+		if t.accepts(combinedT) {
 			combinedT = t
 			continue
 		}

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -58,11 +58,11 @@ func (p *parser) parseTopLevelExpr() Node {
 func (p *parser) parseFuncCall() Node {
 	fc := &FuncCall{token: p.cur, Name: p.cur.Literal}
 	p.advance() // advance past function name IDENT
-	funcDecl := p.funcs[fc.Name]
-	funcDecl.isCalled = true
-	fc.FuncDecl = funcDecl
+	funcDef := p.funcs[fc.Name]
+	funcDef.isCalled = true
+	fc.FuncDef = funcDef
 	fc.Arguments = p.parseExprList()
-	p.assertArgTypes(fc.FuncDecl, fc.Arguments)
+	p.assertArgTypes(fc.FuncDef, fc.Arguments)
 	return fc
 }
 

--- a/pkg/parser/expression.go
+++ b/pkg/parser/expression.go
@@ -388,7 +388,7 @@ func (p *parser) parseLiteral() Node {
 		return &NumLiteral{token: tok, Value: val}
 	case lexer.TRUE, lexer.FALSE:
 		p.advance()
-		return &Bool{token: tok, Value: tt == lexer.TRUE}
+		return &BoolLiteral{token: tok, Value: tt == lexer.TRUE}
 	case lexer.LBRACKET:
 		return p.parseArrayLiteral()
 	case lexer.LCURLY:

--- a/pkg/parser/format.go
+++ b/pkg/parser/format.go
@@ -68,8 +68,8 @@ func (f *formatting) format(n Node) {
 		f.formatForStmt(n)
 	case *ReturnStmt:
 		f.formatReturnStmt(n)
-	case *FuncDeclStmt:
-		f.formatFuncDeclStmt(n)
+	case *FuncDefStmt:
+		f.formatFuncDefStmt(n)
 	case *FuncCallStmt:
 		f.format(n.FuncCall)
 		f.writeComment(n)
@@ -209,7 +209,7 @@ func (f *formatting) formatReturnStmt(s *ReturnStmt) {
 	f.writeComment(s)
 }
 
-func (f *formatting) formatFuncDeclStmt(s *FuncDeclStmt) {
+func (f *formatting) formatFuncDefStmt(s *FuncDefStmt) {
 	f.writes("func ", s.Name)
 	if s.ReturnType != NONE_TYPE {
 		f.write(":")

--- a/pkg/parser/format.go
+++ b/pkg/parser/format.go
@@ -126,7 +126,7 @@ func (f *formatting) format(n Node) {
 		f.write("(")
 		f.format(n.Expr)
 		f.write(")")
-	case *Bool:
+	case *BoolLiteral:
 		f.write(n.String())
 	case *NumLiteral:
 		f.write(n.String())

--- a/pkg/parser/format_test.go
+++ b/pkg/parser/format_test.go
@@ -233,7 +233,7 @@ print i
 	}
 }
 
-func TestFuncDeclFormat(t *testing.T) {
+func TestFuncDefFormat(t *testing.T) {
 	tests := map[string]string{
 		`func fox     // func
 		print   "🦊"  // print

--- a/pkg/parser/multiline.go
+++ b/pkg/parser/multiline.go
@@ -135,7 +135,7 @@ func newAccumulations(stmts []Node, comments map[Node]string) []accumulation {
 			if comments[s] != "" {
 				stmtType = "comment"
 			}
-		case *FuncDeclStmt, *EventHandlerStmt:
+		case *FuncDefStmt, *EventHandlerStmt:
 			stmtType = "func"
 		}
 		if stmtType != lastStmtType || stmtType == "func" {

--- a/pkg/parser/operator.go
+++ b/pkg/parser/operator.go
@@ -88,7 +88,3 @@ func op(tok *lexer.Token) Operator {
 func (o Operator) String() string {
 	return operatorStrings[o]
 }
-
-func (o Operator) GoString() string {
-	return o.String()
-}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -175,12 +175,12 @@ func (p *parser) parseProgram() *Program {
 		default:
 			tok := p.cur
 			stmt = p.parseStatement()
-			if stmt != nil && program.AlwaysTerminates() {
+			if stmt != nil && program.alwaysTerminates() {
 				p.appendErrorForToken("unreachable code", tok)
 				stmt = nil
 			}
-			if alwaysTerminates(stmt) {
-				program.alwaysTerminates = true
+			if alwaysTerms(stmt) {
+				program.alwaysTerms = true
 			}
 		}
 		if stmt != nil {
@@ -224,7 +224,7 @@ func (p *parser) parseFunc() Node {
 		p.appendError(fmt.Sprintf("redeclaration of function %q", funcName))
 		return nil
 	}
-	if fd.ReturnType != NONE_TYPE && !block.AlwaysTerminates() {
+	if fd.ReturnType != NONE_TYPE && !block.alwaysTerminates() {
 		p.appendError("missing return")
 	}
 	p.assertEnd()
@@ -677,14 +677,14 @@ func (p *parser) parseBlockWithEndTokens(endTokens map[lexer.TokenType]bool) *Bl
 		if stmt == nil {
 			continue
 		}
-		if block.AlwaysTerminates() {
+		if block.alwaysTerminates() {
 			if _, ok := stmt.(*EmptyStmt); !ok {
 				p.appendErrorForToken("unreachable code", tok)
 				continue
 			}
 		}
-		if alwaysTerminates(stmt) {
-			block.alwaysTerminates = true
+		if alwaysTerms(stmt) {
+			block.alwaysTerms = true
 		}
 		block.Statements = append(block.Statements, stmt)
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -7,7 +7,6 @@
 package parser
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -48,14 +47,6 @@ func (e Errors) Truncate(length int) Errors {
 		return e
 	}
 	return e[:length]
-}
-
-func TruncateError(err error, length int) error {
-	var parseErrors Errors
-	if errors.As(err, &parseErrors) {
-		return parseErrors.Truncate(8)
-	}
-	return err
 }
 
 // Error is an Evy parse error.

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -384,7 +384,7 @@ func (p *parser) parseAssignmentStatement() Node {
 		p.advancePastNL()
 		return nil
 	}
-	if !target.Type().Accepts(value.Type()) {
+	if !target.Type().accepts(value.Type()) {
 		msg := fmt.Sprintf("%q accepts values of type %s, found %s", target.String(), target.Type().String(), value.Type().String())
 		p.appendErrorForToken(msg, tok)
 	}
@@ -540,7 +540,7 @@ func (p *parser) parseInferredDeclStatement() Node {
 		p.appendError(fmt.Sprintf("invalid declaration, function %q has no return value", valToken.Literal))
 		return nil
 	}
-	decl.Var.T = val.Type().Infer() // assign ANY to sub_type to empty arrays and maps.
+	decl.Var.T = val.Type().infer() // assign ANY to sub_type to empty arrays and maps.
 	if !p.validateVarDecl(decl.Var, decl.token, false /* allowUnderscore */) {
 		return nil
 	}
@@ -575,7 +575,7 @@ func (p *parser) assertArgTypes(decl *FuncDefStmt, args []Node) {
 		paramType := decl.VariadicParam.Type()
 		for _, arg := range args {
 			argType := arg.Type()
-			if !paramType.Accepts(argType) && !paramType.Matches(argType) {
+			if !paramType.accepts(argType) && !paramType.Matches(argType) {
 				msg := fmt.Sprintf("%q takes variadic arguments of type %s, found %s", funcName, paramType.String(), argType.String())
 				p.appendErrorForToken(msg, arg.Token())
 			}
@@ -594,7 +594,7 @@ func (p *parser) assertArgTypes(decl *FuncDefStmt, args []Node) {
 	for i, arg := range args {
 		paramType := decl.Params[i].Type()
 		argType := arg.Type()
-		if !paramType.Accepts(argType) && !paramType.Matches(argType) {
+		if !paramType.accepts(argType) && !paramType.Matches(argType) {
 			msg := fmt.Sprintf("%q takes %s argument of type %s, found %s", funcName, ordinalize(i+1), paramType.String(), argType.String())
 			p.appendErrorForToken(msg, arg.Token())
 		}
@@ -786,7 +786,7 @@ func (p *parser) parseReturnStatement() Node {
 	}
 	if p.scope.returnType == nil {
 		p.appendErrorForToken("return statement not allowed here", retValueToken)
-	} else if !p.scope.returnType.Accepts(ret.T) {
+	} else if !p.scope.returnType.accepts(ret.T) {
 		msg := "expected return value of type " + p.scope.returnType.String() + ", found " + ret.T.String()
 		if p.scope.returnType == NONE_TYPE && ret.T != NONE_TYPE {
 			msg = "expected no return value, found " + ret.T.String()
@@ -853,7 +853,7 @@ func (p *parser) parseForStatement() Node {
 		forNode.Range = n
 	case ARRAY:
 		if forNode.LoopVar != nil {
-			forNode.LoopVar.T = t.Infer().Sub
+			forNode.LoopVar.T = t.infer().Sub
 		}
 		forNode.Range = n
 	case NUM:

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -1028,11 +1028,3 @@ func (p *parser) calledBuiltinFuncs() []string {
 	}
 	return funcs
 }
-
-func EventHandlerNames(eventHandlers map[string]*EventHandlerStmt) []string {
-	names := make([]string, 0, len(eventHandlers))
-	for name := range eventHandlers {
-		names = append(names, name)
-	}
-	return names
-}

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -121,10 +121,10 @@ func TestFunccall(t *testing.T) {
 
 func TestFunccallError(t *testing.T) {
 	builtins := testBuiltins()
-	builtins.Funcs["f0"] = &FuncDeclStmt{Name: "f0", ReturnType: NONE_TYPE}
-	builtins.Funcs["f1"] = &FuncDeclStmt{Name: "f1", VariadicParam: &Var{Name: "a", T: NUM_TYPE}, ReturnType: NONE_TYPE}
-	builtins.Funcs["f2"] = &FuncDeclStmt{Name: "f2", Params: []*Var{{Name: "a", T: NUM_TYPE}}, ReturnType: NONE_TYPE}
-	builtins.Funcs["f3"] = &FuncDeclStmt{
+	builtins.Funcs["f0"] = &FuncDefStmt{Name: "f0", ReturnType: NONE_TYPE}
+	builtins.Funcs["f1"] = &FuncDefStmt{Name: "f1", VariadicParam: &Var{Name: "a", T: NUM_TYPE}, ReturnType: NONE_TYPE}
+	builtins.Funcs["f2"] = &FuncDefStmt{Name: "f2", Params: []*Var{{Name: "a", T: NUM_TYPE}}, ReturnType: NONE_TYPE}
+	builtins.Funcs["f3"] = &FuncDefStmt{
 		Name:       "f3",
 		Params:     []*Var{{Name: "a", T: NUM_TYPE}, {Name: "b", T: STRING_TYPE}},
 		ReturnType: NONE_TYPE,
@@ -197,7 +197,7 @@ print(x)
 	assert.Equal(t, want, got.String())
 }
 
-func TestFuncDecl(t *testing.T) {
+func TestFuncDef(t *testing.T) {
 	input := `
 c := 1
 func nums1:num n1:num n2:num
@@ -256,7 +256,7 @@ end
 	assert.Equal(t, "return n2", returnStmt.String())
 }
 
-func TestVariadicFuncDecl(t *testing.T) {
+func TestVariadicFuncDef(t *testing.T) {
 	inputs := []string{
 		`
 func fox nums:num...
@@ -1084,7 +1084,7 @@ end`,
 	}
 }
 
-func TestFuncDeclErr(t *testing.T) {
+func TestFuncDefErr(t *testing.T) {
 	inputs := map[string]string{
 		`
 func len s:string
@@ -1368,7 +1368,7 @@ func assertNoParseError(t *testing.T, parser *parser, input string) {
 }
 
 func testBuiltins() Builtins {
-	funcs := map[string]*FuncDeclStmt{
+	funcs := map[string]*FuncDefStmt{
 		"print": {
 			Name:          "print",
 			VariadicParam: &Var{Name: "a", T: ANY_TYPE},

--- a/pkg/parser/type.go
+++ b/pkg/parser/type.go
@@ -62,10 +62,6 @@ func (t TypeName) Name() string {
 	return typeNameStrings[t].name
 }
 
-func (t TypeName) GoString() string {
-	return t.String()
-}
-
 type Type struct {
 	Name TypeName // string, num, bool, composite types array, map
 	Sub  *Type    // e.g.: `[]int` : Type{Name: "array", Sub: &Type{Name: "int"} }

--- a/pkg/parser/type.go
+++ b/pkg/parser/type.go
@@ -58,7 +58,7 @@ func (t TypeName) String() string {
 	return typeNameStrings[t].format
 }
 
-func (t TypeName) Name() string {
+func (t TypeName) name() string {
 	return typeNameStrings[t].name
 }
 
@@ -74,7 +74,7 @@ func (t *Type) String() string {
 	return t.Name.String() + t.Sub.String()
 }
 
-func (t *Type) Accepts(t2 *Type) bool {
+func (t *Type) accepts(t2 *Type) bool {
 	if t.acceptsStrict(t2) {
 		return true
 	}
@@ -107,7 +107,7 @@ func (t *Type) Matches(t2 *Type) bool {
 	return t.Sub.Matches(t2.Sub)
 }
 
-func (t *Type) Infer() *Type {
+func (t *Type) infer() *Type {
 	if t.Name != ARRAY && t.Name != MAP {
 		return t
 	}
@@ -116,7 +116,7 @@ func (t *Type) Infer() *Type {
 		t2.Sub = ANY_TYPE
 		return &t2
 	}
-	t.Sub = t.Sub.Infer()
+	t.Sub = t.Sub.infer()
 	return t
 }
 

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -86,9 +86,11 @@ func parse(input string, rt evaluator.Runtime) (*parser.Program, error) {
 }
 
 func prepareUI(prog *parser.Program) {
-	funcNames := prog.CalledBuiltinFuncs
-	eventHandlerNames := parser.EventHandlerNames(prog.EventHandlers)
-	names := append(funcNames, eventHandlerNames...)
+	names := make([]string, 0, len(prog.CalledBuiltinFuncs)+len(prog.EventHandlers))
+	names = append(names, prog.CalledBuiltinFuncs...)
+	for name := range prog.EventHandlers {
+		names = append(names, name)
+	}
 	jsPrepareUI(strings.Join(names, ","))
 }
 
@@ -103,10 +105,10 @@ func evaluate(prog *parser.Program, rt *jsRuntime) error {
 }
 
 func handleEvents(yielder *sleepingYielder) error {
-	if eval == nil || len(eval.EventHandlerNames()) == 0 {
+	if eval == nil || len(eval.EventHandlerNames) == 0 {
 		return nil
 	}
-	for _, name := range eval.EventHandlerNames() {
+	for _, name := range eval.EventHandlerNames {
 		registerEventHandler(name)
 	}
 	for {

--- a/pkg/wasm/main.go
+++ b/pkg/wasm/main.go
@@ -76,7 +76,11 @@ func parse(input string, rt evaluator.Runtime) (*parser.Program, error) {
 	builtins := evaluator.DefaultBuiltins(rt).ParserBuiltins()
 	prog, err := parser.Parse(input, builtins)
 	if err != nil {
-		return nil, parser.TruncateError(err, 8)
+		var parseErrors parser.Errors
+		if errors.As(err, &parseErrors) {
+			err = parseErrors.Truncate(8)
+		}
+		return nil, err
 	}
 	return prog, nil
 }


### PR DESCRIPTION
Prepare for parser godoc revision by renaming some types and functions, making
others private and removing a few altogether. All these changes
came about by looking at the docs and asking: do I want to support this?
Does this make sense? 

I've started using the `revive` linter again, "a drop in
replacement for deprecated `golint`", which also covers missing godocs but
it isn't ready yet to be added to the CI flow. However, it has surfaced
a couple of other problems that have been addressed here. The main
reason I'm already cutting this as PR is because the prep work is
getting a bit big.

---

For a local review of the resulting godocs pull this branch and run

     go run golang.org/x/pkgsite/cmd/pkgsite@latest -open .